### PR TITLE
refactor: remove unused checks

### DIFF
--- a/lib/buildFile.js
+++ b/lib/buildFile.js
@@ -29,9 +29,9 @@ var path = require('path'),
  * @returns {null}
  */
 function buildFile(destination, format, platform, dictionary, filter) {
-  if (!format || typeof format !== 'function')
+  if (typeof format !== 'function')
     throw new Error('Please enter a valid file format');
-  if (!destination || typeof destination !== 'string')
+  if (typeof destination !== 'string')
     throw new Error('Please enter a valid destination');
 
   var fullDestination = destination;

--- a/lib/cleanDir.js
+++ b/lib/cleanDir.js
@@ -29,7 +29,7 @@ var path  = require('path'),
  */
 function cleanDir(destination, format, platform, dictionary, filter) {
 
-  if (!destination || typeof destination !== 'string')
+  if (typeof destination !== 'string')
     throw new Error('Please enter a valid destination');
 
   // if there is a clean path, prepend the destination with it

--- a/lib/cleanFile.js
+++ b/lib/cleanFile.js
@@ -29,7 +29,7 @@ var path  = require('path'),
  */
 function cleanFile(destination, format, platform, dictionary, filter) {
 
-  if (!destination || typeof destination !== 'string')
+  if (typeof destination !== 'string')
     throw new Error('Please enter a valid destination');
 
   // if there is a clean path, prepend the destination with it

--- a/lib/utils/convertToBase64.js
+++ b/lib/utils/convertToBase64.js
@@ -20,7 +20,7 @@ var fs = require('fs');
  * @returns {String}
  */
 function convertToBase64(filePath) {
-  if (!filePath || typeof filePath !== 'string')
+  if (typeof filePath !== 'string')
     throw new Error('filePath name must be a string');
 
   var body = fs.readFileSync(filePath, 'binary');


### PR DESCRIPTION
*Description of changes:*
Replaces

    if (!format || typeof format !== 'function')

into 

    if (typeof format !== 'function')

because 

     typeof null !== 'object' and typeof undefined === 'undefined'

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
