### PR TITLE
feat: Making include accept an array of globs, like source does

### DIFF
--- a/__tests__/extend.test.js
+++ b/__tests__/extend.test.js
@@ -82,7 +82,7 @@ describe('extend', () => {
       expect(StyleDictionaryExtended.properties).toEqual(helpers.fileToJSON(__dirname + "/__properties/paddings.json"));
     });
 
-    it('should override existing properties include is given', () => {
+    it('should override existing properties if include is given', () => {
       var StyleDictionaryExtended = StyleDictionary.extend({
         properties: test_props,
         include: [__dirname + "/__properties/paddings.json"]
@@ -114,7 +114,7 @@ describe('extend', () => {
       ).toThrow('source must be an array');
     });
 
-    it('should not update properties if sourche glob paths dont resolve to anything', () => {
+    it('should not update properties if source glob paths don\'t resolve to anything', () => {
       var StyleDictionaryExtended = StyleDictionary.extend({
         source: ['foo']
       });

--- a/__tests__/extend.test.js
+++ b/__tests__/extend.test.js
@@ -61,10 +61,33 @@ describe('extend', () => {
       ).toThrow('include must be an array');
     });
 
-    it('should throw if a path in the includes array doesnt resolve', () => {
-      expect(
-        StyleDictionary.extend.bind(null, {include: ['foo']})
-      ).toThrow("Cannot find module 'foo'");
+    it('should not update properties if include glob paths dont resolve to anything', () => {
+      var StyleDictionaryExtended = StyleDictionary.extend({
+        include: ['foo']
+      });
+      expect(typeof StyleDictionaryExtended.properties.size).toBe('undefined');
+    });
+
+    it('should properly glob paths', () => {
+      var StyleDictionaryExtended = StyleDictionary.extend({
+        include: [__dirname + '/__properties/*.json']
+      });
+      expect(typeof StyleDictionaryExtended.properties.size.padding.tiny).toBe('object');
+    });
+
+    it('should build the properties object if an include is given', () => {
+      var StyleDictionaryExtended = StyleDictionary.extend({
+        "include": [__dirname + "/__properties/paddings.json"]
+      });
+      expect(StyleDictionaryExtended.properties).toEqual(helpers.fileToJSON(__dirname + "/__properties/paddings.json"));
+    });
+
+    it('should override existing properties include is given', () => {
+      var StyleDictionaryExtended = StyleDictionary.extend({
+        properties: test_props,
+        include: [__dirname + "/__properties/paddings.json"]
+      });
+      expect(StyleDictionaryExtended.properties).toEqual(helpers.fileToJSON(__dirname + "/__properties/paddings.json"));
     });
 
     it('should update properties if there are includes', () => {
@@ -91,10 +114,11 @@ describe('extend', () => {
       ).toThrow('source must be an array');
     });
 
-    it('should throw if a path in the source array doesnt resolve', () => {
-      expect(
-        StyleDictionary.extend.bind(null, {include: ['foo']})
-      ).toThrow("Cannot find module 'foo'");
+    it('should not update properties if sourche glob paths dont resolve to anything', () => {
+      var StyleDictionaryExtended = StyleDictionary.extend({
+        source: ['foo']
+      });
+      expect(typeof StyleDictionaryExtended.properties.size).toBe('undefined');
     });
 
     it('should build the properties object if a source is given', () => {

--- a/docs/config.md
+++ b/docs/config.md
@@ -34,8 +34,8 @@ By default, Style Dictionary looks for a `config.json` file in the root of your 
 
 | Attribute | Type | Description |
 | :--- | :--- | :--- |
-| includes | Array[String] (optional) | An array of paths to Style Dictionary property files that contain default styles. The Style Dictionary uses this as a base collection of properties. The properties found using the "source" attribute will overwrite properties found using includes. |
-| source | Array[String] | An array of paths to JSON files that contain style properties. The Style Dictionary will do a deep merge of all of the JSON files so you can separate your properties into multiple files. |
+| include | Array[String] (optional) | An array of path [globs](https://github.com/isaacs/node-glob) to Style Dictionary property files that contain default styles. The Style Dictionary uses this as a base collection of properties. The properties found using the "source" attribute will overwrite properties found using include. |
+| source | Array[String] | An array of path [globs](https://github.com/isaacs/node-glob) to JSON files that contain style properties. The Style Dictionary will do a deep merge of all of the JSON files so you can separate your properties into multiple files. |
 | platforms | Object | An object containing platform config objects that describe how the Style Dictionary should build for that platform. You can add any arbitrary attributes on this object that will get passed to formats and actions (more on these in a bit). This is useful for things like build paths, name prefixes, variable names, etc.  |
 | platform.transforms | Array[String] (optional) | An array of [transforms](transforms.md) to be performed on the style properties object. These will transform the properties in a non-destructive way so each platform can transform the properties. Transforms to apply sequentially to all properties. Can be a built-in one or you can create your own. |
 | platform.transformGroup | String (optional) | A string that maps to an array of transforms. This makes it easier to reference transforms by grouping them together. You must either define this or `transforms`. |

--- a/lib/extend.js
+++ b/lib/extend.js
@@ -103,9 +103,7 @@ function extend(opts) {
     if (!_.isArray(options.include))
       throw new Error('include must be an array');
 
-    _.forEach(options.include, function(file){
-      to_ret.properties = deepExtend([{}, to_ret.properties, require(file)]);
-    });
+    to_ret.properties = combineJSON(options.include, true);
 
     to_ret.include = null; // We don't want to carry over include references
   }


### PR DESCRIPTION
*Issue #, if available:* #215 

*Description of changes:* Changing the behavior of `include` attribute on the config to match the behavior of `source`. Now `include` accepts an array of path globs, instead of just file paths. This change should be a superset change, as normal file paths still function the same. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
