### PR TITLE
Upgrade engines to node v6, upgrade husky and add node v6/v8 to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: node_js
 node_js:
+  - "8"
   - "6"
-  - "5"
-  - "4"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "style-dictionary": "./bin/style-dictionary"
   },
   "engines": {
-    "node": ">=4.2.4"
+    "node": ">=6.0.0"
   },
   "files": [
     "bin",
@@ -42,8 +42,12 @@
     "version": "node ./scripts/version.js && npm run generate-docs",
     "generate-docs": "node ./scripts/generateDocs.js",
     "serve-docs": "docsify serve docs -p 3000 -P 12345",
-    "install-cli": "npm install -g $(npm pack)",
-    "precommit": "npm test"
+    "install-cli": "npm install -g $(npm pack)"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "npm test"
+    }
   },
   "repository": {
     "type": "git",
@@ -73,7 +77,7 @@
     "docsify": "^4.5.7",
     "docsify-cli": "^4.2.0",
     "eslint": "^3.11.1",
-    "husky": "^0.14.3",
+    "husky": "^1.0.0-rc.2",
     "istanbul": "^0.4.5",
     "jsdoc-to-markdown": "^3.0.3",
     "less": "^3.0.1",


### PR DESCRIPTION
*Issue #, if available:*
Node V4 end of life is today! 🎉 
So updating the infra to reflect that.
https://github.com/nodejs/Release#nodejs-release-working-group

Continuation of this PR:
https://github.com/amzn/style-dictionary/pull/83

*Description of changes:*
- Bump engine to V6, did unit testing and serving of docs in node V6 and V8 without any issue.
- Upgrading Husky to the latest
- Change CI to only test V6 and V8 from now onwards

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
