### PR TITLE
add commonJS format

### DIFF
--- a/docs/default_formats.md
+++ b/docs/default_formats.md
@@ -41,6 +41,11 @@
       <td></td>
     </tr>
     <tr>
+      <td>javascript/commonJS</td>
+      <td></td>
+      <td></td>
+    </tr>
+    <tr>
       <td>json</td>
       <td></td>
       <td></td>

--- a/lib/common/formats.js
+++ b/lib/common/formats.js
@@ -95,6 +95,14 @@ module.exports = {
       }).join('\n');
   },
 
+  'javascript/commonJS': function(dictionary) {
+    var props = _.filter(dictionary.allProperties, this.filter);
+    return jsHeader() +
+      _.map(props, function(prop) {
+        return 'exports.' + prop.name + ' = \'' + prop.value + '\';';
+      }).join('\n');
+  },
+
   'json': function(dictionary) {
     return JSON.stringify(dictionary.properties, null, 2);
   },


### PR DESCRIPTION
Consumers may expect a javascript distribution to be pre-transpiled. This format enables generation of a distribution with CommonJS module exports. 