### PR TITLE
feat: add support for !default in SCSS variables format

### DIFF
--- a/__tests__/formats/scssVariables.test.js
+++ b/__tests__/formats/scssVariables.test.js
@@ -63,7 +63,7 @@ describe('formats', () => {
       });
     });
 
-    it('should optionally use !default', done => {
+    it('should optionally use !default', () => {
       var themeableDictionary = _.cloneDeep(dictionary),
         formattedScss = formatter(dictionary),
         themeableScss = "";
@@ -74,7 +74,6 @@ describe('formats', () => {
       themeableScss = formatter(themeableDictionary);
 
       expect(themeableScss).toMatch("#EF5350 !default;");
-      return done();
     });
   });
 });

--- a/__tests__/formats/scssVariables.test.js
+++ b/__tests__/formats/scssVariables.test.js
@@ -13,6 +13,7 @@
 
 var formats = require('../../lib/common/formats');
 var scss = require('node-sass');
+var _ = require('lodash');
 
 var file = {
   "destination": "__output/",
@@ -62,5 +63,18 @@ describe('formats', () => {
       });
     });
 
+    it('should optionally use !default', done => {
+      var themeableDictionary = _.cloneDeep(dictionary),
+        formattedScss = formatter(dictionary),
+        themeableScss = "";
+
+      expect(formattedScss).not.toMatch("!default");
+
+      themeableDictionary.allProperties[0].themeable = true;
+      themeableScss = formatter(themeableDictionary);
+
+      expect(themeableScss).toMatch("#EF5350 !default;");
+      return done();
+    });
   });
 });

--- a/lib/common/formats.js
+++ b/lib/common/formats.js
@@ -40,7 +40,14 @@ function fileHeader(options, commentStyle) {
 
 function variablesWithPrefix(prefix, properties, commentStyle) {
   return properties.map(function(prop) {
-      var to_ret_prop = prefix + prop.name + ': ' + (prop.attributes.category==='asset' ? '"'+prop.value+'"' : prop.value) + ';';
+      var to_ret_prop = prefix + prop.name + ': ';
+      to_ret_prop += (prop.attributes.category==='asset' ? '"'+prop.value+'"' : prop.value);
+
+      if (prop.themeable === true) {
+        to_ret_prop += ' !default';
+      }
+
+      to_ret_prop += ';';
 
       if (prop.comment) {
         if (commentStyle === 'short') {
@@ -175,14 +182,16 @@ module.exports = {
   },
 
   /**
-   * Creates a SCSS file with variable definitions based on the style dictionary
+   * Creates a SCSS file with variable definitions based on the style dictionary.
+   *
+   * Add `!default` to any variable by setting a `themeable: true` property in the token's definition.
    *
    * @memberof Formats
    * @kind member
    * @example
    * ```scss
    * $color-background-base: #f0f0f0;
-   * $color-background-alt: #eeeeee;
+   * $color-background-alt: #eeeeee !default;
    * ```
    */
   'scss/variables': function(dictionary) {

--- a/lib/common/formats.js
+++ b/lib/common/formats.js
@@ -38,12 +38,28 @@ function fileHeader(options, commentStyle) {
   return to_ret;
 }
 
-function variablesWithPrefix(prefix, properties, commentStyle) {
+function formattedVariables(format, properties) {
+  var prefix, commentStyle;
+
+  switch(format) {
+    case 'css':
+      prefix = '  --';
+      break;
+    case 'sass':
+      prefix = '$';
+      commentStyle = 'short';
+      break;
+    case 'less':
+      prefix = '@';
+      commentStyle = 'short';
+      break;
+  }
+
   return properties.map(function(prop) {
       var to_ret_prop = prefix + prop.name + ': ';
       to_ret_prop += (prop.attributes.category==='asset' ? '"'+prop.value+'"' : prop.value);
 
-      if (prop.themeable === true) {
+      if (format == 'sass' && prop.themeable === true) {
         to_ret_prop += ' !default';
       }
 
@@ -111,7 +127,7 @@ module.exports = {
   'css/variables': function(dictionary) {
     return fileHeader(this.options) +
       ':root {\n' +
-      variablesWithPrefix('  --', dictionary.allProperties) +
+      formattedVariables('css', dictionary.allProperties) +
       '\n}\n';
   },
 
@@ -195,7 +211,7 @@ module.exports = {
    * ```
    */
   'scss/variables': function(dictionary) {
-    return fileHeader(this.options, 'short') + variablesWithPrefix('$', dictionary.allProperties, 'short');
+    return fileHeader(this.options, 'short') + formattedVariables('sass', dictionary.allProperties);
   },
 
   /**
@@ -225,7 +241,7 @@ module.exports = {
    * ```
    */
   'less/variables': function(dictionary) {
-    return fileHeader(this.options, 'short') + variablesWithPrefix('@', dictionary.allProperties, 'short');
+    return fileHeader(this.options, 'short') + formattedVariables('less', dictionary.allProperties);
   },
 
   /**


### PR DESCRIPTION
*Issue #, if available:* #307

*Description of changes:*
This addresses the feature request made in #307 in one way. For my use case I'd like to make some variables "themeable" with `!default` but not all. For example, base colors should be immutable but the default text color could be configurable by the consumer of the design tokens.

I chose the key "themeable" because of seeing that language in the design systems community (for example with [the Lightning Design System](https://lightningdesignsystem.com/design-tokens/) or from [Brad Frost](https://bradfrost.com/blog/post/creating-themeable-design-systems/)). And that way other formats could implement their own version of what theme-ability is.

This doesn't address setting `!default` on all variables through the configuration, but it should be easy enough to add that to what I've implemented.

Thanks in advance for considering this PR!

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
