### PR TITLE
ci: add support for node v10 & v12, remove v6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
 node_js:
   - "8"
-  - "6"
+  - "10"
+  - "12"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "style-dictionary": "./bin/style-dictionary"
   },
   "engines": {
-    "node": ">=6.0.0"
+    "node": ">=8.0.0"
   },
   "files": [
     "bin",


### PR DESCRIPTION
*Issue #, if available:*
302

*Description of changes:*
Removed support for node v6. Added node v10 & v12

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
