### PR TITLE
Use "format" instead of deprecated "template"

### DIFF
--- a/examples/complete/config.json
+++ b/examples/complete/config.json
@@ -83,7 +83,7 @@
       "buildPath": "android/styledictionary/src/main/res/values/",
       "files": [{
         "destination": "style_dictionary_colors.xml",
-        "template": "android/colors"
+        "format": "android/colors"
       },{
         "destination": "style_dictionary_font_dimens.xml",
         "format": "android/fontDimens"


### PR DESCRIPTION
Description of changes:
Use "format" instead of the deprecated "template" property name.
As starter pack should be nice to not throw any deprecation warnings for the first build.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
