### PR TITLE
fix(formats): change scss comments to short version

### DIFF
--- a/__tests__/formats/__snapshots__/all.test.js.snap
+++ b/__tests__/formats/__snapshots__/all.test.js.snap
@@ -532,21 +532,19 @@ exports[`formats all should match json/nested snapshot 1`] = `
 `;
 
 exports[`formats all should match less/icons snapshot 1`] = `
-"/**
- * Do not edit directly
- * Generated on Sat, 01 Jan 2000 00:00:00 GMT
- */
+"
+// Do not edit directly
+// Generated on Sat, 01 Jan 2000 00:00:00 GMT
 
 "
 `;
 
 exports[`formats all should match less/variables snapshot 1`] = `
-"/**
- * Do not edit directly
- * Generated on Sat, 01 Jan 2000 00:00:00 GMT
- */
+"
+// Do not edit directly
+// Generated on Sat, 01 Jan 2000 00:00:00 GMT
 
-@color_red: #FF0000; /* comment */"
+@color_red: #FF0000; // comment"
 `;
 
 exports[`formats all should match sass/map-deep snapshot 1`] = `
@@ -581,10 +579,9 @@ $tokens: (
 `;
 
 exports[`formats all should match scss/icons snapshot 1`] = `
-"/**
- * Do not edit directly
- * Generated on Sat, 01 Jan 2000 00:00:00 GMT
- */
+"
+// Do not edit directly
+// Generated on Sat, 01 Jan 2000 00:00:00 GMT
 
 "
 `;

--- a/__tests__/formats/__snapshots__/all.test.js.snap
+++ b/__tests__/formats/__snapshots__/all.test.js.snap
@@ -621,12 +621,11 @@ $tokens: (
 `;
 
 exports[`formats all should match scss/variables snapshot 1`] = `
-"/**
- * Do not edit directly
- * Generated on Sat, 01 Jan 2000 00:00:00 GMT
- */
+"
+// Do not edit directly
+// Generated on Sat, 01 Jan 2000 00:00:00 GMT
 
-$color_red: #FF0000; /* comment */"
+$color_red: #FF0000; // comment"
 `;
 
 exports[`formats all should match sketch/palette snapshot 1`] = `

--- a/lib/common/formats.js
+++ b/lib/common/formats.js
@@ -201,7 +201,7 @@ module.exports = {
    * ```
    */
   'scss/icons': function(dictionary, config) {
-    return fileHeader(this.options) + iconsWithPrefix('$', dictionary.allProperties, config);
+    return fileHeader(this.options, 'short') + iconsWithPrefix('$', dictionary.allProperties, config, 'short');
   },
 
   /**
@@ -216,7 +216,7 @@ module.exports = {
    * ```
    */
   'less/variables': function(dictionary) {
-    return fileHeader(this.options) + variablesWithPrefix('@', dictionary.allProperties);
+    return fileHeader(this.options, 'short') + variablesWithPrefix('@', dictionary.allProperties, 'short');
   },
 
   /**
@@ -231,7 +231,7 @@ module.exports = {
    * ```
    */
   'less/icons': function(dictionary, config) {
-    return fileHeader(this.options) + iconsWithPrefix('@', dictionary.allProperties, config);
+    return fileHeader(this.options, 'short') + iconsWithPrefix('@', dictionary.allProperties, config, 'short');
   },
 
   /**

--- a/lib/common/formats.js
+++ b/lib/common/formats.js
@@ -17,26 +17,39 @@ var fs = require('fs'),
 
 var SASS_MAP_FORMAT_DEPRECATION_WARNINGS = GroupMessages.GROUP.SassMapFormatDeprecationWarnings;
 
-function fileHeader(options) {
+function fileHeader(options, commentStyle) {
   var to_ret = '';
   // for backward compatibility we need to have the user explicitly hide them
   var showFileHeader = (options) ? options.showFileHeader : true;
   if (showFileHeader) {
-    to_ret += '/**\n';
-    to_ret += ' * Do not edit directly\n';
-    to_ret += ' * Generated on ' + new Date().toUTCString() + '\n';
-    to_ret += ' */\n\n';
+    if (commentStyle === 'short') {
+      to_ret += '\n';
+      to_ret += '// Do not edit directly\n';
+      to_ret += '// Generated on ' + new Date().toUTCString() + '\n';
+      to_ret += '\n';
+    } else {
+      to_ret += '/**\n';
+      to_ret += ' * Do not edit directly\n';
+      to_ret += ' * Generated on ' + new Date().toUTCString() + '\n';
+      to_ret += ' */\n\n';
+    }
   }
 
   return to_ret;
 }
 
-function variablesWithPrefix(prefix, properties) {
+function variablesWithPrefix(prefix, properties, commentStyle) {
   return _.map(properties, function(prop) {
       var to_ret_prop = prefix + prop.name + ': ' + (prop.attributes.category==='asset' ? '"'+prop.value+'"' : prop.value) + ';';
 
-      if (prop.comment)
-        to_ret_prop = to_ret_prop.concat(' /* ' + prop.comment + ' */');
+      if (prop.comment) {
+        if (commentStyle === 'short') {
+          to_ret_prop = to_ret_prop.concat(' // ' + prop.comment);
+        } else {
+          to_ret_prop = to_ret_prop.concat(' /* ' + prop.comment + ' */');
+        }
+      }
+        
       return to_ret_prop;
     })
     .filter(function(strVal) { return !!strVal })
@@ -173,7 +186,7 @@ module.exports = {
    * ```
    */
   'scss/variables': function(dictionary) {
-    return fileHeader(this.options) + variablesWithPrefix('$', dictionary.allProperties);
+    return fileHeader(this.options, 'short') + variablesWithPrefix('$', dictionary.allProperties, 'short');
   },
 
   /**


### PR DESCRIPTION
*Issue #, if available:* #305 

*Description of changes:* Change scss variables format to use shorthand comments `//` rather than block comments so they don't pollute the compiled CSS. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
