### PR TITLE
Adding color/css transform

### DIFF
--- a/lib/common/transformGroups.js
+++ b/lib/common/transformGroups.js
@@ -23,7 +23,7 @@ module.exports = {
    * [attribute/cti](transforms.md#attributecti)
    * [name/cti/kebab](transforms.md#namectikebab)
    * [size/px](transforms.md#sizepx)
-   * [color/hex](transforms.md#colorhex)
+   * [color/css](transforms.md#colorcss)
    *
    * @memberof TransformGroups
    */
@@ -31,7 +31,7 @@ module.exports = {
     'attribute/cti',
     'name/cti/kebab',
     'size/px',
-    'color/hex'
+    'color/css'
   ],
 
   /**
@@ -42,7 +42,7 @@ module.exports = {
    * [time/seconds](transforms.md#timeseconds)
    * [content/icon](transforms.md#contenticon)
    * [size/rem](transforms.md#sizerem)
-   * [color/hex](transforms.md#colorhex)
+   * [color/css](transforms.md#colorcss)
    *
    * @memberof TransformGroups
    */
@@ -52,7 +52,7 @@ module.exports = {
     'time/seconds',
     'content/icon',
     'size/rem',
-    'color/hex'
+    'color/css'
   ],
 
   /**

--- a/lib/common/transforms.js
+++ b/lib/common/transforms.js
@@ -337,6 +337,31 @@ module.exports = {
   },
 
   /**
+   * Transforms the value into a hex or rgb string depending on if it has transparency
+   *
+   * ```css
+   * // Matches: prop.attributes.category === 'color'
+   * // Returns:
+   * #000000
+   * rgba(0,0,0,0.5)
+   * ```
+   *
+   * @memberof Transforms
+   */
+  'color/css': {
+    type: 'value',
+    matcher: isColor,
+    transformer: function (prop) {
+      var color = Color(prop.value);
+      if (color.getAlpha() === 1) {
+        return color.toHexString();
+      } else {
+        return color.toRgbString();
+      }
+    }
+  },
+
+  /**
    * Transforms the value into a scale-independent pixel (sp) value for font sizes on Android. It will not scale the number.
    *
    * ```js

--- a/test/transforms.js
+++ b/test/transforms.js
@@ -278,6 +278,22 @@ describe('transforms', function() {
   });
 
 
+  describe('color/css', function() {
+    it('should handle normal colors', function() {
+      var value = transforms["color/css"].transformer({
+        value: "rgb(170, 170, 170)"
+      });
+      assert.equal(value, "#aaaaaa");
+    });
+
+    it('should handle colors with transparency', function() {
+      var value = transforms["color/css"].transformer({
+        value: "#aaaaaa99"
+      });
+      assert.equal(value, "rgba(170, 170, 170, 0.6)");
+    });
+  });
+
   describe('size/sp', function() {
     it('should work', function() {
       var value = transforms["size/sp"].transformer({


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adding 'color/css' transform which either outputs a 6bit hex if there is no transparency or rgba string if there is transparency. Added unit tests for it. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
