### PR TITLE
feat: file path as cti path (example mechanism for discussion)

### DIFF
--- a/lib/extend.js
+++ b/lib/extend.js
@@ -103,7 +103,7 @@ function extend(opts) {
     if (!_.isArray(options.include))
       throw new Error('include must be an array');
 
-    to_ret.properties = combineJSON(options.include, true);
+    to_ret.properties = combineJSON(options.include, true, null, options.includeFilePathAsCTI);
 
     to_ret.include = null; // We don't want to carry over include references
   }
@@ -119,7 +119,7 @@ function extend(opts) {
         PROPERTY_VALUE_COLLISIONS,
         `Collision detected at: ${prop.path.join('.')}! Original value: ${prop.target[prop.key]}, New value: ${prop.copy[prop.key]}`
       );
-    });
+    }, options.sourceFilePathAsCTI);
 
     if(GroupMessages.count(PROPERTY_VALUE_COLLISIONS) > 0) {
       var collisions = GroupMessages.flush(PROPERTY_VALUE_COLLISIONS).join('\n');

--- a/lib/utils/combineJSON.js
+++ b/lib/utils/combineJSON.js
@@ -28,7 +28,7 @@ var glob = require('glob'),
  * @param {Function} collision - A function to be called when a name collision happens that isn't a normal deep merge of objects
  * @returns {Object}
  */
-function combineJSON(arr, deep, collision) {
+function combineJSON(arr, deep, collision, useFilePathAsCTI) {
   var i, files = [],
     to_ret = {};
 
@@ -46,6 +46,34 @@ function combineJSON(arr, deep, collision) {
     } catch (e) {
       e.message = 'Failed to load or parse JSON or JS Object: ' + e.message;
       throw e;
+    }
+
+    if(useFilePathAsCTI) {
+      let filePath = path.relative('./', files[i]);
+      let ctisetup = filePath.split('.');
+      if(ctisetup.length > 1) {
+        ctisetup.pop();
+      }
+      ctisetup = ctisetup.join('.').split('/');
+
+      // should this be included? This removes the initial "properties" folder if it is containing all the properties
+      if(ctisetup[0]==='properties') {
+        ctisetup.shift();
+      }
+
+      let newContent = {};
+      let contentPos = newContent;
+      ctisetup.forEach((pathPiece, index) => {
+        if(index < ctisetup.length-1) {
+          contentPos[pathPiece] = {};
+          contentPos = contentPos[pathPiece];
+        }
+        else {
+          contentPos[pathPiece] = file_content;
+        }
+      });
+
+      file_content = newContent;
     }
 
     if (deep) {


### PR DESCRIPTION
#104, part of #251

Added in options in config to use file path as CTI prefix.

This is meant to start discussion of value here.

The options to use in the config are 'sourceFilePathAsCTI' and 'includeFilePathAsCTI'.

Note that I did not attempt to solve the problem if you are using the current system, which would result in a duplication of information in the CTI as per @elliotdickison's comments. (e.g. A file in the path properties/fonts/size.json containing { fonts: { size: { small: value: '10px'; } } } using this option would result in fonts.size.fonts.size.small).

If we like this, I can add tests and add in functionality to detect and remove duplication. Also, let me know if I should remove that top level folder if it is called "properties", or what we should do to handle that.....