### PR TITLE
JavaScript config files

### DIFF
--- a/bin/style-dictionary
+++ b/bin/style-dictionary
@@ -55,11 +55,8 @@ function styleDictionaryBuild(options) {
   options = options || {};
   var configPath = options.config ? options.config : './config.json';
 
-  console.log("Reading config file from " + configPath);
-  var config = JSON.parse( fs.readFileSync(configPath) );
-
   // Create a style dictionary object with the config
-  var styleDictionary = StyleDictionary.extend( config );
+  var styleDictionary = StyleDictionary.extend( configPath );
 
   if (options.platform && options.platform.length > 0) {
     options.platform.forEach(function(platform) {
@@ -74,11 +71,8 @@ function styleDictionaryClean(options) {
   options = options || {};
   var configPath = options.config ? options.config : './config.json';
 
-  console.log("Reading config file from " + configPath);
-  var config = JSON.parse( fs.readFileSync(configPath) );
-
   // Create a style dictionary object with the config
-  var styleDictionary = StyleDictionary.extend( config );
+  var styleDictionary = StyleDictionary.extend( configPath );
 
   if (options.platform && options.platform.length > 0) {
     options.platform.forEach(function(platform) {

--- a/docs/build_process.md
+++ b/docs/build_process.md
@@ -19,7 +19,7 @@ Here is what the build system is doing under the hood.
 
 If you use this as a node module, the steps are slightly different, but the overall.
 
-1. When you call the [`extend`](api.md#extend) method, you can either pass it a path to a JSON config file, or give it a plain object that has the configuration. This will perform steps 1-3 above.
+1. When you call the [`extend`](api.md#extend) method, you can either pass it a path to a JSON or JS config file, or give it a plain object that has the configuration. This will perform steps 1-3 above.
 1. Then you can now call `buildAllPlatforms` or other methods like `buildPlatform('scss')` or `exportPlatform('javascript')`. This is equivalent to step 4 above.
 
 ```javascript

--- a/lib/extend.js
+++ b/lib/extend.js
@@ -13,7 +13,7 @@
 
 var combineJSON = require('./utils/combineJSON'),
     deepExtend = require('./utils/deepExtend'),
-    fs = require('fs-extra'),
+    resolveCwd = require('resolve-cwd'),
     _ = require('lodash'),
     chalk = require('chalk');
 
@@ -81,13 +81,13 @@ var combineJSON = require('./utils/combineJSON'),
 function extend(opts) {
   var options, to_ret;
 
-  // Overloaded method, can accept a string as a path that points to a JSON file
-  // or a plain object. Potentially refactor.
+  // Overloaded method, can accept a string as a path that points to a JS or
+  // JSON file or a plain object. Potentially refactor.
   if (_.isString(opts)) {
-    options = fs.readJsonSync(opts);
+    options = require(resolveCwd(opts));
   } else {
     options = opts;
-  }
+  }``
 
   // Creating a new object and copying over the options
   // Also keeping an options object just in case

--- a/test/cliBuild.js
+++ b/test/cliBuild.js
@@ -12,24 +12,22 @@
  */
 
 var assert          = require('chai').assert,
-    helpers         = require('./helpers'),
-    StyleDictionary = require('../index');
+    childProcess    = require("child_process"),
+    helpers         = require('./helpers');
 
-describe('buildAllPlatforms', function() {
+describe('cliBuildWithJsConfig', function() {
   beforeEach(function() {
     helpers.clearOutput();
   });
 
   it('should work with json config', function() {
-    var test = StyleDictionary.extend(__dirname + '/configs/test.json');
-    test.buildAllPlatforms();
+    childProcess.execSync("node ./bin/style-dictionary build --config ./test/configs/test.json")
     assert(helpers.fileExists('./test/output/web/_icons.css'));
     assert(helpers.fileExists('./test/output/android/colors.xml'));
   });
 
-  it('should work with js config', function() {
-    var test = StyleDictionary.extend(__dirname + '/configs/test.js');
-    test.buildAllPlatforms();
+  it('should work with javascript config', function() {
+    childProcess.execSync("node ./bin/style-dictionary build --config ./test/configs/test.js")
     assert(helpers.fileExists('./test/output/web/_icons.css'));
     assert(helpers.fileExists('./test/output/android/colors.xml'));
   });

--- a/test/configs/test.js
+++ b/test/configs/test.js
@@ -1,0 +1,1 @@
+module.exports = require("./test.json")


### PR DESCRIPTION
This change enables the user to use a JavaScript module for their
config file. The goal of this change is to enable more flexible
configuration similar to Webpack or Babel. For example filter
functions, which previously could only be provided using the Node
API, can now be included directly in a JS config file.

JavaScript config files could also eventually remove the need for
the register APIs because you could simply pass formatters,
transformers, etc. as functions directly in the config instead of
registering them with an alias and then referencing that alias in
the config. This could potentially provide a simpler API very
similar to the way webpack handles plugins:
https://webpack.js.org/configuration/plugins/. Just a thought
though. For now the default config file `./config.json` and the
ability to continue to use JSON config files has not changed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
