### PR TITLE
Adding more testing infrastructure

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "istanbul": "^0.4.5",
     "jsdoc-to-markdown": "^3.0.3",
     "less": "^3.0.1",
-    "mocha": "^3.1.2"
+    "mocha": "^3.1.2",
+    "node-sass": "^4.8.3"
   }
 }

--- a/test/cleanDirs.js
+++ b/test/cleanDirs.js
@@ -46,27 +46,6 @@ var platformWithBuildPath = {
   ]
 };
 
-var platformWithoutFormatter = {
-  buildPath: 'test/output/extradir1/extradir2/',
-  files: [
-    {
-      destination: 'test.json',
-    }
-  ]
-};
-
-var platformWithBadBuildPath = {
-  buildPath: 'test/output/extradir1/extradir2',
-  files: [
-    {
-      destination: 'test.json',
-      format: function(dictionary) {
-        return JSON.stringify(dictionary.properties)
-      }
-    }
-  ]
-};
-
 describe('cleanDirs', function() {
   beforeEach(function() {
     helpers.clearOutput();

--- a/test/cleanFiles.js
+++ b/test/cleanFiles.js
@@ -45,27 +45,6 @@ var platformWithBuildPath = {
   ]
 };
 
-var platformWithoutFormatter = {
-  buildPath: 'test/output/',
-  files: [
-    {
-      destination: 'test.json',
-    }
-  ]
-};
-
-var platformWithBadBuildPath = {
-  buildPath: 'test/output',
-  files: [
-    {
-      destination: 'test.json',
-      format: function(dictionary) {
-        return JSON.stringify(dictionary.properties)
-      }
-    }
-  ]
-};
-
 describe('cleanFiles', function() {
   beforeEach(function() {
     helpers.clearOutput();

--- a/test/formats/javascriptObject.js
+++ b/test/formats/javascriptObject.js
@@ -11,9 +11,7 @@
  * and limitations under the License.
  */
 
-var assert  = require('chai').assert,
-    fs = require('fs-extra'),
-    helpers = require('../helpers'),
+var vm = require('vm'),
     formats = require('../../lib/common/formats');
 
 var file = {
@@ -33,8 +31,14 @@ var dictionary = {
 var formatter = formats['javascript/object'].bind(file);
 
 describe('formats', function() {
-  describe('javascript/module', function() {
-    // Can't test a non-node type js file (without module.exports)
-    // TODO: figure out how to test this
+  describe('javascript/object', function() {
+    it('should be valid JS syntax', function(done){
+      try {
+        vm.runInNewContext(formatter(dictionary))
+        return done();
+      } catch (err) {
+        return done(new Error(err));
+      }
+    });
   });
 });

--- a/test/formats/scssIcons.js
+++ b/test/formats/scssIcons.js
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+var assert  = require('chai').assert,
+    scss    = require('node-sass'),
+    formats = require('../../lib/common/formats');
+
+var file = {
+  "destination": "output/",
+  "format": "scss/icons",
+  "name": "foo"
+};
+
+var propertyName = "content-icon-email";
+var propertyValue = "'\\E001'";
+var itemClass = "3d_rotation";
+
+var dictionary = {
+  "allProperties": [{
+    "name": propertyName,
+    "value": propertyValue,
+    "original": {
+      "value": propertyValue
+    },
+    "attributes": {
+      "category": "content",
+      "type": "icon",
+      "item": itemClass
+    }
+  }]
+};
+
+var config = {
+  prefix: 'sd' // Style-Dictionary Prefix
+};
+
+
+var formatter = formats['scss/icons'].bind(file);
+
+describe('formats', function() {
+  describe('scss/icons', function() {
+    it('should have a valid scss syntax', function(done) {
+      scss.render({
+        data: formatter(dictionary, config),
+      }, function(err, result) {
+        if(err) {
+          return done(new Error(err));
+        }
+        assert.isDefined(result.css);
+        return done();
+      });
+    });
+  });
+});

--- a/test/formats/scssVariables.js
+++ b/test/formats/scssVariables.js
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+var assert  = require('chai').assert,
+    scss = require('node-sass'),
+    formats = require('../../lib/common/formats');
+
+var file = {
+  "destination": "output/",
+  "format": "scss/variables",
+  "name": "foo"
+};
+
+var propertyName = "color-base-red-400";
+var propertyValue = "#EF5350";
+
+var dictionary = {
+  "allProperties": [{
+    "name": propertyName,
+    "value": propertyValue,
+    "original": {
+      "value": propertyValue
+    },
+    "attributes": {
+      "category": "color",
+      "type": "base",
+      "item": "red",
+      "subitem": "400"
+    },
+    "path": [
+      "color",
+      "base",
+      "red",
+      "400"
+    ]
+  }]
+};
+
+var formatter = formats['scss/variables'].bind(file);
+
+describe('formats', function() {
+  describe('scss/variables', function() {
+    it('should have a valid scss syntax', function(done) {
+      scss.render({
+        data: formatter(dictionary),
+      }, function(err, result) {
+        if(err) {
+          return done(new Error(err));
+        }
+        assert.isDefined(result.css);
+        return done();
+      });
+    });
+  });
+});

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -11,8 +11,7 @@
  * and limitations under the License.
  */
 
-var fs   = require('fs-extra'),
-    glob = require('glob');
+var fs   = require('fs-extra');
 
 module.exports = {
   clearOutput: function() {

--- a/test/property.js
+++ b/test/property.js
@@ -12,7 +12,6 @@
  */
 
 var assert            = require('chai').assert,
-    helpers           = require('./helpers'),
     transformProperty = require('../lib/transform/property');
 
 
@@ -20,20 +19,20 @@ var options = {
   transforms: [
     {
       type: 'attribute',
-      transformer: function(prop) {
+      transformer: function() {
         return {
           foo: 'bar'
         }
       }
     },{
       type: 'attribute',
-      transformer: function(prop) {
+      transformer: function() {
         return {bar: 'foo'}
       }
     },{
       type: 'name',
       matcher: function(prop) { return prop.attributes.foo === 'bar'; },
-      transformer: function(prop) { return "hello"; }
+      transformer: function() { return "hello"; }
     }
   ]
 };

--- a/test/transforms.js
+++ b/test/transforms.js
@@ -13,7 +13,6 @@
 
 var assert     = require('chai').assert,
     path       = require('path'),
-    helpers    = require('./helpers'),
     transforms = require('../lib/common/transforms');
 
 

--- a/test/utils/deepExtend.js
+++ b/test/utils/deepExtend.js
@@ -49,9 +49,7 @@ describe('deepExtend', function() {
   });
 
   it('shouldn\'t fail loudly if it is a normal deep extend', function () {
-    var test = deepExtend([{foo: {bar:'bar'}}, {foo: {baz:'baz'}}], function(name) {
-
-    });
+    var test = deepExtend([{foo: {bar:'bar'}}, {foo: {baz:'baz'}}], function() {});
     assert.equal(test.foo.bar, 'bar');
     assert.equal(test.foo.baz, 'baz');
   });
@@ -59,7 +57,7 @@ describe('deepExtend', function() {
   describe('collision detection', function() {
     it('should call the collision function if a collision happens', function () {
       assert.throws(
-        deepExtend.bind(null, [{foo: {bar:'bar'}}, {foo: {bar:'baz'}}], function(opts) {
+        deepExtend.bind(null, [{foo: {bar:'bar'}}, {foo: {bar:'baz'}}], function() {
           throw new Error('danger danger. high voltage.');
         }),
         Error,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Fixed most of the ESlint warnings, left the ones in the ES6 export testing file because I also couldn't figure out a way to test ES6 in this normal JS.

- Added Testing for SCSS by adding the `node-sass` library and testing against correctness of syntax (valid output)

- Added Testing of normal Javascript object using the `vm` node API with a try/catch block. This can also be achieved with an eval, but the run in context doesn't pollute the global scope I think.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
