### PR TITLE
feat(transforms): Add UIColor transform for swift

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,7 +4,8 @@
   },
   "env": {
     "node": true,
-    "mocha": true
+    "mocha": true,
+    "jest": true
   },
   "globals": {
     "Buffer": true,

--- a/__tests__/common/transforms.test.js
+++ b/__tests__/common/transforms.test.js
@@ -277,6 +277,22 @@ describe('common', () => {
       });
     });
 
+    describe('color/UIColorSwift', () => {
+      it('should handle normal colors', () => {
+        var value = transforms["color/UIColorSwift"].transformer({
+          value: "#aaaaaa"
+        });
+        expect(value).toBe("UIColor(red: 0.67, green: 0.67, blue: 0.67, alpha:1)");
+      });
+
+      it('should handle colors with transparency', () => {
+        var value = transforms["color/UIColorSwift"].transformer({
+          value: "#aaaaaa99"
+        });
+        expect(value).toBe("UIColor(red: 0.67, green: 0.67, blue: 0.67, alpha:0.6)");
+      });
+    });
+
 
     describe('color/css', () => {
       it('should handle normal colors', () => {

--- a/docs/transforms.md
+++ b/docs/transforms.md
@@ -6,7 +6,6 @@ EDIT scripts/handlebars/templates/api.hbs OR JSDOC COMMENT INSTEAD!
 
 Transforms are functions that transform a property so that each platform can consume the property in different ways. A simple example is changing pixel values to point values for iOS and dp or sp for Android. Transforms are applied in a non-destructive way so each platform can transform the properties. Transforms are performed sequentially, so the order you use transforms matters. Transforms are used in your [configuration](config.md), and can be either [pre-defined transforms](transforms.md?id=pre-defined-transforms) supplied by Style Dictionary or [custom transforms](transforms.md?id=defining-custom-transforms).
 
-## Using Transforms
 You use transforms in your config file under platforms > [platform] > transforms
 
 ```json
@@ -22,7 +21,7 @@ You use transforms in your config file under platforms > [platform] > transforms
 
 A transform consists of 4 parts: type, name, matcher, and transformer. Transforms are run on all properties where the matcher returns true. *NOTE: if you don't provide a matcher function, it will match all properties.*
 
-## Transform Types
+### Transform Types
 There are 3 types of transforms: attribute, name, and value.
 
 **Attribute:** An attribute transform adds to the attributes object on a property. This is for including any meta-data about a property such as it's CTI or other information.
@@ -38,7 +37,7 @@ You can define custom transforms with the [`registerTransform`](api.md#registert
 
 [lib/common/transforms.js](https://github.com/amzn/style-dictionary/blob/master/lib/common/transforms.js)
 
-> All the pre-defined transforms included use the [CTI structure](properties.md?id=category-type-item) for the match properties. If you structure your style properties differently you will need to write [custom transforms](transforms.md?id=defining-custom-transforms) or make sure the property CTIs are on the attributes of your properties.
+> All the pre-defined transforms included use the [CTI structure](package_structure.md#properties) for the match properties. If you structure your style properties differently you will need to write [custom transforms](#custom-transforms) or make sure the property CTIs are on the attributes of your properties.
 
 ### attribute/cti 
 
@@ -248,6 +247,20 @@ Transforms the value into an UIColor class for iOS
 // Matches: prop.attributes.category === 'color'
 // Returns:
 [UIColor colorWithRed:0.00f green:0.59f blue:0.53f alpha:1.0f]
+```
+
+
+* * *
+
+### color/UIColorSwift 
+
+
+Transforms the value into an UIColor swift class for iOS
+
+```swift
+// Matches: prop.attributes.category === 'color'
+// Returns:
+UIColor(red: 0.67, green: 0.67, blue: 0.67, alpha:0.6)
 ```
 
 

--- a/lib/common/transforms.js
+++ b/lib/common/transforms.js
@@ -336,6 +336,29 @@ module.exports = {
     }
   },
 
+    /**
+   * Transforms the value into an UIColor swift class for iOS
+   *
+   * ```swift
+   * // Matches: prop.attributes.category === 'color'
+   * // Returns:
+   * UIColor(red: 0.67, green: 0.67, blue: 0.67, alpha:0.6)
+   * ```
+   *
+   * @memberof Transforms
+   */
+  'color/UIColorSwift': {
+    type: 'value',
+    matcher: isColor,
+    transformer: function (prop) {
+      const { r, g, b, a } = Color(prop.value).toRgb();
+      const rFixed = (r / 255.0).toFixed(2);
+      const gFixed = (g / 255.0).toFixed(2);
+      const bFixed = (b / 255.0).toFixed(2);
+      return `UIColor(red: ${rFixed}, green: ${gFixed}, blue: ${bFixed}, alpha:${a})`;
+    }
+  },
+
   /**
    * Transforms the value into a hex or rgb string depending on if it has transparency
    *


### PR DESCRIPTION
Added UIColor transform for swift based on apple's spec:
https://developer.apple.com/documentation/uikit/uicolor/1621925-init

re #161

Is this the correct branch to point it to?

~Note: @dbanksdesign Some weirdness happened when generating the docs... do you want me to take them out? I got extra files when generated and I had to unstage them. I also got a new package-lock.json.~
Just saw this: https://github.com/amzn/style-dictionary/pull/240

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
