### PR TITLE
Update multi-brand-multi-platform to use format

### DIFF
--- a/examples/advanced/multi-brand-multi-platform/build.js
+++ b/examples/advanced/multi-brand-multi-platform/build.js
@@ -23,13 +23,13 @@ function getStyleDictionaryConfig(brand, platform) {
         "buildPath": `build/android/${brand}/`,
         "files": [{
           "destination": "tokens.colors.xml",
-          "template": "android/colors"
+          "format": "android/colors"
         },{
           "destination": "tokens.dimens.xml",
-          "template": "android/dimens"
+          "format": "android/dimens"
         },{
           "destination": "tokens.font_dimens.xml",
-          "template": "android/fontDimens"
+          "format": "android/fontDimens"
         }]
       },
       "ios": {
@@ -37,7 +37,7 @@ function getStyleDictionaryConfig(brand, platform) {
         "buildPath": `build/ios/${brand}/`,
         "files": [{
           "destination": "tokens.h",
-          "template": "ios/macros"
+          "format": "ios/macros"
         }]
       }
     }


### PR DESCRIPTION
*Description of changes:* Running `npm run build` for the multi-brand-multi-platform example would yield the following deprecation warning:

```
⚠️ DEPRECATION WARNING ️️️️️⚠️
Templates are deprecated and will be removed, please update your config to use formats.
This is an example of how to update your config.json:
...
```

Changing `template` to `format` fixes this.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
