### PR TITLE
Improved error messages for registerTemplate

### DIFF
--- a/lib/register/template.js
+++ b/lib/register/template.js
@@ -33,7 +33,7 @@ var fs = require('fs'),
  */
 function registerTemplate(options) {
   if (typeof options.name !== 'string')
-    throw new Error('Transform name must be a string: ' + chalk.red(JSON.stringify(options.name)));
+    throw new Error('Template name must be a string: ' + chalk.red(JSON.stringify(options.name)));
   if (typeof options.template !== 'string')
     throw new Error('Template path must be a string: ' + chalk.red(JSON.stringify(options.template)));
   if (!fs.existsSync(options.template))

--- a/lib/register/template.js
+++ b/lib/register/template.js
@@ -12,7 +12,8 @@
  */
 
 var fs = require('fs'),
-    _  = require('lodash');
+    _  = require('lodash'),
+    chalk = require('chalk');
 
 /**
  * Add a custom template to the Style Dictionary
@@ -32,11 +33,11 @@ var fs = require('fs'),
  */
 function registerTemplate(options) {
   if (typeof options.name !== 'string')
-    throw new Error('transform name must be a string');
+    throw new Error('Transform name must be a string: ' + chalk.red(JSON.stringify(options.name)));
   if (typeof options.template !== 'string')
-    throw new Error('template path must be a string');
+    throw new Error('Template path must be a string: ' + chalk.red(JSON.stringify(options.template)));
   if (!fs.existsSync(options.template))
-    throw new Error('template must be a file');
+    throw new Error('Can\'t find template: ' + chalk.red(JSON.stringify(options.template)));
 
   var template_string = fs.readFileSync( options.template );
 


### PR DESCRIPTION
*Issue #134:*

*Description of changes:*
Added failing `option` values to error messages in `registerTemplate` function. Feel free to update the format/formatting of the messages (if there is a more "standard" way, more consistent with other error messages).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
