### PR TITLE
fix(utils): handle 0 as a reference value

### DIFF
--- a/__tests__/utils/resolveObject.test.js
+++ b/__tests__/utils/resolveObject.test.js
@@ -294,5 +294,15 @@ describe('utils', () => {
       ]));
     });
 
+    it('should handle 0', () => {
+      GroupMessages.clear(PROPERTY_REFERENCE_WARNINGS);
+      var test = resolveObject({
+        "test": { "value": "{zero.value}" },
+        "zero": { "value": 0}
+      });
+      expect(GroupMessages.fetchMessages(PROPERTY_REFERENCE_WARNINGS).length).toBe(0);
+      expect(test.test.value).toBe(0);
+    });
+
   });
 });

--- a/lib/utils/resolveObject.js
+++ b/lib/utils/resolveObject.js
@@ -88,7 +88,7 @@ function compile_value(value, stack) {
     // Find what the value is referencing
     ref = selfRef(variable.trim(), updated_object);
 
-    if (ref) {
+    if (typeof ref !== 'undefined') {
       if (typeof ref === 'string') {
         to_ret = value.replace(match, ref);
 
@@ -150,24 +150,24 @@ function selfRef(str, obj) {
       context = current_context.join(options.separator);
 
   for (i = 0; i < array.length; i++) {
-    if (ref[array[i]]) {
+    // Check for undefined as 0 is a valid, truthy value
+    if (typeof ref[array[i]] !== 'undefined') {
       ref = ref[array[i]];
     } else {
-      ref = obj;
+      // set the reference as undefined if we don't find anything
+      ref = undefined;
       break;
     }
   }
 
-  // If the reference doesn't change then it means
-  // we didn't find it in the object
-  if (ref === obj) {
+  if (typeof ref === 'undefined') {
     GroupMessages.add(
       PROPERTY_REFERENCE_WARNINGS,
       "Reference doesn't exist: " + context + " tries to reference " + str + ", which is not defined"
     );
+  } else {
+    return ref;
   }
-
-  return ref;
 }
 
 


### PR DESCRIPTION
*Issue #, if available:* #324

*Description of changes:* Adding proper checking for alias/reference resolution so that `0` is a valid value. Now we check for undefined rather than "truthiness", because 0 is "false". 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
