### PR TITLE
fix(extend): multiple extensions properly deep merge

### DIFF
--- a/__tests__/extend.test.js
+++ b/__tests__/extend.test.js
@@ -171,4 +171,22 @@ describe('extend', () => {
     var StyleDictionaryExtended = StyleDictionary.extend(__dirname + '/__configs/test.json5');
     expect(StyleDictionaryExtended).toHaveProperty('platforms.web');
   });
+  
+  it('should allow for chained extends and not mutate the original', function() {
+    var StyleDictionary1 = StyleDictionary.extend({
+      foo: 'bar'
+    });
+    var StyleDictionary2 = StyleDictionary1.extend({
+      foo: 'baz'
+    });
+    var StyleDictionary3 = StyleDictionary.extend({
+      foo: 'bar'
+    }).extend({
+      foo: 'boo'
+    });
+    expect(StyleDictionary1.foo).toBe('bar');
+    expect(StyleDictionary2.foo).toBe('baz');
+    expect(StyleDictionary3.foo).toBe('boo');
+    expect(StyleDictionary).not.toHaveProperty('foo');
+  });
 });

--- a/lib/extend.js
+++ b/lib/extend.js
@@ -96,7 +96,7 @@ function extend(opts) {
 
   // Creating a new object and copying over the options
   // Also keeping an options object just in case
-  to_ret = deepExtend([{options: options}, this, options]);
+  to_ret = deepExtend([{}, this, {options: options}, options]);
 
   // Update properties with includes from dependencies
   if (options.include) {


### PR DESCRIPTION
*Issue #, if available:* #274

*Description of changes:* Fixing `.extend` method to allow for chained extensions. Right now if you try to extend multiple times it won't properly override attributes. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
