### PR TITLE
Issue #348 - Fix comment phrasing in docs/api.md line 279

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -276,7 +276,7 @@ Transforms can manipulate a property's name, value, or attributes
 | transform.type | <code>String</code> | Type of transform, can be: name, attribute, or value |
 | transform.name | <code>String</code> | Name of the transformer (used by transformGroup to call a list of transforms). |
 | [transform.matcher] | <code>function</code> | Matcher function, return boolean if transform should be applied. If you omit the matcher function, it will match all properties. |
-| transform.transformer | <code>function</code> | Performs a transform on a property object, should return a string or object depending on the type. Will only update certain properties by which you can't mess up property objects on accident. |
+| transform.transformer | <code>function</code> | Performs a transform on a property object, should return a string or object depending on the type. Will only update certain properties to avoid accidentally messing up property objects. |
 
 **Example**  
 ```js


### PR DESCRIPTION
Issue #348

Change text from "Will only update certain properties by which you can't
mess up property objects on accident" to "Will only update certain
properties to avoid accidentally messing up property objects"



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
