### PR TITLE
docs(example): adding component cti example

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -34,7 +34,7 @@ If you want to look at more advanced examples of possible applications and custo
 * [**npm-module**](https://github.com/amzn/style-dictionary/tree/master/examples/advanced/npm-module) shows how to set up a style dictionary as an npm module, either to publish to a local npm service or to publish externally.
 * [**s3**](https://github.com/amzn/style-dictionary/tree/master/examples/advanced/s3) shows how to set up a style dictionary to build files for different platforms (web, iOS, Android) and upload those build artifacts, together with a group of assets, to an S3 bucket.
 * [**referencing_aliasing**](https://github.com/amzn/style-dictionary/tree/master/examples/advanced/referencing_aliasing) shows how to use referencing (or "aliasing") to reference a value -or an attribute– of a property and assign it to the value –or attribute– of another property.
-
+* [**component-cti**](https://github.com/amzn/style-dictionary/tree/master/examples/advanced/component-cti) shows how to write component tokens and still use the CTI structure.
 
 ---
 

--- a/examples/advanced/component-cti/.gitignore
+++ b/examples/advanced/component-cti/.gitignore
@@ -1,0 +1,2 @@
+build/
+node_modules/

--- a/examples/advanced/component-cti/README.md
+++ b/examples/advanced/component-cti/README.md
@@ -1,6 +1,58 @@
 ## Component CTI Structure
 
-This example will show you one way to define component tokens in an easy way while still using the CTI attributes.
+This example will show you one way to define component tokens in an easy way while still using the CTI attributes for transforming the tokens. The CTI structure for Style Dictionary tokens makes defining component-level tokens really cumbersome and not user-friendly. This is because the CTI of tokens are based on the object path of the token. So if you wanted to write tokens for a button component it would have to look something like this:
+
+```json
+{
+  "size": {
+    "padding" : {
+      "button": { "value": "{size.padding.base.value}" }
+    },
+    "font": {
+      "button": { "value": 2 }
+    }
+  },
+
+  "color": {
+    "font": {
+      "button": {
+        "primary": { "value": "{color.font.inverse.value}" },
+        "secondary": { "value": "{color.font.link.value}" }
+      }
+    },
+
+    "background": {
+      "button": {
+        "primary": { "value": "hsl(10, 80, 50)" },
+        "secondary": { "value": "{color.background.primary.value}" }
+      }
+    }
+  }
+}
+```
+
+Instead, when defining component tokens it makes more sense to structure them more like CSS. `component.button.background-color` makes more sense than `color.background.button`. Here is what the component tokens would look like in this new structure:
+
+```json
+{
+  "component": {
+    "button": {
+      "padding": { "value": "{size.padding.medium.value}" },
+      "font-size": { "value": 2 },
+      
+      "primary": {
+        "background-color": { "value": "hsl(10, 80, 50)" },
+        "color": { "value": "{color.font.inverse.value}" }
+      },
+      
+      "secondary": {
+        "background-color": { "value": "{color.background.primary.value}" },
+        "color": { "value": "{color.font.link.value}" }
+      }
+    }
+  }
+}
+```
 
 ### Running the example
 
@@ -10,6 +62,8 @@ At this point, if you want to build the tokens run `npm run build`. This command
 
 
 ### How does it work
+
+All of the built-in transforms target tokens using the CTI attributes. The built-in [`attribute/cti`](https://amzn.github.io/style-dictionary/#/transforms?id=attributecti) transform adds the CTI attributes to each token based on the object path of the token. In this example we override the default behavior of the [`attribute/cti`](https://amzn.github.io/style-dictionary/#/transforms?id=attributecti) transform to apply CTI attributes based on token's key, or last part of the object path to generate the equivalent category and type. This way we can correctly map a token with an object path of `component.button.background-color` to a category of `color` and type of `background`. 
 
 Style Dictionary allows for extensibility through [monkey patching](https://en.wikipedia.org/wiki/Monkey_patch). This allows you to override default behavior of the Style Dictionary library, and any built-in transforms and formats. You can override built-in transforms and formats by adding ones with the same name. Also, all of the built-in transforms, transformGroups, and formats are available by accessing them in the Style Dictionary library under the attributes `transform`, `transformGroup`, and `format` respectively. For example:
 
@@ -25,12 +79,7 @@ const cti = StyleDictionary.transform['attribute/cti'];
 
 In this example we monkey patch the `attribute/cti` transform to look at the top-level namespace of the token and if it is 'component', instead of running the default `attribute/cti` transform, it instead looks at the last part of the object path to generate the equivalent category and type.
 
-For example, if the key of the token (the last part of the object path) is "background-color", the monkey patched `attribute/cti` transform will return a category of 'color' and type of 'background'. This example uses CSS property names, but you could also change it to use similar React/CSS-in-JS names like 'backgroundColor' instead of 'background-color'. 
-
-### Why do this?
-
-The CTI structure for Style Dictionary tokens makes defining component-level tokens really cumbersome and not user-friendly. Instead, when defining component tokens it makes more sense to structure them more like CSS. `component.button.background-color` makes more sense than `color.background.button`
-
+For example, if the key of the token (the last part of the object path) is "background-color", the monkey patched `attribute/cti` transform will return a category of 'color' and type of 'background'. This example uses CSS property names, but you could also change it to use similar React/CSS-in-JS names like 'backgroundColor' instead of 'background-color'.
 
 ### What to look at
 

--- a/examples/advanced/component-cti/README.md
+++ b/examples/advanced/component-cti/README.md
@@ -1,0 +1,40 @@
+## Component CTI Structure
+
+This example will show you one way to define component tokens in an easy way while still using the CTI attributes.
+
+### Running the example
+
+First of all, set up the required dependencies running the command `npm install` in your local CLI environment (if you prefer to use *yarn*, update the commands accordingly).
+
+At this point, if you want to build the tokens run `npm run build`. This command will generate the files in the `build` folder.
+
+
+### How does it work
+
+Style Dictionary allows for extensibility through [monkey patching](https://en.wikipedia.org/wiki/Monkey_patch). This allows you to override default behavior of the Style Dictionary library, and any built-in transforms and formats. You can override built-in transforms and formats by adding ones with the same name. Also, all of the built-in transforms, transformGroups, and formats are available by accessing them in the Style Dictionary library under the attributes `transform`, `transformGroup`, and `format` respectively. For example:
+
+```javascript
+const StyleDictionary = require('style-dictionary');
+
+const cti = StyleDictionary.transform['attribute/cti'];
+// {
+//   type: 'attribute',
+//   transformer: f () {}
+// }
+```
+
+In this example we monkey patch the `attribute/cti` transform to look at the top-level namespace of the token and if it is 'component', instead of running the default `attribute/cti` transform, it instead looks at the last part of the object path to generate the equivalent category and type.
+
+For example, if the key of the token (the last part of the object path) is "background-color", the monkey patched `attribute/cti` transform will return a category of 'color' and type of 'background'. This example uses CSS property names, but you could also change it to use similar React/CSS-in-JS names like 'backgroundColor' instead of 'background-color'. 
+
+### Why do this?
+
+The CTI structure for Style Dictionary tokens makes defining component-level tokens really cumbersome and not user-friendly. Instead, when defining component tokens it makes more sense to structure them more like CSS. `component.button.background-color` makes more sense than `color.background.button`
+
+
+### What to look at
+
+* `config.js`:
+  * `propertiesToCTI`: A plain object where we map the CSS property name to the proper category and type.
+  * `CTITransform`: A transform object that defines a transformer method, which will override the default `attribute/cti` transform. This is similar to creating a child class with some custom logic and then calling `super`. In the transformer function it first looks at the top-level namespace, the first item in the object path, and if it is 'component' we run our custom logic using the `propertiesToCTI` map. If it is not 'component', use the built-in `attribute/cti`.
+* `tokens/component/button.json`: Take a look at how it defines the component tokens and uses the last part of the object path as the CSS property. Notice how we can define token values in here that are not references, but they still get transformed properly: font-size uses 'rem' and background-color uses hex in the output.

--- a/examples/advanced/component-cti/config.js
+++ b/examples/advanced/component-cti/config.js
@@ -1,0 +1,60 @@
+const StyleDictionary = require('style-dictionary');
+
+const propertiesToCTI = {
+  'width': {category: 'size', type: 'dimension'},
+  'min-width': {category: 'size', type: 'dimension'},
+  'max-width': {category: 'size', type: 'dimension'},
+  'height': {category: 'size', type: 'dimension'},
+  'min-height': {category: 'size', type: 'dimension'},
+  'max-height': {category: 'size', type: 'dimension'},
+  'border-width': {category: 'size', type: 'border', item: 'width'},
+  'border-radius': { category: 'size', type: 'border', item: 'width' },
+  'border-color': {category: 'color', type: 'border'},
+  'background-color': {category: 'color', type: 'background'},
+  'color': {category: 'color', type: 'font'},
+  'text-color': { category: 'color', type: 'font' },
+  'padding': {category: 'size', type: 'padding'},
+  'padding-vertical': {category: 'size', type: 'padding'},
+  'padding-horziontal': {category: 'size', type: 'padding'},
+  'icon': {category: 'content', type: 'icon'},
+  'font-size': {category: 'size', type: 'font'},
+  'line-height': { category: 'size', type: 'line-height' },
+  'size': {category: 'size', type: 'icon'}
+}
+
+const CTITransform = {
+  transformer: (prop) => {
+    // Only do this custom functionality in the 'component' top-level namespace.
+    if (prop.path[0] === 'component') {
+      // When defining component tokens, the key of the token is the relevant CSS property
+      // The key of the token is the last element in the path array
+      return propertiesToCTI[prop.path[prop.path.length - 1]];
+    } else {
+      // Fallback to the original 'attribute/cti' transformer
+      return StyleDictionary.transform['attribute/cti'].transformer(prop);
+    }
+  }
+}
+
+module.exports = {
+  // Rather than calling .registerTransform() we can apply the new transform
+  // directly in our configuration. Using .registerTransform() with the same
+  // transform name, 'attribute/cti', would work as well. 
+  transform: {
+    // Override the attribute/cti transform
+    'attribute/cti': CTITransform
+  },
+  source: ['tokens/**/*.json'],
+  platforms: {
+    scss: {
+      // We can still use this transformGroup because we are overriding
+      // the underlying transform
+      transformGroup: "scss",
+      buildPath: 'build/',
+      files: [{
+        destination: 'variables.scss',
+        format: 'scss/variables'
+      }]
+    }
+  }
+}

--- a/examples/advanced/component-cti/package-lock.json
+++ b/examples/advanced/component-cti/package-lock.json
@@ -1,0 +1,248 @@
+{
+  "name": "style-dictionary-tokens-deprecation",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^1.9.0"
+      }
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      }
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "commander": {
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "fs-extra": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-6.0.1.tgz",
+      "integrity": "sha512-GnyIkKhhzXZUWFCaJzvyDLEEgDkPfb4/TPvJCJVuS8MWZgoSsErf++QpiAlDnKFcqhRlm+tIOcencCjyJE6ZCA==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+      "dev": true
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "json5": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
+      "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.0"
+      }
+    },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "lodash": {
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "dev": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "resolve-cwd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
+      "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
+      "dev": true,
+      "requires": {
+        "resolve-from": "^3.0.0"
+      }
+    },
+    "resolve-from": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+      "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
+      "dev": true
+    },
+    "style-dictionary": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/style-dictionary/-/style-dictionary-2.7.0.tgz",
+      "integrity": "sha512-DRyiFQXy8Ue3EXpCdTBBb0MCoNtfaJWf+EWKq/H0ivhgA+v1MwQXER4GRkAorJapBbuqBe7yTpPRK5Ofn7vGAQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.1",
+        "commander": "^2.9.0",
+        "fs-extra": "^6.0.1",
+        "glob": "^7.1.1",
+        "json5": "^2.1.0",
+        "lodash": "^4.16.4",
+        "resolve-cwd": "^2.0.0",
+        "tinycolor2": "^1.4.1"
+      }
+    },
+    "supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
+    },
+    "tinycolor2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.1.tgz",
+      "integrity": "sha1-9PrTM0R7wLB9TcjpIJ2POaisd+g=",
+      "dev": true
+    },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    }
+  }
+}

