### PR TITLE
Fix scss/map-flat example into documentation

### DIFF
--- a/docs/formats.md
+++ b/docs/formats.md
@@ -163,8 +163,8 @@ Name the map by adding a 'mapName' attribute on the file object in your config.
 **Example**  
 ```scss
 $tokens: (
-  $color-background-base: #f0f0f0;
-  $color-background-alt: #eeeeee;
+  'color-background-base': #f0f0f0;
+  'color-background-alt': #eeeeee;
 )
 ```
 

--- a/lib/common/formats.js
+++ b/lib/common/formats.js
@@ -118,8 +118,8 @@ module.exports = {
    * @example
    * ```scss
    * $tokens: (
-   *   $color-background-base: #f0f0f0;
-   *   $color-background-alt: #eeeeee;
+   *   'color-background-base': #f0f0f0;
+   *   'color-background-alt': #eeeeee;
    * )
    * ```
    */


### PR DESCRIPTION
Hi,

I think there is a mistake in the `scss/map-flat` example into documentation.
The current example is:
```
$tokens: (
  $color-background-base: #f0f0f0;
  $color-background-alt: #eeeeee;
)
```
whereas it should be:
```
$tokens: (
  'color-background-base': #f0f0f0;
  'color-background-alt': #eeeeee;
)
```

This is not a huge contribution but it's an important fix :grimacing: