### PR TITLE
updated error logging

### DIFF
--- a/lib/utils/resolveObject.js
+++ b/lib/utils/resolveObject.js
@@ -63,7 +63,7 @@ function traverseObj(obj) {
       } else {
         if (typeof obj[key] === 'string' && obj[key].indexOf('{') > -1) {
           try {
-            obj[key] = compile_value( obj[key] );
+            obj[key] = compile_value( obj[key], [key] );
           }
           catch (e) {
             errors.push(e);
@@ -83,8 +83,9 @@ function traverseObj(obj) {
 
 
 
-function compile_value(value) {
+function compile_value(value, stack) {
   var to_ret, ref;
+  stack.push(value.slice(1, -1));
 
   // Replace the reference inline, but don't replace the whole string because
   // references can be part of the value such as "1px solid {color.border.light}"
@@ -98,7 +99,14 @@ function compile_value(value) {
 
         // Recursive so we can compute multi-layer variables like a = b, b = c, so a = c
         if ( to_ret.indexOf('{') > -1 ) {
-          to_ret = compile_value( to_ret );
+          var reference = to_ret.slice(1, -1);
+          if(stack.indexOf(reference)!==-1) {
+            stack.push(reference);
+            throw new Error('Variable reference for \'' + stack[0] + '\' resolves to circular definition cycle of \'' + reference + '\':  ' + stack.join(', ') );
+          }
+          else {
+            to_ret = compile_value( to_ret, stack );
+          }
         }
       } else {
         // if evaluated value is not a string, we want to keep the type


### PR DESCRIPTION
updated error logging prevents call stack size exceeded error when another value references a value contained within a circular reference cycle


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