--- a/examples/advanced/component-cti/package.json
+++ b/examples/advanced/component-cti/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "style-dictionary-tokens-deprecation",
+  "version": "1.0.0",
+  "description": "",
+  "main": "build/index.js",
+  "files": [
+    "build",
+    "properties"
+  ],
+  "scripts": {
+    "build": "style-dictionary build --config ./config.js",
+    "clean": "rm -rf build",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "Apache-2.0",
+  "devDependencies": {
+    "style-dictionary": "2.7.0"
+  }
+}

--- a/examples/advanced/component-cti/package.json
+++ b/examples/advanced/component-cti/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "style-dictionary-tokens-deprecation",
+  "name": "style-dictionary-component-cti",
   "version": "1.0.0",
   "description": "",
   "main": "build/index.js",

--- a/examples/advanced/component-cti/tokens/color/background.json
+++ b/examples/advanced/component-cti/tokens/color/background.json
@@ -1,0 +1,9 @@
+{
+  "color": {
+    "background": {
+      "primary": { "value": "#ffffff" },
+      "link": { "value": "#0366d6" },
+      "inverse": { "value": "#111111" }
+    }
+  }
+}

--- a/examples/advanced/component-cti/tokens/color/core.json
+++ b/examples/advanced/component-cti/tokens/color/core.json
@@ -1,0 +1,10 @@
+{
+  "color": {
+    "core": {
+      "white": { "value": "#ffffff" },
+      "black": { "value": "#111111" },
+      "gray": { "value": "#dddddd" },
+      "blue": { "value": "#0366d6" }
+    }
+  }
+}

