### PR TITLE
Add husky pre-commit hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "version": "node ./scripts/version.js && npm run generate-docs",
     "generate-docs": "node ./scripts/generateDocs.js",
     "serve-docs": "docsify serve docs -p 3000 -P 12345",
-    "install-cli": "npm install -g $(npm pack)"
+    "install-cli": "npm install -g $(npm pack)",
+    "precommit": "npm test"
   },
   "repository": {
     "type": "git",
@@ -72,6 +73,7 @@
     "docsify": "^4.5.7",
     "docsify-cli": "^4.2.0",
     "eslint": "^3.11.1",
+    "husky": "^0.14.3",
     "istanbul": "^0.4.5",
     "jsdoc-to-markdown": "^3.0.3",
     "less": "^3.0.1",


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/amzn/style-dictionary/issues/81

*Description of changes:*
Adding husky to test pre-commit.
Tried to add the latest husky version but it seems that is incomatible with node V4 and V5... So I guess we'll have to settle with using V0.14.3. Tradeoff is that if you had githooks in the project before sometimes they are imcompatible, so you need to do
`rm -rf .git/hooks/`.

You can see the issues I had here:
https://travis-ci.org/amzn/style-dictionary/builds/367857409

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
