### PR TITLE
Fix: #111, resolveObject no longer mutates the original properties ob…

### DIFF
--- a/lib/utils/resolveObject.js
+++ b/lib/utils/resolveObject.js
@@ -26,7 +26,7 @@ var updated_object, regex, options;
 function resolveObject(object, opts) {
   options = _.extend({}, defaults, opts);
 
-  updated_object = _.clone(object);  // This object will be edited
+  updated_object = _.cloneDeep(object);  // This object will be edited
 
   regex = new RegExp(
     '\\' +

--- a/test/utils/resolveObject.js
+++ b/test/utils/resolveObject.js
@@ -38,8 +38,8 @@ describe('resolveObject', function() {
   it('should not mutate the original object', function() {
     var original = helpers.fileToJSON(__dirname + '/../json_files/nested_references.json');
     var test = resolveObject( original );
-    console.log(original);
     assert.equal(original.a.b.d, '{e.f.g}');
+    assert.equal(test.a.b.d, 2);
   });
 
   it('should do simple references', function() {

--- a/test/utils/resolveObject.js
+++ b/test/utils/resolveObject.js
@@ -35,6 +35,13 @@ describe('resolveObject', function() {
     );
   });
 
+  it('should not mutate the original object', function() {
+    var original = helpers.fileToJSON(__dirname + '/../json_files/nested_references.json');
+    var test = resolveObject( original );
+    console.log(original);
+    assert.equal(original.a.b.d, '{e.f.g}');
+  });
+
   it('should do simple references', function() {
     var test = resolveObject( helpers.fileToJSON(__dirname + '/../json_files/simple.json') );
     assert.equal(test.bar, 'bar');


### PR DESCRIPTION
*Issue #, if available:* #111 

*Description of changes:* Make resolveObject no longer mutate the original object by using _.cloneDeep instead of _.clone

Unit test added


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
