### PR TITLE
fixed “toUpperCase” case

### DIFF
--- a/docs/extending.md
+++ b/docs/extending.md
@@ -34,7 +34,7 @@ StyleDictionary.registerTransform({
   name: 'name/uppercase',
   type: 'name',
   transformer: function(prop) {
-    return prop.path.join('_').toUppercase();
+    return prop.path.join('_').toUpperCase();
   }
 });
 

--- a/example/complete/package.json
+++ b/example/complete/package.json
@@ -10,6 +10,6 @@
   "author": "",
   "license": "Apache-2.0",
   "devDependencies": {
-    "style-dictionary": "2.2.0"
+    "style-dictionary": "2.2.1"
   }
 }

--- a/example/npm/package.json
+++ b/example/npm/package.json
@@ -18,6 +18,6 @@
   "author": "",
   "license": "Apache-2.0",
   "devDependencies": {
-    "style-dictionary": "2.2.0"
+    "style-dictionary": "2.2.1"
   }
 }

--- a/example/react/package.json
+++ b/example/react/package.json
@@ -10,6 +10,6 @@
   "author": "",
   "license": "Apache-2.0",
   "devDependencies": {
-    "style-dictionary": "2.2.0"
+    "style-dictionary": "2.2.1"
   }
 }

--- a/example/s3/package.json
+++ b/example/s3/package.json
@@ -14,6 +14,6 @@
   "devDependencies": {
     "aws-sdk": "^2.7.21",
     "fs-extra": "^1.0.0",
-    "style-dictionary": "2.2.0"
+    "style-dictionary": "2.2.1"
   }
 }

--- a/lib/utils/combineJSON.js
+++ b/lib/utils/combineJSON.js
@@ -36,7 +36,7 @@ function combineJSON(arr, deep, collision) {
   }
 
   for (i = 0; i < files.length; i++) {
-    var resolvedPath = resolveCwd(path.isAbsolute(files[i]) ? files[i] : '.' + path.sep + files[i]);
+    var resolvedPath = resolveCwd(path.isAbsolute(files[i]) ? files[i] : './' + files[i]);
     var file_content;
 
     try {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "style-dictionary",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "style-dictionary",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Style once, use everywhere. A build system for creating cross-platform styles.",
   "keywords": [
     "style dictionary",


### PR DESCRIPTION
Just a small fix to the documentation, where the JavaScript method "toUpperCase" had the wrong case :)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
