### PR TITLE
Filter API

### DIFF
--- a/docs/package_structure.md
+++ b/docs/package_structure.md
@@ -38,6 +38,7 @@ The default way is to use a config.json file in the root of your package. Here i
       "transforms": ["attribute/cti", "name/cti/snake", "color/hex", "size/remToSp", "size/remToDp"],
       "buildPath": "build/android/src/main/res/values/",
       "files": [{
+        "filter": { "category": "color" },
         "destination": "style_dictionary_colors.xml",
         "template": "android/colors"
       }]
@@ -56,6 +57,7 @@ The default way is to use a config.json file in the root of your package. Here i
 | platform.files | Array (optional) | Files to be generated for this platform. |
 | platform.file.destination | String (optional) | Location to build the file, will be appended to the buildPath. |
 | platform.file.format | String (optional) | [Format](formats.md) used to generate the file. Can be a built-in one or you can create your own. Must declare a format or a template. |
+| platform.file.filter | Function|Object (optional) | A function or object used to filter the properties that will be included in the file. If a function is provided, each property will be passed to the function and the result (true or false) will determine whether the property is included. If an object is provided, each property will be matched against the object using a partial deep comparison to determine whether the property is included. |
 | platform.file.template | String (optional) | [Template](templates.md) used to generate the file. Can be a built-in one or you can create your own. |
 | platform.actions | Array[String] (optional) | [Actions](actions.md) to be performed after the files are built for that platform. Actions can be any arbitrary code you want to run like copying files, generating assets, etc. You can use pre-defined actions or create custom actions. |
 

--- a/lib/buildFile.js
+++ b/lib/buildFile.js
@@ -12,7 +12,7 @@
  */
 
 var path = require('path'),
-    fs   = require('fs-extra')
+    fs   = require('fs-extra'),
     chalk = require('chalk'),
     filterProperties = require('./filterProperties');
 

--- a/lib/buildFile.js
+++ b/lib/buildFile.js
@@ -12,7 +12,8 @@
  */
 
 var path = require('path'),
-    fs   = require('fs-extra');
+    fs   = require('fs-extra'),
+    filterProperties = require('./filterProperties');
 
 
 /**
@@ -23,9 +24,10 @@ var path = require('path'),
  * @param {Function} format
  * @param {Object} platform
  * @param {Object} dictionary
+ * @param {Function} filter
  * @returns {null}
  */
