### PR TITLE
Update docs to include the word "alias"

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ This tells the style dictionary build system how and what to build. The default 
 }
 ```
 
-Here we are creating some basic font size properties. The style definition size.font.small.value is "10px" for example.  The style definition size.font.base.value automatically takes on the value found in size.font.medium.value, so both of those resolve to "16px".
+Here we are creating some basic font size properties. The style definition size.font.small.value is "10px" for example.  The style definition size.font.base.value is automatically aliased to the value found in size.font.medium.value, so both of those resolve to "16px".
 
 Now what the style dictionary build system will do with this information is convert it to different formats so that you can use these values in any type of codebase. From this one file you can generate any number of files like:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,7 +38,7 @@ Let's take a look at a very basic example.
 }
 ```
 
-Here we are creating some basic font size properties. The style property `size.font.small` is "10px" for example. The style definition size.font.base.value automatically takes on the value found in size.font.medium.value, so both of those resolve to "16px".
+Here we are creating some basic font size properties. The style property `size.font.small` is "10px" for example. The style definition size.font.base.value is automatically aliased to the value found in size.font.medium.value, so both of those resolve to "16px".
 
 Now what the style dictionary build system will do with this information is convert it to different formats so that you can use these values in any type of codebase. From this one file you can generate any number of files like:
 


### PR DESCRIPTION
*Issue #, if available:*
We recently embarked on extracting design tokens from our component library, and compared style-dictionary vs. theo to do so. We loved what we saw with this project, but ultimately chose theo because we (mistakenly) believed there was no concept of referencing another property's value within a property (what theo calls an "alias").

In hindsight, I see now that your docs make that functionality quite clear, but I think literally using the word "alias", so that it shows up in a quick Find command, would be helpful.

*Description of changes:*
Simple reword of the repo README and the README used as the overview in the docs.

<!--By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.-->