--- a/examples/advanced/component-cti/tokens/color/font.json
+++ b/examples/advanced/component-cti/tokens/color/font.json
@@ -1,0 +1,9 @@
+{
+  "color": {
+    "font": {
+      "primary": { "value": "{color.core.black.value}" },
+      "link": { "value": "{color.core.blue.value}" },
+      "inverse": { "value": "{color.core.white.value}" }
+    }
+  }
+}

--- a/examples/advanced/component-cti/tokens/component/button.json
+++ b/examples/advanced/component-cti/tokens/component/button.json
@@ -1,0 +1,19 @@
+{
+  "component": {
+    "button": {
+      "padding": { "value": "{size.padding.medium.value}" },
+      "font-size": { "value": 2 },
+      "text-align": { "value": "center" },
+      
+      "primary": {
+        "background-color": { "value": "hsl(10, 80, 50)" },
+        "color": { "value": "{color.font.inverse.value}" }
+      },
+      
+      "secondary": {
+        "background-color": { "value": "{color.background.primary.value}" },
+        "color": { "value": "{color.font.link.value}" }
+      }
+    }
+  }
+}

--- a/examples/advanced/component-cti/tokens/size/font.json
+++ b/examples/advanced/component-cti/tokens/size/font.json
@@ -1,0 +1,9 @@
+{
+  "size": {
+    "font": {
+      "small": { "value": 0.75 },
+      "medium": { "value": 1 },
+      "large": { "value": 1.5 }
+    }
+  }
+}

--- a/examples/advanced/component-cti/tokens/size/padding.json
+++ b/examples/advanced/component-cti/tokens/size/padding.json
@@ -1,0 +1,9 @@
+{
+  "size": {
+    "padding": {
+      "small": { "value": 0.5 },
+      "medium": { "value": 1 },
+      "large": { "value": 2 }
+    }
+  }
+}


### PR DESCRIPTION
*Issue #, if available:* #246

*Description of changes:* Adding component CTI example which shows how to monkey patch built-in transforms and formats as well as showing one way to organize component tokens. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
