### PR TITLE
feat(config): use config.js if config.json is not found; updated docs

### DIFF
--- a/bin/style-dictionary
+++ b/bin/style-dictionary
@@ -59,7 +59,20 @@ program.on('command:*', function () {
 
 function styleDictionaryBuild(options) {
   options = options || {};
-  var configPath = options.config ? options.config : './config.json';
+  var configPath = options.config;
+
+  if(!configPath) {
+    if(fs.existsSync('./config.json')) {
+      configPath = './config.json';
+    }
+    else if(fs.existsSync('./config.js')) {
+      configPath = './config.js';
+    }
+    else {
+      console.error('Build failed; unable to find config file.');
+      process.exit(1);
+    }
+  }
 
   // Create a style dictionary object with the config
   var styleDictionary = StyleDictionary.extend( configPath );

--- a/docs/config.md
+++ b/docs/config.md
@@ -2,7 +2,10 @@
 
 Style dictionaries are configuration driven. Your config file defines what executes and what to output when the style dictionary builds.
 
-By default, Style Dictionary looks for a `config.json` file in the root of your package. You can also specify a custom location when you use the [CLI](using_the_cli.md). If you want a custom build system using the [npm module](using_the_npm_module.md), you can specify a custom location for a configuration file or use a plain Javascript object.
+By default, Style Dictionary looks for a `config.json` file in the root of your package. If not found, it looks for a `config.js` file in the root of your package. You can also specify a custom location when you use the [CLI](using_the_cli.md). If you want a custom build system using the [npm module](using_the_npm_module.md), you can specify a custom location for a configuration file or use a plain Javascript object.
+
+## config.js
+You can find out more about creating configurations in JS in our documentation about using the [npm module](using_the_npm_module.md).
 
 ## config.json
  Here is a quick example:


### PR DESCRIPTION
feat(config): use config.js if config.json is not found; updating documentation

Added functionality to search / use 'config.js' in root if 'config.json' is not found in root.
Modified documentation to ensure clarity around using JS based config with the CLI.

fix: #238
docs: #238
replaces #247 to be based on master branch instead of develop

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