-function buildFile(destination, format, platform, dictionary) {
+function buildFile(destination, format, platform, dictionary, filter) {
   if (!format || typeof format !== 'function')
     throw new Error('Please enter a valid file format');
   if (!destination || typeof destination !== 'string')
@@ -40,7 +42,7 @@ function buildFile(destination, format, platform, dictionary) {
   if (!fs.existsSync(dirname))
     fs.mkdirsSync(dirname);
 
-  fs.writeFileSync(destination, format(dictionary, platform));
+  fs.writeFileSync(destination, format(filterProperties(dictionary, filter), platform));
   console.log('✔︎ ' + destination);
 }
 

--- a/lib/buildFiles.js
+++ b/lib/buildFiles.js
@@ -31,9 +31,9 @@ function buildFiles(dictionary, platform) {
 
   _.each(platform.files, function (file) {
     if (file.template) {
-      buildFile(file.destination, file.template.bind(file), platform, dictionary);
+      buildFile(file.destination, file.template.bind(file), platform, dictionary, file.filter);
     } else if (file.format) {
-      buildFile(file.destination, file.format.bind(file), platform, dictionary);
+      buildFile(file.destination, file.format.bind(file), platform, dictionary, file.filter);
     } else {
       throw new Error('Please supply a template or formatter')
     }

--- a/lib/cleanDir.js
+++ b/lib/cleanDir.js
@@ -23,9 +23,10 @@ var path = require('path'),
  * @param {Function} format (unused)
  * @param {Object} platform
  * @param {Object} dictionary (unused)
+ * @param {Function} filter (unused)
  * @returns {null}
  */
-function cleanDir(destination, format, platform, dictionary) {
+function cleanDir(destination, format, platform, dictionary, filter) {
 
   if (!destination || typeof destination !== 'string')
     throw new Error('Please enter a valid destination');

--- a/lib/cleanFile.js
+++ b/lib/cleanFile.js
@@ -23,9 +23,10 @@ var path = require('path'),
  * @param {Function} format (unused)
  * @param {Object} platform
  * @param {Object} dictionary (unused)
+ * @param {Function} filter (unused)
  * @returns {null}
  */
-function cleanFile(destination, format, platform, dictionary) {
+function cleanFile(destination, format, platform, dictionary, filter) {
 
   if (!destination || typeof destination !== 'string')
     throw new Error('Please enter a valid destination');

--- a/lib/common/formats.js
+++ b/lib/common/formats.js
@@ -230,9 +230,7 @@ module.exports = {
   },
 
   /**
-   * Creates a ES6 module of the style dictionary. You can filter the style dictionary
-   * to only export properties of a certain type by adding a 'filter' attribute on the
-   * file object in the config.
+   * Creates a ES6 module of the style dictionary.
    *
    * ```json
    * {
@@ -241,10 +239,7 @@ module.exports = {
    *       "files": [
    *         {
    *           "format": "javascript/es6",
-   *           "destination": "colors.js",
-   *           "filter": {
-   *             "category": "color"
-   *           }
+   *           "destination": "colors.js"
    *         }
    *       ]
    *     }
@@ -261,10 +256,8 @@ module.exports = {
    * ```
    */
   'javascript/es6': function(dictionary) {
-    // this is bound to the file object
-    var props = _.filter(dictionary.allProperties, this.filter);
     return fileHeader() +
-      _.map(props, function(prop) {
+      _.map(dictionary.allProperties, function(prop) {
         return 'export const ' + prop.name + ' = \'' + prop.value + '\';';
       }).join('\n');
   },

--- a/lib/filterProperties.js
+++ b/lib/filterProperties.js
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+var _ = require("lodash")
+
+/**
+ * Takes a nested object of properties and filters them using the provided
+ * function.
+ *
+ * @param {Object} properties
+ * @param {Function} filter - A function that receives a property object and
+ *   returns `true` if the property should be included in the output or `false`
+ *   if the property should be excluded from the output.
+ * @returns {Object[]} properties - A new object containing only the properties
+ *   that matched the filter.
+ */
+function filterPropertyObject(properties, filter) {
+  // Use reduce to generate a new object with the unwanted properties filtered
+  // out
+  return _.reduce(properties, (result, value, key) => {
+    // If the value is not an object, we don't know what it is so just return it
+    // it as-is.
+    if (!_.isObject(value)) {
+      return result
+    // If the value has a `value` member we know it's a property, so pass it to
+    // the filter function and either include it in the final `result` object or
+    // exclude it (by returning the `result` object without it added).
+    } else if (value.value) {
+      return filter(value) ? _.assign(result, { [key]: value }) : result
+    // If we got here we have an object that is not a property. We'll assume
+    // it's an object containing multiple properties and recursively filter it
+    // using the `filterPropertyObject` function.
+    } else {
+      const filtered = filterPropertyObject(value, filter)
+      // If the filtered object is not empty then add it to the final `result`
+      // object. If it is empty then every property inside of it was filtered
+      // out, so exclude it entirely from the final `result` object.
+      return _.isEmpty(filtered) ? result : _.assign(result, { [key]: filtered })
+    }
+  }, {})
+}
+
+/**
+ * Takes an array of properties and filters them using the provided function.
+ *
+ * @param {Object[]} properties
+ * @param {Function} filter - A function that receives a property object and
+ *   returns `true` if the property should be included in the output or `false`
+ *   if the property should be excluded from the output.
+ * @returns {Object[]} properties - A new array containing only the properties
+ *   that matched the filter.
+ */
+function filterPropertyArray(properties, filter) {
+  // Go lodash!
+  return _.filter(properties, filter)
+}
+
+/**
+ * Takes a dictionary and filters the `allProperties` array and the `properties`
+ * object using a function provided by the user.
+ *
+ * @param {Object} dictionary
+ * @param {Function|Object} filter - Either a function that receives a property
+ *   object and returns `true` if the property should be included in the output
+ *   or `false` if the property should be excluded from the output, or an object
+ *   to compare each property to (see lodash/matches).
+ * @returns {Object} dictionary - A new dictionary containing only the
+ *   properties that matched the filter (or the original dictionary if no filter
+ *   function was provided).
+ */
+function filterProperties(dictionary, filter) {
+  if (!filter) {
+    return dictionary
+  } else {
+    const filterFunc = _.isFunction(filter) ? filter : _.matches(filter)
+    return _.assign({}, dictionary, {
+      allProperties: filterPropertyArray(dictionary.allProperties, filterFunc),
+      properties: filterPropertyObject(dictionary.properties, filterFunc)
+    })
+  }
+}
+
+module.exports = filterProperties

--- a/test/buildFiles.js
+++ b/test/buildFiles.js
@@ -12,12 +12,14 @@
  */
 
 var assert     = require('chai').assert,
+    expect     = require('chai').expect,
     helpers    = require('./helpers'),
     buildFiles = require('../lib/buildFiles');
 
 var dictionary = {
   properties: {
-    foo: 'bar'
+    foo: { value: 'bar' },
+    bingo: { value: 'bango' }
   }
 };
 
@@ -40,6 +42,21 @@ var platformWithBuildPath = {
       format: function(dictionary) {
         return JSON.stringify(dictionary.properties)
       }
+    }
+  ]
+};
+
+var platformWithFilter = {
+  buildPath: 'test/output/',
+  files: [
+    {
+      destination: 'test.json',
+      filter: function(property) {
+        return property.value === "bango"
+      },
+      format: function(dictionary) {
+        return JSON.stringify(dictionary.properties)
+      },
     }
   ]
 };
@@ -94,5 +111,13 @@ describe('buildFiles', function() {
   it('should work with buildPath', function() {
     buildFiles( dictionary, platformWithBuildPath );
     assert(helpers.fileExists('./test/output/test.json'));
+  });
+
+  it('should work with a filter', function() {
+    buildFiles( dictionary, platformWithFilter );
+    assert(helpers.fileExists('./test/output/test.json'));
+    var output = require("./output/test.json")
+    expect(output).to.not.have.any.keys("foo")
+    expect(output).to.have.all.keys("bingo")
   });
 });

--- a/test/filterProperties.js
+++ b/test/filterProperties.js
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+var assert  = require('chai').assert,
+    expect = require('chai').expect,
+    fs = require('fs-extra'),
+    helpers = require('./helpers'),
+    flattenProperties = require("../lib/utils/flattenProperties"),
+    filterProperties = require('../lib/filterProperties');
+
+var colorRed = {
+  "value": "#FF0000",
+  "original": {
+    "value": "#FF0000",
+  },
+  "name": "color-red",
+  "attributes": { type: "color" },
+  "path": [
+    "color",
+    "red"
+  ]
+}
+
+var colorBlue = {
+  "value": "#0000FF",
+  "original": {
+    "value": "#0000FF",
+  },
+  "name": "color-blue",
+  "attributes": { type: "color" },
+  "path": [
+    "color",
+    "blue"
+  ]
+}
+
+var sizeSmall = {
+  "value": "2px",
+  "original": {
+    "value": "2px",
+  },
+  "name": "size-small",
+  "attributes": { category: "size" },
+  "path": [
+    "size",
+    "small"
+  ]
+}
+
+var sizeLarge = {
+  "value": "4px",
+  "original": {
+    "value": "4px",
+  },
+  "name": "size-large",
+  "attributes": { category: "size" },
+  "path": [
+    "size",
+    "large"
+  ]
+}
+
+var properties = {
+  "color": {
+    "red": colorRed,
+    "blue": colorBlue,
+  },
+  "size": {
+    "small": sizeSmall,
+    "large": sizeLarge,
+  }
+};
+
+var dictionary = {
+  "properties": properties,
+  "allProperties": flattenProperties(properties)
+}
+
+describe('filterProperties', function() {
+  beforeEach(function() {
+    helpers.clearOutput();
+  });
+
+  it('should return the original dictionary if no filter is provided', function() {
+    assert.equal(dictionary, filterProperties(dictionary))
+  });
+
+  it('should work with a filter function', function() {
+    var filter = function(property) {
+      return property.path.includes("size")
+    }
+    var filteredDictionary = filterProperties(dictionary, filter)
+    expect(filteredDictionary.allProperties).to.not.have.any.members([colorRed, colorBlue])
+    expect(filteredDictionary.allProperties).to.have.all.members([sizeSmall, sizeLarge])
+    expect(filteredDictionary.properties).to.not.have.any.keys("color")
+    expect(filteredDictionary.properties).to.have.all.keys("size")
+  });
+
+  it('should work with a filter object', function() {
+    var filter = { "attributes": { "category": "size" } }
+    var filteredDictionary = filterProperties(dictionary, filter)
+    expect(filteredDictionary.allProperties).to.not.have.any.members([colorRed, colorBlue])
+    expect(filteredDictionary.allProperties).to.have.all.members([sizeSmall, sizeLarge])
+    expect(filteredDictionary.properties).to.not.have.any.keys("color")
+    expect(filteredDictionary.properties).to.have.all.keys("size")
+  });
+});


### PR DESCRIPTION
*Issue #, if available:*

#86 

*Description of changes:*

New filter API

These changes introduce a new filter API that addresses #86. The key differences are:

* Filters are applied automatically in the `buildFile` function to both the `properties` and `allProperties` members of a dictionary. Filters are no longer applied ad-hoc in formatters.
* A filter can be a function in addition to an object. If a function is provided the property is passed wholesale to the function and the result (true or false) is used to determine whether the property should be included or filtered out. If an object is provided the behavior is the same as it used to be (a partial deep comparison is performed using lodash).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
