### PR TITLE
Add LESS format and create tests for less

### DIFF
--- a/docs/formats.md
+++ b/docs/formats.md
@@ -78,6 +78,32 @@ $content-icon-email: '\E001';
 
 * * *
 
+### less/variables 
+
+
+Creates a LESS file with variable definitions based on the style dictionary
+
+**Example**  
+```less
+@color-background-base: #f0f0f0;
+@color-background-alt: #eeeeee;
+```
+
+* * *
+
+### less/icons 
+
+
+Creates a LESS file with variable definitions and helper classes for icons
+
+**Example**  
+```less
+@content-icon-email: '\E001';
+.icon.email:before { content:@content-icon-email; }
+```
+
+* * *
+
 ### javascript/module 
 
 

--- a/docs/transform_groups.md
+++ b/docs/transform_groups.md
@@ -46,6 +46,20 @@ Transforms:
 [size/rem](transforms.md#sizerem)
 [color/hex](transforms.md#colorhex)
 
+* * *
+
+### less 
+
+
+Transforms:
+
+[attribute/cti](transforms.md#attributecti)
+[name/cti/kebab](transforms.md#namectikebab)
+[time/seconds](transforms.md#timeseconds)
+[content/icon](transforms.md#contenticon)
+[size/rem](transforms.md#sizerem)
+[color/hex](transforms.md#colorhex)
+
 
 * * *
 

--- a/lib/common/formats.js
+++ b/lib/common/formats.js
@@ -14,25 +14,38 @@
 var _ = require('lodash');
 var module_def = 'module.exports = ';
 
-function jsHeader() {
+function fileHeader() {
   return '/**\n' +
          ' * Do not edit directly\n' +
          ' * Generated on ' + new Date() + '\n' +
          ' */\n\n';
 }
 
-function sassHeader() {
-  return '//\n' +
-         '// Do not edit directly\n' +
-         '// Generated on ' + new Date() + '\n' +
-         '//\n\n'
+function variablesWithPrefix(prefix, properties) {
+  return _.map(properties, function(prop) {
+      var to_ret_prop = prefix + prop.name + ': ' + (prop.attributes.category==='asset' ? '"'+prop.value+'"' : prop.value) + ';';
+
+      if (prop.attributes.comment)
+        to_ret_prop = to_ret_prop.concat(' // ' + prop.attributes.comment);
+      return to_ret_prop;
+    })
+    .filter(function(strVal) { return !!strVal })
+    .join('\n');
 }
 
-function cssHeader() {
-  return '/* Do not edit directly */\n' +
-         '/* Generated on ' + new Date() + ' */\n\n';
+function iconsWithPrefix(prefix, properties, config) {
+  return fileHeader() + _.chain(properties)
+    .filter(function(prop) {
+      return prop.attributes.category === 'content' && prop.attributes.type === 'icon';
+    })
+    .map(function(prop) {
+      var varName = prefix + prop.name + ': ' + prop.value + ';';
+      var className = '.' + config.prefix + '-icon.' + prop.attributes.item + ':before ';
+      var declaration = '{ content: ' + prefix + prop.name + '; }';
+      return varName + '\n' + className + declaration;
+    })
+    .value().join('\n');
 }
-
 /**
  * @namespace Formats
  */
@@ -52,15 +65,8 @@ module.exports = {
    * ```
    */
   'css/variables': function(dictionary) {
-    var root_vars = ':root {\n' + _.map(dictionary.allProperties, function (prop) {
-      var to_ret_prop = '  --' + prop.name + ': ' + (prop.attributes.category==='asset' ? '"'+prop.value+'"' : prop.value) + ';';
-
-      if (prop.attributes.comment)
-        to_ret_prop = to_ret_prop.concat(' /* ' + prop.attributes.comment + ' */ ');
-      return to_ret_prop;
-    }).filter(function (strVal) { return !!strVal; }).join('\n') + '\n}\n';
-
-    return cssHeader() + root_vars;
+    var root_vars = ':root {\n' + variablesWithPrefix(' --', dictionary.allProperties) + '\n}\n';
+    return fileHeader() + root_vars;
   },
 
   /**
@@ -75,14 +81,7 @@ module.exports = {
    * ```
    */
   'scss/variables': function(dictionary) {
-    var to_ret;
-    return sassHeader() + _.map(dictionary.allProperties, function (prop) {
-      to_ret = '$' + prop.name + ': ' + (prop.attributes.category==='asset' ? '"'+prop.value+'"' : prop.value) + ';';
-
-      if (prop.attributes.comment)
-        to_ret = to_ret.concat(' // ' + prop.attributes.comment);
-      return to_ret;
-    }).filter(function (strVal) { return !!strVal; }).join('\n');
+    return fileHeader() + variablesWithPrefix('$', dictionary.allProperties);
   },
 
   /**
@@ -97,17 +96,37 @@ module.exports = {
    * ```
    */
   'scss/icons': function(dictionary, config) {
-    return sassHeader() + _.chain(dictionary.allProperties)
-      .filter(function(prop) {
-        return prop.attributes.category === 'content' && prop.attributes.type === 'icon';
-      })
-      .map(function(prop) {
-        var varName = '$' + prop.name + ': ' + prop.value + ';';
-        var className = '.' + config.prefix + '-icon.' + prop.attributes.item + ':before ';
-        var declaration = '{ content: $' + prop.name + '; }';
-        return varName + '\n' + className + declaration;
-      })
-      .value().join('\n');
+    return iconsWithPrefix('$', dictionary.allProperties, config);
+  },
+
+  /**
+   * Creates a LESS file with variable definitions based on the style dictionary
+   *
+   * @memberof Formats
+   * @kind member
+   * @example
+   * ```less
+   * @color-background-base: #f0f0f0;
+   * @color-background-alt: #eeeeee;
+   * ```
+   */
+  'less/variables': function(dictionary) {
+    return fileHeader() + variablesWithPrefix('@', dictionary.allProperties);
+  },
+
+  /**
+   * Creates a LESS file with variable definitions and helper classes for icons
+   *
+   * @memberof Formats
+   * @kind member
+   * @example
+   * ```less
+   * @content-icon-email: '\E001';
+   * .icon.email:before { content:@content-icon-email; }
+   * ```
+   */
+  'less/icons': function(dictionary, config) {
+    return iconsWithPrefix('@', dictionary.allProperties, config);
   },
 
   /**
@@ -129,7 +148,7 @@ module.exports = {
    * ```
    */
   'javascript/module': function(dictionary) {
-    return  jsHeader() +
+    return  fileHeader() +
       module_def +
       JSON.stringify(dictionary.properties, null, 2) + ';';
   },
@@ -154,7 +173,7 @@ module.exports = {
    * ```
    */
   'javascript/object': function(dictionary) {
-    return  jsHeader() +
+    return  fileHeader() +
       'var ' +
       (this.name || '_styleDictionary') +
       ' = ' +
@@ -194,7 +213,7 @@ module.exports = {
    */
   'javascript/umd': function(dictionary) {
     var name = this.name || '_styleDictionary'
-    return jsHeader() +
+    return fileHeader() +
       '(function(root, factory) {\n' +
       '  if (typeof module === "object" && module.exports) {\n' +
       '    module.exports = factory();\n' +
@@ -244,7 +263,7 @@ module.exports = {
   'javascript/es6': function(dictionary) {
     // this is bound to the file object
     var props = _.filter(dictionary.allProperties, this.filter);
-    return jsHeader() +
+    return fileHeader() +
       _.map(props, function(prop) {
         return 'export const ' + prop.name + ' = \'' + prop.value + '\';';
       }).join('\n');

--- a/lib/common/transformGroups.js
+++ b/lib/common/transformGroups.js
@@ -59,6 +59,27 @@ module.exports = {
    * Transforms:
    *
    * [attribute/cti](transforms.md#attributecti)
+   * [name/cti/kebab](transforms.md#namectikebab)
+   * [time/seconds](transforms.md#timeseconds)
+   * [content/icon](transforms.md#contenticon)
+   * [size/rem](transforms.md#sizerem)
+   * [color/hex](transforms.md#colorhex)
+   *
+   * @memberof TransformGroups
+   */
+  'less': [
+    'attribute/cti',
+    'name/cti/kebab',
+    'time/seconds',
+    'content/icon',
+    'size/rem',
+    'color/hex'
+  ],
+
+  /**
+   * Transforms:
+   *
+   * [attribute/cti](transforms.md#attributecti)
    * [attribute/color](transforms.md#attributecolor)
    * [name/human](transforms.md#namehuman)
    *

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "eslint": "^3.11.1",
     "istanbul": "^0.4.5",
     "jsdoc-to-markdown": "^3.0.3",
+    "less": "^3.0.1",
     "mocha": "^3.1.2"
   }
 }

--- a/test/buildAllPlatforms.js
+++ b/test/buildAllPlatforms.js
@@ -26,7 +26,7 @@ describe('buildAllPlatforms', function() {
 
   it('should work', function() {
     test.buildAllPlatforms();
-    assert(helpers.fileExists('./test/output/web/_icons.scss'));
+    assert(helpers.fileExists('./test/output/web/_icons.css'));
     assert(helpers.fileExists('./test/output/android/colors.xml'));
   });
 });

--- a/test/buildPlatform.js
+++ b/test/buildPlatform.js
@@ -36,11 +36,23 @@ describe('buildPlatform', function() {
     });
   });
 
-  it('should build the proper files', function() {
+  it('should build web platform files', function() {
     test.buildPlatform('web');
-    assert(helpers.fileExists('./test/output/web/_icons.scss'));
+    assert(helpers.fileExists('./test/output/web/_icons.css'));
     assert(helpers.fileExists('./test/output/web/_styles.js'));
-    assert(helpers.fileExists('./test/output/web/_variables.scss'));
+    assert(helpers.fileExists('./test/output/web/_variables.css'));
+  });
+
+  it('should build scss platform files', function() {
+    test.buildPlatform('scss');
+    assert(helpers.fileExists('./test/output/scss/_icons.scss'));
+    assert(helpers.fileExists('./test/output/scss/_variables.scss'));
+  });
+
+  it('should build less platform files', function() {
+    test.buildPlatform('less');
+    assert(helpers.fileExists('./test/output/less/_icons.less'));
+    assert(helpers.fileExists('./test/output/less/_variables.less'));
   });
 
   it('should do android stuff', function() {

--- a/test/configs/test.json
+++ b/test/configs/test.json
@@ -2,9 +2,26 @@
   "source": ["test/properties/**/*.json"],
   "platforms": {
     "web": {
-      "transformGroup": "scss",
+      "transformGroup": "web",
       "prefix": "smop",
       "buildPath": "test/output/web/",
+      "files": [
+        {
+          "destination": "_icons.css",
+          "format": "scss/icons"
+        },{
+          "destination": "_variables.css",
+          "format": "scss/variables"
+        },{
+          "destination": "_styles.js",
+          "format": "javascript/module"
+        }
+      ]
+    },
+    "scss": {
+      "transformGroup": "scss",
+      "prefix": "smop",
+      "buildPath": "test/output/scss/",
       "files": [
         {
           "destination": "_icons.scss",
@@ -12,9 +29,20 @@
         },{
           "destination": "_variables.scss",
           "format": "scss/variables"
+        }
+      ]
+    },
+    "less": {
+      "transformGroup": "less",
+      "prefix": "smop",
+      "buildPath": "test/output/less/",
+      "files": [
+        {
+          "destination": "_icons.less",
+          "format": "less/icons"
         },{
-          "destination": "_styles.js",
-          "format": "javascript/module"
+          "destination": "_variables.less",
+          "format": "less/variables"
         }
       ]
     },

--- a/test/formats/lessIcons.js
+++ b/test/formats/lessIcons.js
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+var assert  = require('chai').assert,
+    less    = require('less'),
+    formats = require('../../lib/common/formats');
+
+var file = {
+  "destination": "output/",
+  "format": "less/icons",
+  "name": "foo"
+};
+
+var propertyName = "content-icon-email";
+var propertyValue = "'\\E001'";
+var itemClass = "3d_rotation";
+
+var dictionary = {
+  "allProperties": [{
+    "name": propertyName,
+    "value": propertyValue,
+    "original": {
+      "value": propertyValue
+    },
+    "attributes": {
+      "category": "content",
+      "type": "icon",
+      "item": itemClass
+    }
+  }]
+};
+
+var config = {
+  prefix: 'sd' // Style-Dictionary Prefix
+};
+
+
+var formatter = formats['less/icons'].bind(file);
+
+describe('formats', function() {
+  describe('less/icons', function() {
+    it('should have a valid less syntax', function(done) {
+      less.render(formatter(dictionary, config))
+        .then(function(output) {
+          assert.isDefined(output);
+          done();
+        })
+        .catch(function(err) {
+           done(new Error(err))
+        });
+    });
+  });
+});

--- a/test/formats/lessVariables.js
+++ b/test/formats/lessVariables.js
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+var assert  = require('chai').assert,
+    less = require('less'),
+    formats = require('../../lib/common/formats');
+
+var file = {
+  "destination": "output/",
+  "format": "less/variables",
+  "name": "foo"
+};
+
+var propertyName = "color-base-red-400";
+var propertyValue = "#EF5350";
+
+var dictionary = {
+  "allProperties": [{
+    "name": propertyName,
+    "value": propertyValue,
+    "original": {
+      "value": propertyValue
+    },
+    "attributes": {
+      "category": "color",
+      "type": "base",
+      "item": "red",
+      "subitem": "400"
+    },
+    "path": [
+      "color",
+      "base",
+      "red",
+      "400"
+    ]
+  }]
+};
+
+var formatter = formats['less/variables'].bind(file);
+
+describe('formats', function() {
+  describe('less/variables', function() {
+    it('should have a valid less syntax', function(done) {
+      less.render(formatter(dictionary))
+        .then(function(output) {
+          assert.isDefined(output);
+          done();
+        })
+        .catch(function(err) {
+           done(new Error(err))
+        });
+    });
+  });
+});


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/amzn/style-dictionary/issues/54

*Description of changes:*
- Add LESS format based on SCSS output
- Use of the same function for file headers since all the format languages support multi-line comments
- Updated docs to reflect new changes
- Created tests for the format and also updated general tests to add new format

*Notes:*
Should I add myself as contributor if this is merged?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
