### PR TITLE
Buxfix/css comments

### DIFF
--- a/lib/common/formats.js
+++ b/lib/common/formats.js
@@ -32,12 +32,14 @@ function variablesWithPrefix(prefix, properties) {
   return _.map(properties, function(prop) {
       var to_ret_prop = prefix + prop.name + ': ' + (prop.attributes.category==='asset' ? '"'+prop.value+'"' : prop.value) + ';';
 
-      if (prop.comment)
-        if(prefix === 'css') {
+      if (prop.comment) {
+        // css prefix
+        if(prefix === ' --') {
           to_ret_prop = to_ret_prop.concat(' /* ' + prop.comment + ' */');
         } else {
           to_ret_prop = to_ret_prop.concat(' // ' + prop.comment);
         }
+      }
       return to_ret_prop;
     })
     .filter(function(strVal) { return !!strVal })

--- a/lib/common/formats.js
+++ b/lib/common/formats.js
@@ -33,7 +33,11 @@ function variablesWithPrefix(prefix, properties) {
       var to_ret_prop = prefix + prop.name + ': ' + (prop.attributes.category==='asset' ? '"'+prop.value+'"' : prop.value) + ';';
 
       if (prop.comment)
-        to_ret_prop = to_ret_prop.concat(' // ' + prop.comment);
+        if(prefix === 'css') {
+          to_ret_prop = to_ret_prop.concat(' /* ' + prop.comment + ' */');
+        } else {
+          to_ret_prop = to_ret_prop.concat(' // ' + prop.comment);
+        }
       return to_ret_prop;
     })
     .filter(function(strVal) { return !!strVal })


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This writes css single line comments as `/* comment */`. This was necessary to maintain variables separately in css files while using postcss to compile.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
