### PR TITLE
Improved tests

### DIFF
--- a/lib/buildFile.js
+++ b/lib/buildFile.js
@@ -26,9 +26,9 @@ var path = require('path'),
  * @returns {null}
  */
 function buildFile(destination, format, platform, dictionary) {
-  if (!format)
+  if (!format || typeof format !== 'function')
     throw new Error('Please enter a valid file format');
-  if (!destination)
+  if (!destination || typeof destination !== 'string')
     throw new Error('Please enter a valid destination');
 
   // if there is a build path, prepend the destination with it

--- a/lib/buildPlatform.js
+++ b/lib/buildPlatform.js
@@ -25,8 +25,15 @@ var flattenProperties = require('./utils/flattenProperties'),
  * @param {String} platform
  * @returns {StyleDictionary}
  */
+var _ = require('lodash');
+
 function buildPlatform(platform) {
   console.log('\n' + platform);
+
+  if (!this.options || !_.has(this.options.platforms, platform)) {
+    throw new Error('Platform ' + platform + ' doesn\'t exist');
+  }
+
   var properties;
   // We don't want to mutate the original object
   var platformConfig = transformConfig(this.options.platforms[platform], this);

--- a/lib/register/transformGroup.js
+++ b/lib/register/transformGroup.js
@@ -27,10 +27,10 @@ function registerTransformGroup(options) {
   if (!_.isArray(options.transforms))
     throw new Error('transforms must be an array of registered value transforms');
 
-  options.transforms.forEach(function(t) {
+  options.transforms.forEach((function(t) {
     if (_.has(this.transforms, t))
       throw new Error('transforms must be an array of registered value transforms');
-  });
+  }).bind(this));
 
   this.transformGroup[options.name] = options.transforms;
   return this;

--- a/lib/register/transformGroup.js
+++ b/lib/register/transformGroup.js
@@ -28,7 +28,7 @@ function registerTransformGroup(options) {
     throw new Error('transforms must be an array of registered value transforms');
 
   options.transforms.forEach((function(t) {
-    if (_.has(this.transforms, t))
+    if (!_.has(this.transform, t))
       throw new Error('transforms must be an array of registered value transforms');
   }).bind(this));
 

--- a/lib/utils/resolveObject.js
+++ b/lib/utils/resolveObject.js
@@ -129,6 +129,7 @@ function selfRef(string, obj) {
   var test = options.opening_character + context + options.closing_character;
 
   if (typeof ref === 'string' && ref.indexOf(test) > -1) {
+    current_context = [];
     throw new Error('Circular definition: ' + context + ' | ' + string);
   } else {
     return ref;

--- a/lib/utils/resolveObject.js
+++ b/lib/utils/resolveObject.js
@@ -39,6 +39,7 @@ function resolveObject(object, opts) {
   );
 
   if (typeof object === 'object') {
+    current_context = [];
     return traverseObj( updated_object );
   } else {
     throw new Error('Please pass an object in');
@@ -129,7 +130,6 @@ function selfRef(string, obj) {
   var test = options.opening_character + context + options.closing_character;
 
   if (typeof ref === 'string' && ref.indexOf(test) > -1) {
-    current_context = [];
     throw new Error('Circular definition: ' + context + ' | ' + string);
   } else {
     return ref;

--- a/package.json
+++ b/package.json
@@ -35,9 +35,9 @@
     "NOTICE"
   ],
   "scripts": {
-    "lint": "eslint index.js lib/**/*.js test/**/*.js",
+    "lint": "eslint index.js lib/**/*.js test/*.js test/**/*.js",
     "test": "npm run lint && mocha --recursive -c",
-    "coverage": "istanbul cover ./node_modules/mocha/bin/_mocha -- test",
+    "coverage": "istanbul cover ./node_modules/mocha/bin/_mocha -- test/*.js test/**/*.js",
     "install-cli": "npm install -g $(npm pack)"
   },
   "repository": {

--- a/test/buildFile.js
+++ b/test/buildFile.js
@@ -25,27 +25,39 @@ describe('buildFile', function() {
   });
 
   it('should error if format doesnt exist or isnt a function', function() {
-    assert.throws(function() {
-      buildFile('test/output/test.txt', {}, {}, {})
-    });
-    assert.throws(function() {
-      buildFile('test/output/test.txt', [], {}, {})
-    });
-    assert.throws(function() {
-      buildFile('test/output/test.txt', null, {}, {})
-    });
+    assert.throws(
+      buildFile.bind(null, 'test/output/test.txt', {}, {}, {}),
+      Error,
+      'Please enter a valid file format'
+    );
+    assert.throws(
+      buildFile.bind(null, 'test/output/test.txt', [], {}, {}),
+      Error,
+      'Please enter a valid file format'
+    );
+    assert.throws(
+      buildFile.bind(null, 'test/output/test.txt', null, {}, {}),
+      Error,
+      'Please enter a valid file format'
+    );
   });
 
   it('should error if destination doesnt exist or isnt a string', function() {
-    assert.throws(function() {
-      buildFile({}, format, {}, {})
-    });
-    assert.throws(function() {
-      buildFile([], format, {}, {})
-    });
-    assert.throws(function() {
-      buildFile(null, format, {}, {})
-    });
+    assert.throws(
+      buildFile.bind(null, {}, format, {}, {}),
+      Error,
+      'Please enter a valid destination'
+    );
+    assert.throws(
+      buildFile.bind(null, [], format, {}, {}),
+      Error,
+      'Please enter a valid destination'
+    );
+    assert.throws(
+      buildFile.bind(null, null, format, {}, {}),
+      Error,
+      'Please enter a valid destination'
+    );
   });
 
   it('should write to a file properly', function() {

--- a/test/buildFiles.js
+++ b/test/buildFiles.js
@@ -44,6 +44,15 @@ var platformWithBuildPath = {
   ]
 };
 
+var platformWithoutFormatter = {
+  buildPath: 'test/output/',
+  files: [
+    {
+      destination: 'test.json',
+    }
+  ]
+};
+
 var platformWithBadBuildPath = {
   buildPath: 'test/output',
   files: [
@@ -62,9 +71,19 @@ describe('buildFiles', function() {
   });
 
   it('should throw if build path doesn\'t have a trailing slash', function() {
-    assert.throws(function() {
-      buildFiles( dictionary, platformWithBadBuildPath );
-    });
+    assert.throws(
+      buildFiles.bind(null, dictionary, platformWithBadBuildPath),
+      Error,
+      'Build path must end in a trailing slash or you will get weird file names.'
+    );
+  });
+
+  it('should throw if template or formatter missing', function() {
+    assert.throws(
+      buildFiles.bind(null, dictionary, platformWithoutFormatter),
+      Error,
+      'Please supply a template or formatter'
+    );
   });
 
   it('should work without buildPath', function() {

--- a/test/buildPlatform.js
+++ b/test/buildPlatform.js
@@ -25,9 +25,11 @@ describe('buildPlatform', function() {
   });
 
   it('should throw if passed a platform that doesn\'t exist', function() {
-    assert.throws(function() {
-      test.buildPlatform('foobar');
-    });
+    assert.throws(
+      test.buildPlatform.bind(test, 'foobar'),
+      Error,
+      'Platform foobar doesn\'t exist'
+    );
 
     assert.doesNotThrow(function() {
       test.buildPlatform('web');

--- a/test/extend.js
+++ b/test/extend.js
@@ -59,13 +59,21 @@ describe('extend', function() {
   describe('includes', function() {
     it('should throw if include isnt an array', function() {
       assert.throws(
-        StyleDictionary.extend.bind({include: {}})
+        StyleDictionary.extend.bind(null, {
+          include: {}
+        }),
+        Error,
+        'include must be an array'
       );
     });
 
     it('should throw if a path in the includes array doesnt resolve', function() {
       assert.throws(
-        StyleDictionary.extend.bind({include: ['foo']})
+        StyleDictionary.extend.bind(null, {
+          include: ['foo']
+        }),
+        Error,
+        "Cannot find module \'foo\'"
       );
     });
 
@@ -89,13 +97,21 @@ describe('extend', function() {
   describe('source', function() {
     it('should throw if source isnt an array', function() {
       assert.throws(
-        StyleDictionary.extend.bind({source: {}})
+        StyleDictionary.extend.bind(null, {
+          source: {}
+        }),
+        Error,
+        'source must be an array'
       );
     });
 
     it('should throw if a path in the source array doesnt resolve', function() {
       assert.throws(
-        StyleDictionary.extend.bind({include: ['foo']})
+        StyleDictionary.extend.bind(null, {
+          include: ['foo']
+        }),
+        Error,
+        "Cannot find module \'foo\'"
       );
     });
 

--- a/test/propertySetup.js
+++ b/test/propertySetup.js
@@ -18,19 +18,25 @@ var assert = require('chai').assert,
 describe('propertySetup', function() {
   it('should error if property is not an object', function() {
     assert.throws(
-      propertySetup.bind(null, 'foo', [])
+      propertySetup.bind(null, null, 'foo', []),
+      Error,
+      'Property object must be an object'
     );
   });
 
   it('should error if name in not a string', function() {
     assert.throws(
-      propertySetup.bind({}, null, [])
+      propertySetup.bind(null, {}, null, []),
+      Error,
+      'Name must be a string'
     );
   });
 
   it('should error path is not an array', function() {
     assert.throws(
-      propertySetup.bind({}, 'name', null)
+      propertySetup.bind(null, {}, 'name', null),
+      Error,
+      'Path must be an array'
     );
   });
 

--- a/test/registerAction.js
+++ b/test/registerAction.js
@@ -18,66 +18,84 @@ var assert = require('chai').assert,
 describe('registerAction', function() {
   it('should error if name is not a string', function() {
     assert.throws(
-      StyleDictionary.registerAction.bind({
+      StyleDictionary.registerAction.bind(null, {
         action: function() {}
-      })
+      }),
+      Error,
+      'transform name must be a string'
     );
 
     assert.throws(
-      StyleDictionary.registerAction.bind({
+      StyleDictionary.registerAction.bind(null, {
         name: 1,
         action: function() {}
-      })
+      }),
+      Error,
+      'transform name must be a string'
     );
 
     assert.throws(
-      StyleDictionary.registerAction.bind({
+      StyleDictionary.registerAction.bind(null, {
         name: [],
         action: function() {}
-      })
+      }),
+      Error,
+      'transform name must be a string'
     );
 
     assert.throws(
-      StyleDictionary.registerAction.bind({
+      StyleDictionary.registerAction.bind(null, {
         name: {},
         action: function() {}
-      })
+      }),
+      Error,
+      'transform name must be a string'
     );
   });
 
   it('should error if formatter is not a function', function() {
     assert.throws(
-      StyleDictionary.registerAction.bind({
+      StyleDictionary.registerAction.bind(null, {
         name: 'test'
-      })
+      }),
+      Error,
+      'format formatter must be a function'
     );
 
     assert.throws(
-      StyleDictionary.registerAction.bind({
+      StyleDictionary.registerAction.bind(null, {
         name: 'test',
         action: 1
-      })
+      }),
+      Error,
+      'format formatter must be a function'
     );
 
     assert.throws(
-      StyleDictionary.registerAction.bind({
+      StyleDictionary.registerAction.bind(null, {
         name: 'test',
         action: 'name'
-      })
+      }),
+      Error,
+      'format formatter must be a function'
     );
 
     assert.throws(
-      StyleDictionary.registerAction.bind({
+      StyleDictionary.registerAction.bind(null, {
         name: 'test',
         action: []
-      })
+      }),
+      Error,
+      'format formatter must be a function'
     );
 
     assert.throws(
-      StyleDictionary.registerAction.bind({
+      StyleDictionary.registerAction.bind(null, {
         name: 'test',
         action: {}
-      })
+      }),
+      Error,
+      'format formatter must be a function'
     );
   });
 

--- a/test/registerFormat.js
+++ b/test/registerFormat.js
@@ -18,64 +18,82 @@ var assert = require('chai').assert,
 describe('registerFormat', function() {
   it('should error if name is not a string', function() {
     assert.throws(
-      StyleDictionary.registerFormat.bind({formatter: function() {}})
+      StyleDictionary.registerFormat.bind(null, {
+        formatter: function() {}
+      }),
+      Error,
+      'transform name must be a string'
     );
 
     assert.throws(
-      StyleDictionary.registerFormat.bind({
+      StyleDictionary.registerFormat.bind(null, {
         name: 1,
         formatter: function() {}
-      })
+      }),
+      Error,
+      'transform name must be a string'
     );
 
     assert.throws(
-      StyleDictionary.registerFormat.bind({
+      StyleDictionary.registerFormat.bind(null, {
         name: [],
         formatter: function() {}
       })
     );
 
     assert.throws(
-      StyleDictionary.registerFormat.bind({
+      StyleDictionary.registerFormat.bind(null, {
         name: {},
         formatter: function() {}
-      })
+      }),
+      Error,
+      'transform name must be a string'
     );
   });
 
   it('should error if formatter is not a function', function() {
     assert.throws(
-      StyleDictionary.registerFormat.bind({
+      StyleDictionary.registerFormat.bind(null, {
         name: 'test'
-      })
+      }),
+      Error,
+      'format formatter must be a function'
     );
 
     assert.throws(
-      StyleDictionary.registerFormat.bind({
+      StyleDictionary.registerFormat.bind(null, {
         name: 'test',
         formatter: 1
-      })
+      }),
+      Error,
+      'format formatter must be a function'
     );
 
     assert.throws(
-      StyleDictionary.registerFormat.bind({
+      StyleDictionary.registerFormat.bind(null, {
         name: 'test',
         formatter: 'name'
-      })
+      }),
+      Error,
+      'format formatter must be a function'
     );
 
     assert.throws(
-      StyleDictionary.registerFormat.bind({
+      StyleDictionary.registerFormat.bind(null, {
         name: 'test',
         formatter: []
-      })
+      }),
+      Error,
+      'format formatter must be a function'
     );
 
     assert.throws(
-      StyleDictionary.registerFormat.bind({
+      StyleDictionary.registerFormat.bind(null, {
         name: 'test',
         formatter: {}
-      })
+      }),
+      Error,
+      'format formatter must be a function'
     );
   });
 

--- a/test/registerTransform.js
+++ b/test/registerTransform.js
@@ -18,35 +18,56 @@ var assert = require('chai').assert,
 describe('registerTransform', function() {
   it('should error if type is not a string', function() {
     assert.throws(
-      StyleDictionary.registerTransform.bind({type: 3})
+      StyleDictionary.registerTransform.bind(null, {
+        type: 3
+      }),
+      Error,
+      'type must be a string'
     );
   });
 
   it('should error if type is not a valid type', function() {
     assert.throws(
-      StyleDictionary.registerTransform.bind({type: 'foo'})
+      StyleDictionary.registerTransform.bind(null, {
+        type: 'foo'
+      }),
+      Error,
+      'foo type is not one of: name, value, attribute'
     );
   });
 
   it('should error if name is not a string', function() {
     assert.throws(
-      StyleDictionary.registerTransform.bind({type: 'name'})
+      StyleDictionary.registerTransform.bind(null, {
+        type: 'name'
+      }),
+      Error,
+      'name must be a string'
     );
   });
 
   it('should error if matcher is not a function', function() {
     assert.throws(
-      StyleDictionary.registerTransform.bind({type: 'name', matcher: 'foo'})
+      StyleDictionary.registerTransform.bind(null, {
+        type: 'name',
+        name: 'name',
+        matcher: 'foo'
+      }),
+      Error,
+      'matcher must be a function'
     );
   });
 
   it('should error if transformer is not a function', function() {
     assert.throws(
-      StyleDictionary.registerTransform.bind({
+      StyleDictionary.registerTransform.bind(null, {
         type: 'name',
+        name: 'name',
         matcher: function() { return true; },
         transformer: 'foo'
-      })
+      }),
+      Error,
+      'transformer must be a function'
     );
   });
 

--- a/test/registerTransformGroup.js
+++ b/test/registerTransformGroup.js
@@ -18,47 +18,96 @@ var assert = require('chai').assert,
 describe('registerTransformGroup', function() {
   it('should error if name is not a string', function() {
     assert.throws(
-      StyleDictionary.registerTransformGroup.bind({transforms: ['foo']})
+      StyleDictionary.registerTransformGroup.bind(null, {
+        transforms: ['foo']
+      }),
+      Error,
+      'transform name must be a string'
     );
 
     assert.throws(
-      StyleDictionary.registerTransformGroup.bind({name: 1, transforms: ['foo']})
+      StyleDictionary.registerTransformGroup.bind(null, {
+        name: 1,
+        transforms: ['foo']
+      }),
+      Error,
+      'transform name must be a string'
     );
 
     assert.throws(
-      StyleDictionary.registerTransformGroup.bind({name: [], transforms: ['foo']})
+      StyleDictionary.registerTransformGroup.bind(null, {
+        name: [],
+        transforms: ['foo']
+      }),
+      Error,
+      'transform name must be a string'
     );
 
     assert.throws(
-      StyleDictionary.registerTransformGroup.bind({name: {}, transforms: ['foo']})
+      StyleDictionary.registerTransformGroup.bind(null, {
+        name: {},
+        transforms: ['foo']
+      }),
+      Error,
+      'transform name must be a string'
     );
 
     assert.throws(
-      StyleDictionary.registerTransformGroup.bind({name: function() {}, transforms: ['foo']})
+      StyleDictionary.registerTransformGroup.bind(null, {
+        name: function() {},
+        transforms: ['foo']
+      }),
+      Error,
+      'transform name must be a string'
     );
   });
 
   it('should error if transforms isnt an array', function() {
     assert.throws(
-      StyleDictionary.registerTransformGroup.bind({name: 'foo'})
+      StyleDictionary.registerTransformGroup.bind(null, {
+        name: 'foo'
+      }),
+      Error,
+      'transforms must be an array of registered value transforms'
     );
 
     assert.throws(
-      StyleDictionary.registerTransformGroup.bind({name: 'foo', transforms: 'foo'})
+      StyleDictionary.registerTransformGroup.bind(null, {
+        name: 'foo',
+        transforms: 'foo'
+      }),
+      Error,
+      'transforms must be an array of registered value transforms'
     );
 
     assert.throws(
-      StyleDictionary.registerTransformGroup.bind({name: 'foo', transforms: {}})
+      StyleDictionary.registerTransformGroup.bind(null, {
+        name: 'foo',
+        transforms: {}
+      }),
+      Error,
+      'transforms must be an array of registered value transforms'
     );
 
     assert.throws(
-      StyleDictionary.registerTransformGroup.bind({name: 'foo', transforms: function() {}})
+      StyleDictionary.registerTransformGroup.bind(null, {
+        name: 'foo',
+        transforms: function() {}
+      }),
+      Error,
+      'transforms must be an array of registered value transforms'
     );
   });
 
   it('should error if transforms arent registered', function() {
     assert.throws(
-      StyleDictionary.registerTransformGroup.bind({name: 'foo', transforms: ['bar']})
+      StyleDictionary.registerTransformGroup.bind({ transforms: { bar: 'cat' } },
+      {
+        name: 'foo',
+        transforms: ['bar']
+      }),
+      Error,
+      'transforms must be an array of registered value transforms'
     );
   });
 

--- a/test/registerTransformGroup.js
+++ b/test/registerTransformGroup.js
@@ -101,10 +101,10 @@ describe('registerTransformGroup', function() {
 
   it('should error if transforms arent registered', function() {
     assert.throws(
-      StyleDictionary.registerTransformGroup.bind({ transforms: { bar: 'cat' } },
+      StyleDictionary.registerTransformGroup.bind(StyleDictionary,
       {
         name: 'foo',
-        transforms: ['bar']
+        transforms: ['foo']
       }),
       Error,
       'transforms must be an array of registered value transforms'
@@ -114,16 +114,18 @@ describe('registerTransformGroup', function() {
   it('should work if everything is good', function() {
     StyleDictionary.registerTransformGroup({
       name: 'foo',
-      transforms: ['foo']
+      transforms: ['size/px']
     });
 
     assert.isArray(StyleDictionary.transformGroup.foo);
     assert.isString(StyleDictionary.transformGroup.foo[0]);
+    assert.equal(StyleDictionary.transformGroup.foo[0], 'size/px');
   });
 
   it('should properly pass the registered format to instances', function() {
     var test = StyleDictionary.extend({});
     assert.isArray(test.transformGroup.foo);
     assert.isString(test.transformGroup.foo[0]);
+    assert.equal(test.transformGroup.foo[0], 'size/px');
   });
 });

--- a/test/utils/convertToBase64.js
+++ b/test/utils/convertToBase64.js
@@ -16,13 +16,29 @@ var assert          = require('chai').assert,
 
 describe('base64', function() {
   it('should error if filePath isnt a string', function() {
-    assert.throws(convertToBase64);
-    assert.throws(convertToBase64.bind([]));
-    assert.throws(convertToBase64.bind({}));
+    assert.throws(
+      convertToBase64.bind(null),
+      Error,
+      'filePath name must be a string'
+    );
+    assert.throws(
+      convertToBase64.bind(null, []),
+      Error,
+      'filePath name must be a string'
+    );
+    assert.throws(
+      convertToBase64.bind(null, {}),
+      Error,
+      'filePath name must be a string'
+    );
   });
 
   it('should error if filePath isnt a file', function() {
-    assert.throws(convertToBase64.bind('foo'));
+    assert.throws(
+      convertToBase64.bind(null, 'foo'),
+      Error,
+      "ENOENT: no such file or directory, open \'foo\'"
+    );
   });
 
   it('should return a string', function() {

--- a/test/utils/resolveObject.js
+++ b/test/utils/resolveObject.js
@@ -18,9 +18,21 @@ var assert        = require('chai').assert,
 
 describe('resolveObject', function() {
   it('should error on non-objects', function() {
-    assert.throws(resolveObject.bind('foo'));
-    assert.throws(resolveObject);
-    assert.throws(resolveObject.bind(0));
+    assert.throws(
+      resolveObject.bind(null, 'foo'),
+      Error,
+      'Please pass an object in'
+    );
+    assert.throws(
+      resolveObject.bind(null),
+      Error,
+      'Please pass an object in'
+    );
+    assert.throws(
+      resolveObject.bind(null, 0),
+      Error,
+      'Please pass an object in'
+    );
   });
 
   it('should do simple references', function() {
@@ -101,16 +113,32 @@ describe('resolveObject', function() {
 
   it('should gracefully handle circular references', function() {
     assert.throws(
-      resolveObject.bind(helpers.fileToJSON(__dirname + '/../json_files/circular.json'))
+      resolveObject.bind(null,
+        helpers.fileToJSON(__dirname + '/../json_files/circular.json')
+      ),
+      Error,
+      'Circular definition: a | d'
     );
     assert.throws(
-      resolveObject.bind( helpers.fileToJSON(__dirname + '/../json_files/circular_2.json'))
+      resolveObject.bind(null,
+        helpers.fileToJSON(__dirname + '/../json_files/circular_2.json')
+      ),
+      Error,
+      'Circular definition: a.b.c | d'
     );
     assert.throws(
-      resolveObject.bind( helpers.fileToJSON(__dirname + '/../json_files/circular_3.json'))
+      resolveObject.bind(null,
+        helpers.fileToJSON(__dirname + '/../json_files/circular_3.json')
+      ),
+      Error,
+      'Circular definition: a.b.c | d.e.f'
     );
     assert.throws(
-      resolveObject.bind( helpers.fileToJSON(__dirname + '/../json_files/circular_4.json'))
+      resolveObject.bind(null,
+        helpers.fileToJSON(__dirname + '/../json_files/circular_4.json')
+      ),
+      Error,
+      'Circular definition: a.b.c | g.h'
     );
   });
 


### PR DESCRIPTION
This PR covers the following:
- I found a bug on some tests while using `assert.throws`. The first parameter of `.bind` is the `this` value and the rest are the arguments of the function. The tests were still passing because the arguments where undefined thus causing an exception (but not really the exception we wanted).
- all the `assert.throws` tests now check for the specific error message
- fixed `package.json` to include all test in the coverage and lint
- fixed a bug in `transformGroup.js`. The `this` reference inside the `forEach ` was wrong.