### PR TITLE
Fixes #9

### DIFF
--- a/lib/utils/resolveObject.js
+++ b/lib/utils/resolveObject.js
@@ -4,7 +4,8 @@ var current_context = []; // To maintain the context so we can test for circular
 var defaults = {
   opening_character: '{',
   closing_character: '}',
-  separator: '.'
+  separator: '.',
+  ignoreKeys: ['original']
 };
 var updated_object, regex, options;
 
@@ -37,12 +38,15 @@ function traverseObj(obj) {
   var key;
 
   for (key in obj) {
-    if (obj.hasOwnProperty(key)) {
+    // We want to check for ignoredKeys, this is so
+    // we can skip over attributes that should not be
+    // mutated, like a copy of the original property.
+    if (obj.hasOwnProperty(key) && (options.ignoreKeys||[]).indexOf(key) < 0) {
       current_context.push(key);
       if (typeof obj[key] === 'object') {
         traverseObj( obj[key] );
       } else {
-        if (typeof obj[key] === 'string' && obj[key].indexOf('{') > -1 ) {
+        if (typeof obj[key] === 'string' && obj[key].indexOf('{') > -1) {
           obj[key] = compile_value( obj[key] );
         }
       }

--- a/test/exportPlatform.js
+++ b/test/exportPlatform.js
@@ -66,4 +66,16 @@ describe('exportPlatform', function() {
       -1
     );
   });
+
+  // Make sure when we perform transforms and resolve references
+  // we don't mutate the original object added to the property.
+  it('properties should have original value untouched', function() {
+    var dictionary = test.exportPlatform('web');
+    var properties = helpers.fileToJSON('test/properties/colors.json');
+
+    assert.equal(
+      dictionary.color.font.link.original.value,
+      properties.color.font.link.value
+    );
+  });
 });

--- a/test/utils/resolveObject.js
+++ b/test/utils/resolveObject.js
@@ -100,4 +100,131 @@ describe('resolveObject', function() {
       resolveObject.bind( helpers.fileToJSON(__dirname + '/../json_files/circular_4.json'))
     );
   });
+
+  describe('ignoreKeys', function() {
+    it('should handle default value of original', function() {
+      var test = resolveObject({
+        foo: { value: 'bar' },
+        bar: {
+          value: '{foo.value}',
+          original: '{foo.value}'
+        }
+      });
+
+      assert.equal(
+        test.bar.original,
+        '{foo.value}'
+      );
+    });
+
+    it('should handle any nested keys under the ignoreKey', function() {
+      var test = resolveObject({
+        foo: { value: 'bar' },
+        bar: {
+          value: '{foo.value}',
+          original: {
+            value: '{foo.value}',
+            foo: {
+              bar: '{foo.value}'
+            }
+          }
+        }
+      });
+
+      assert.equal(
+        test.bar.original.value,
+        '{foo.value}'
+      );
+      assert.equal(
+        test.bar.original.foo.bar,
+        '{foo.value}'
+      );
+    });
+
+    it('should handle passing in custom ignoreKeys', function() {
+      var test = resolveObject({
+        foo: { value: 'bar' },
+        bar: {
+          value: '{foo.value}',
+          baz: '{foo.value}'
+        }
+      }, {
+        ignoreKeys: ['baz']
+      });
+
+      assert.equal(
+        test.bar.baz,
+        '{foo.value}'
+      );
+    });
+
+    it('should handle multiple keys', function() {
+      var test = resolveObject({
+        foo: { value: 'bar' },
+        bar: {
+          value: '{foo.value}',
+          original: '{foo.value}',
+          baz: '{foo.value}'
+        }
+      },{
+        ignoreKeys: ['baz','original']
+      });
+
+      assert.equal(
+        test.bar.original,
+        '{foo.value}'
+      );
+      assert.equal(
+        test.bar.baz,
+        '{foo.value}'
+      );
+    });
+
+    it('should not ignore anything if set to null or empty array', function() {
+      var test = resolveObject({
+        foo: { value: 'bar' },
+        bar: {
+          value: '{foo.value}',
+          original: '{foo.value}'
+        }
+      },{
+        ignoreKeys: []
+      });
+
+      assert.equal(
+        test.bar.original,
+        'bar'
+      );
+
+      var test2 = resolveObject({
+        foo: { value: 'bar' },
+        bar: {
+          value: '{foo.value}',
+          original: '{foo.value}'
+        }
+      },{
+        ignoreKeys: null
+      });
+
+      assert.equal(
+        test2.bar.original,
+        'bar'
+      );
+
+      var test3 = resolveObject({
+        foo: { value: 'bar' },
+        bar: {
+          value: '{foo.value}',
+          original: '{foo.value}'
+        }
+      },{
+        ignoreKeys: undefined
+      });
+
+      assert.equal(
+        test3.bar.original,
+        'bar'
+      );
+    });
+  });
 });


### PR DESCRIPTION
Fixes #9. Added unit tests to both resolveObject and exportPlatform. resolveObject method now accepts an option of ignoreKeys which is an array of strings to ignore if it sees any of those strings as a key in the object and will not perform resolving the reference. It will work on nested references (ignore anything nested below an ignored key). To ignore nothing, pass in an empty array or null. Default is 'original'.