### PR TITLE
Added public access level to Swift class and enum properties

### DIFF
--- a/lib/common/templates/ios-swift/class.swift.template
+++ b/lib/common/templates/ios-swift/class.swift.template
@@ -35,5 +35,5 @@
 import UIKit
 
 public class <%= this.className %> {
-    <%= _.map(props, function(prop) { return 'static let ' + prop.name + ' = ' + prop.value; }).join('\n    ') %>
+    <%= _.map(props, function(prop) { return 'public static let ' + prop.name + ' = ' + prop.value; }).join('\n    ') %>
 }

--- a/lib/common/templates/ios-swift/enum.swift.template
+++ b/lib/common/templates/ios-swift/enum.swift.template
@@ -34,5 +34,5 @@
 import UIKit
 
 public enum <%= this.className %> {
-    <%= _.map(props, function(prop) { return 'static let ' + prop.name + ' = ' + prop.value; }).join('\n    ') %>
+    <%= _.map(props, function(prop) { return 'public static let ' + prop.name + ' = ' + prop.value; }).join('\n    ') %>
 }


### PR DESCRIPTION
*Issue #, if available:*
#295 

*Description of changes:*
Added public access level to Swift class and enum properties. Without explicitly declaring each property as public, apps cannot access these properties when consuming design tokens as a Cocoapod (or any other dependency management solution), rendering them useless.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
