### PR TITLE
Added 'json/flat' format

### DIFF
--- a/__tests__/formats/__snapshots__/all.test.js.snap
+++ b/__tests__/formats/__snapshots__/all.test.js.snap
@@ -478,6 +478,12 @@ exports[`formats all should return json as a string 1`] = `
 
 exports[`formats all should return json/asset as a string 1`] = `"{}"`;
 
+exports[`formats all should return json/flat as a string 1`] = `
+"{
+  \\"color_red\\": \\"#FF0000\\"
+}"
+`;
+
 exports[`formats all should return json/nested as a string 1`] = `
 "{
   \\"color\\": {

--- a/__tests__/formats/jsonFlat.test.js
+++ b/__tests__/formats/jsonFlat.test.js
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+var formats = require('../../lib/common/formats');
+var fs = require('fs-extra');
+var helpers = require('../__helpers');
+
+var file = {
+  "destination": "__output/",
+  "format": "json/flat"
+};
+
+var dictionary = {
+  "allProperties": [{
+    "name": "color-base-red",
+    "value": "#EF5350",
+    "original": {
+      "value": "#EF5350"
+    },
+    "attributes": {
+      "category": "color",
+      "type": "base",
+      "item": "red"
+    },
+    "path": [
+      "color",
+      "base",
+      "red"
+    ]
+  }]
+};
+
+var formatter = formats['json/flat'].bind(file);
+
+describe('formats', () => {
+  describe('json/flat', () => {
+
+    beforeEach(() => {
+      helpers.clearOutput();
+    });
+
+    afterEach(() => {
+      helpers.clearOutput();
+    });
+
+    it('should be a valid JSON file', () => {
+      fs.writeFileSync('./__tests__/__output/output.flat.json', formatter(dictionary) );
+      var test = require('../__output/output.flat.json');
+      expect(test['color-base-red']).toEqual(dictionary.allProperties[0].value);
+    });
+  });
+
+});

--- a/lib/common/formats.js
+++ b/lib/common/formats.js
@@ -585,6 +585,23 @@ module.exports = {
     return JSON.stringify(minifyDictionary(dictionary.properties), null, 2);
   },
 
+  /**
+   * Creates a JSON flat file of the style dictionary.
+   *
+   * @memberof Formats
+   * @kind member
+   * @example
+   * ```json
+   * {
+   *   "color-base-red": "#ff000"
+   * }
+   * ```
+   */
+  'json/flat': function(dictionary) {
+    return '{\n' + _.map(dictionary.allProperties, function(prop) {
+        return `  "${prop.name}": ${JSON.stringify(prop.value)}`;
+      }).join(',\n') + '\n}';
+  },
 
   /**
    * Creates a sketchpalette file of all the base colors

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "scripts": {
     "lint": "eslint index.js lib/**/*.js test/*.js test/**/*.js",
     "test": "npm run lint && jest --runInBand",
+    "test-watch": "npm run lint && jest --runInBand --watch",
     "coverage": "istanbul cover ./node_modules/mocha/bin/_mocha -- test/*.js test/**/*.js",
     "preversion": "npm test",
     "version": "node ./scripts/version.js && npm run generate-docs",


### PR DESCRIPTION
*Issue #138 - Follows #145:*

*Description of changes:*
- added `json/flat` format + corresponding tests
- added the `test-watch` option to package.json to run Jest tests in watch mode

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.