### PR TITLE
Collision detection

### DIFF
--- a/lib/extend.js
+++ b/lib/extend.js
@@ -34,7 +34,7 @@ function extend(opts) {
 
   // Creating a new object and copying over the options
   // Also keeping an options object just in case
-  to_ret = deepExtend({options: options}, this, options);
+  to_ret = deepExtend([{options: options}, this, options]);
 
   // Update properties with includes from dependencies
   if (options.include) {
@@ -42,7 +42,7 @@ function extend(opts) {
       throw new Error('include must be an array');
 
     _.forEach(options.include, function(file){
-      to_ret.properties = deepExtend({}, to_ret.properties, require(file));
+      to_ret.properties = deepExtend([{}, to_ret.properties, require(file)]);
     });
 
     to_ret.include = null; // We don't want to carry over include references
@@ -54,8 +54,18 @@ function extend(opts) {
     if (!_.isArray(options.source))
       throw new Error('source must be an array');
 
-    var props = combineJSON(options.source, {deep: true});
-    to_ret.properties = deepExtend({}, to_ret.properties, props);
+    var props = combineJSON(options.source, true, function Collision(opts) {
+      if (options.log) {
+        var str = `Collision detected at: ${opts.path.join('.')}! Original value: ${opts.target[opts.key]}, New value: ${opts.copy[opts.key]}`;
+        if (options.log === 'warn') {
+          console.warn(str);
+        } else if (options.log === 'error') {
+          throw new Error(str);
+        }
+      }
+
+    });
+    to_ret.properties = deepExtend([{}, to_ret.properties, props]);
     to_ret.source = null; // We don't want to carry over the source references
   }
 

--- a/lib/utils/combineJSON.js
+++ b/lib/utils/combineJSON.js
@@ -21,9 +21,10 @@ var fs         = require('fs'),
  * them together. Optionally does a deep extend.
  * @param {String[]} arr - Array of paths to json files
  * @param {Boolean} [deep=false] - If it should perform a deep merge
+ * @param {Function} collision - A function to be called when a name collision happens that isn't a normal deep merge of objects
  * @returns {Object}
  */
-function combineJSON(arr, deep) {
+function combineJSON(arr, deep, collision) {
   var i, files = [], to_ret = {};
 
   for (i = 0; i < arr.length; i++) {
@@ -34,7 +35,7 @@ function combineJSON(arr, deep) {
   for (i = 0; i < files.length; i++) {
     var file_content = JSON.parse(fs.readFileSync(files[i], 'utf8'));
     if (deep) {
-      deepExtend(to_ret, file_content);
+      deepExtend([to_ret, file_content], collision);
     } else {
       extend(to_ret, file_content);
     }

--- a/lib/utils/deepExtend.js
+++ b/lib/utils/deepExtend.js
@@ -15,14 +15,21 @@ var _ = require('lodash');
 
 /**
  * Performs an deep extend on the objects, from right to left.
- * @param {...Object} object - Any number of JS objects
+ * @param {Object[]} objects - An array of JS objects
+ * @param {Function} collision - A function to be called when a merge collision happens.
+ * @param {string[]} path - (for internal use) An array of strings which is the current path down the object when this is called recursively.
  * @returns {Object}
  */
-function deepExtend(object) {
+function deepExtend(objects, collision, path) {
+  if (objects == null)
+    return {};
+
   var src, copyIsArray, copy, name, options, clone,
-    target = arguments[0] || {},
+    target = objects[0] || {},
     i = 1,
-    length = arguments.length;
+    length = objects.length;
+
+  path = path || [];
 
   // Handle case when target is a string or something (possible in deep copy)
   if ( typeof target !== 'object' ) {
@@ -31,7 +38,7 @@ function deepExtend(object) {
 
   for ( ; i < length; i++) {
     // Only deal with non-null/undefined values
-    if ( (options = arguments[ i ]) != null ) {
+    if ( (options = objects[ i ]) != null ) {
       // Extend the base object
       for (name in options) {
         if (!options.hasOwnProperty(name))
@@ -54,13 +61,19 @@ function deepExtend(object) {
             clone = src && _.isPlainObject(src) ? src : {};
           }
 
+          path.push(name);
+
           // Never move original objects, clone them
-          target[ name ] = deepExtend( clone, copy );
+          target[ name ] = deepExtend( [clone, copy], collision, path );
 
           // Don't bring in undefined values
         } else if ( copy !== undefined ) {
+          if (src != null && typeof collision == 'function') {
+            collision({target: target, copy: options, path: path, key: name});
+          }
           target[ name ] = copy;
         }
+        path.pop();
       }
     }
   }

--- a/test/extend.js
+++ b/test/extend.js
@@ -132,4 +132,34 @@ describe('extend', function() {
   });
 
 
+  // This is to allow style dictionaries to depend on other style dictionaries and
+  // override properties. Useful for skinning
+  it('should not throw a collision error if a source file collides with an include', function() {
+    var test = StyleDictionary.extend({
+      include: [__dirname + "/properties/paddings.json"],
+      source: [__dirname + "/properties/paddings.json"],
+      log: 'error'
+    });
+    assert.deepEqual(test.properties, helpers.fileToJSON(__dirname + "/properties/paddings.json"));
+  });
+
+  it('should throw a error if the collision is in source files and log is set to error', function() {
+    assert.throws(
+      StyleDictionary.extend.bind(null, {
+        source: [__dirname + "/properties/paddings.json", __dirname + "/properties/paddings.json"],
+        log: 'error'
+      }),
+      Error,
+      'Collision detected at:'
+    );
+  });
+
+  it('should throw a warning if the collision is in source files and log is set to warn', function() {
+    assert.doesNotThrow(
+      StyleDictionary.extend.bind(null, {
+        source: [__dirname + "/properties/paddings.json", __dirname + "/properties/paddings.json"],
+        log: 'warn'
+      })
+    );
+  });
 });

--- a/test/utils/combineJSON.js
+++ b/test/utils/combineJSON.js
@@ -42,4 +42,17 @@ describe('combineJSON', function() {
     assert(!test.d.e.f.g);
     assert.equal(test.d.e.f.h, 2);
   });
+
+  it('should fail if there is a collision and it is passed a collision function', function() {
+    assert.throws(
+      combineJSON.bind(null, ["test/json_files/shallow/*.json"], true, function Collision(opts) {
+        assert.equal(opts.key, 'a');
+        assert.equal(opts.target[opts.key], 1);
+        assert.equal(opts.copy[opts.key], 2);
+        throw new Error('test');
+      }),
+      Error,
+      'test'
+    );
+  });
 });

--- a/test/utils/deepExtend.js
+++ b/test/utils/deepExtend.js
@@ -22,29 +22,59 @@ describe('deepExtend', function() {
   });
 
   it('should override properties from right to left', function () {
-    var test = deepExtend({foo:'bar'}, {foo:'baz'});
+    var test = deepExtend([{foo:'bar'}, {foo:'baz'}]);
     assert.equal(test.foo, 'baz');
 
-    var test2 = deepExtend({foo:'bar'}, {foo:'baz'}, {foo:'blah'});
+    var test2 = deepExtend([{foo:'bar'}, {foo:'baz'}, {foo:'blah'}]);
     assert.equal(test2.foo, 'blah');
   });
 
   it('should override nested properties', function () {
-    var test = deepExtend({foo: {foo:'bar'}}, {foo: {foo:'baz'}});
+    var test = deepExtend([{foo: {foo:'bar'}}, {foo: {foo:'baz'}}]);
     assert.equal(test.foo.foo, 'baz');
 
-    var test2 = deepExtend({foo:{foo:'bar'}}, {foo:{foo:'baz'}}, {foo:{foo:'blah'}});
+    var test2 = deepExtend([{foo:{foo:'bar'}}, {foo:{foo:'baz'}}, {foo:{foo:'blah'}}]);
     assert.equal(test2.foo.foo, 'blah');
   });
 
   it('should override nested properties', function () {
-    var test = deepExtend({foo: {bar:'bar'}}, {foo: {baz:'baz'}});
+    var test = deepExtend([{foo: {bar:'bar'}}, {foo: {baz:'baz'}}]);
     assert.equal(test.foo.baz, 'baz');
     assert.equal(test.foo.bar, 'bar');
 
-    var test2 = deepExtend({foo:{bar:'bar'}}, {foo:{baz:'baz'}}, {foo:{blah:'blah'}});
+    var test2 = deepExtend([{foo:{bar:'bar'}}, {foo:{baz:'baz'}}, {foo:{blah:'blah'}}]);
     assert.equal(test2.foo.baz, 'baz');
     assert.equal(test2.foo.bar, 'bar');
     assert.equal(test2.foo.blah, 'blah');
+  });
+
+  it('shouldn\'t fail loudly if it is a normal deep extend', function () {
+    var test = deepExtend([{foo: {bar:'bar'}}, {foo: {baz:'baz'}}], function(name) {
+
+    });
+    assert.equal(test.foo.bar, 'bar');
+    assert.equal(test.foo.baz, 'baz');
+  });
+
+  describe('collision detection', function() {
+    it('should call the collision function if a collision happens', function () {
+      assert.throws(
+        deepExtend.bind(null, [{foo: {bar:'bar'}}, {foo: {bar:'baz'}}], function(opts) {
+          throw new Error('danger danger. high voltage.');
+        }),
+        Error,
+        'danger danger. high voltage.'
+      );
+    });
+
+    it('the collision function should have the proper arguments', function () {
+      var test = deepExtend([{foo: {bar:'bar'}}, {foo: {bar:'baz'}}], function(opts) {
+        assert.equal(opts.target.bar, 'bar');
+        assert.equal(opts.copy.bar, 'baz');
+        assert.equal(opts.path[0], 'foo');
+        assert.equal(opts.key, 'bar');
+      });
+      assert.equal(test.foo.bar, 'baz');
+    });
   });
 });


### PR DESCRIPTION
- Fix #39 
- Alert the user when a property collision happens (a property is
defined twice in same package, does not include imports)
- Usage: set 'log' to 'warn' or 'error' in the config of a style
dictionary
- If set to 'warn' will just output to the console, but not throw
- If set to 'error' will throw