### PR TITLE
handle no command and invalid commands with friendly console output

### DIFF
--- a/bin/style-dictionary
+++ b/bin/style-dictionary
@@ -51,6 +51,12 @@ program
     styleDictionaryBuild();
   });
 
+// error on unknown commands
+program.on('command:*', function () {
+  console.error('Invalid command: %s\nSee --help for a list of available commands.', args.join(' '));
+  process.exit(1);
+});
+
 function styleDictionaryBuild(options) {
   options = options || {};
   var configPath = options.config ? options.config : './config.json';
@@ -84,3 +90,8 @@ function styleDictionaryClean(options) {
 }
 
 program.parse(process.argv);
+
+// show help on no command
+if (!process.argv.slice(2).length) {
+  program.outputHelp();
+}


### PR DESCRIPTION
Description of changes:

- Automatically show help info if someone runs style-dictionary with no commands
- Added friendly output if someone uses an invalid command.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
