### PR TITLE
Make transitive transforms & resolves possible

### DIFF
--- a/__tests__/__properties/colors.json
+++ b/__tests__/__properties/colors.json
@@ -85,6 +85,16 @@
 
     "font": {
       "link": { "value": "{color.base.blue.100.value}" }
+    },
+
+    "button": {
+      "base": { "value": "{color.base.blue.100.value}" },
+      "active": { "value": "{color.button.base.value}", "transformColor": {
+        "darken": 0.5
+      } },
+      "hover": { "value": "{color.button.active.value}", "transformColor": {
+        "darken": 0.2
+      } }
     }
   }
 }

--- a/__tests__/exportPlatform.test.js
+++ b/__tests__/exportPlatform.test.js
@@ -62,6 +62,28 @@ describe('exportPlatform', () => {
     expect(dictionary.size.padding.base.value.indexOf('px')).toBeGreaterThan(0);
   });
 
+  it('should have applied transforms for props with refs in it', () => {
+    const StyleDictionaryExtended = StyleDictionary.extend({
+      platforms: {
+        test: {
+          transforms: ['color/css','color/darken']
+        }
+      }
+    });
+
+    StyleDictionaryExtended.registerTransform({
+      type: 'value',
+      name: 'color/darken',
+      matcher: function(prop) { return !!prop.original.transformColor; },
+      transformer: function(prop) { return prop.value + '-darker'; }
+    });
+
+    const dictionary = StyleDictionaryExtended.exportPlatform('test');
+
+    expect(dictionary.color.button.active.value).toEqual('#0077CC-darker');
+    expect(dictionary.color.button.hover.value).toEqual('#0077CC-darker-darker');
+  });
+
   it('should not have mutated the original properties', () => {
     var dictionary = StyleDictionary.exportPlatform('web');
     expect(dictionary.color.font.link.value).not.toEqual(StyleDictionary.properties.color.font.link.value);

--- a/__tests__/transform/object.test.js
+++ b/__tests__/transform/object.test.js
@@ -33,6 +33,14 @@ const options = {
       transformer: function() {
         return "transformer result";
       }
+    }, {
+      type: 'value',
+      matcher: function(prop) {
+        return prop.path[0] === 'spacing';
+      },
+      transformer: function(val) {
+        return val + 'px';
+      }
     }
   ]
 };
@@ -85,7 +93,31 @@ describe('transform', () => {
 
       const actual = transformObject(objectToTransform, options);
       expect(actual).toEqual(expected);
-    })
+    });
 
+    it('fills the transformationContext with transformed and deferred transforms', () => {
+      const transformedPropRefs = [];
+      const deferredPropValueTransforms = [];
+      const transformationContext = {
+        transformedPropRefs,
+        deferredPropValueTransforms
+      };
+
+      const objectToTransform = {
+        "spacing": {
+          "base": {
+            "value": "16"
+          },
+          "medium": {
+            "value": "{spacing.base.value}"
+          }
+        }
+      };
+
+      transformObject(objectToTransform, options, transformationContext);
+
+      expect(transformedPropRefs).toEqual(['spacing.base']);
+      expect(deferredPropValueTransforms).toEqual(['spacing.medium']);
+    })
   });
 });

--- a/__tests__/utils/reference/usesReference.test.js
+++ b/__tests__/utils/reference/usesReference.test.js
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+const usesReference = require('../../../lib/utils/references/usesReference');
+
+describe('usesReference()', () => {
+  test('returns false for non-strings', () => {
+    expect(usesReference(42)).toBe(false);
+  });
+
+  test('returns false if value uses no reference', () => {
+    expect(usesReference('foo.bar')).toBe(false);
+  });
+
+  test('returns true if value is a reference', () => {
+    expect(usesReference('{foo.bar}')).toBe(true);
+  });
+
+  test('returns true if value uses a reference', () => {
+    expect(usesReference('baz {foo.bar}')).toBe(true);
+  });
+
+  describe('with custom options', () => {
+    test('returns true if value is reference', () => {
+      const customOpts = {
+        opening_character: '(',
+        closing_character: ')',
+        separator: '|'
+      };
+
+      expect(usesReference('(foo|bar)', customOpts)).toBe(true);
+    });
+  });
+});

--- a/__tests__/utils/resolveObject.test.js
+++ b/__tests__/utils/resolveObject.test.js
@@ -181,6 +181,19 @@ describe('utils', () => {
       }));
     });
 
+    describe('ignorePaths', () => {
+      it('should not resolve values containing variables in ignored paths', () => {
+        const test = resolveObject({
+          foo: { value: 'bar' },
+          bar: {
+            value: '{foo.value}'
+          }
+        }, {ignorePaths: ['foo.value']});
+
+        expect(test).toHaveProperty ('bar.value', '{foo.value}');
+      });
+    });
+
     describe('ignoreKeys', () => {
       it('should handle default value of original', () => {
         var test = resolveObject({

--- a/lib/exportPlatform.js
+++ b/lib/exportPlatform.js
@@ -11,12 +11,13 @@
  * and limitations under the License.
  */
 
-var resolveObject   = require('./utils/resolveObject'),
+const resolveObject = require('./utils/resolveObject'),
+    getName = require('./utils/references/getName'),
     transformObject = require('./transform/object'),
     transformConfig = require('./transform/config'),
     GroupMessages = require('./utils/groupMessages');
 
-var PROPERTY_REFERENCE_WARNINGS = GroupMessages.GROUP.PropertyReferenceWarnings;
+const PROPERTY_REFERENCE_WARNINGS = GroupMessages.GROUP.PropertyReferenceWarnings;
 
 /**
  * Exports a properties object with applied
@@ -37,24 +38,90 @@ function exportPlatform(platform) {
   }
 
   // We don't want to mutate the original object
-  var platformConfig = transformConfig(this.options.platforms[platform], this, platform);
+  const platformConfig = transformConfig(this.options.platforms[platform], this);
 
-  // We need to transform the object before we resolve the
-  // variable names because if a value contains concatenated
-  // values like "1px solid {color.border.base}" we want to
-  // transform the original value (color.border.base) before
-  // replacing that value in the string.
-  var to_ret = resolveObject(
-    transformObject(this.properties, platformConfig)
-  );
+  let exportableResult = this.properties;
 
-  if(GroupMessages.count(PROPERTY_REFERENCE_WARNINGS) > 0) {
-    var warnings = GroupMessages.flush(PROPERTY_REFERENCE_WARNINGS).join('\n');
+  // list keeping paths of props with applied value transformations
+  const transformedPropRefs = [];
+  // list keeping paths of props that had references in it, and therefore
+  // could not (yet) have transformed
+  const deferredPropValueTransforms = [];
+
+  const transformationContext = {
+    transformedPropRefs,
+    deferredPropValueTransforms
+  };
+
+  let loopCount = 0;
+
+  // eslint-disable-next-line no-constant-condition
+  while(true) {
+    // We keep up transforming and resolving until all props are resolved
+    // and every defined transformation was executed. Remember: transformations
+    // can only be executed, if the value to be transformed, has no references
+    // in it. So resolving may lead to enable further transformations, and sub
+    // sequent resolving may enable even more transformations - and so on.
+    // So we keep this loop running until sub sequent transformations are ineffective.
+    //
+    // Take the following example:
+    //
+    // color.brand = {
+    //   value: "{color.base.green}"
+    // }
+    //
+    // color.background.button.primary.base = {
+    //   value: "{color.brand.value}",
+    //   color: {
+    //     desaturate: 0.5
+    //   }
+    // }
+    //
+    // color.background.button.primary.hover = {
+    //   value: "{color.background.button.primary.base}",
+    //   color: {
+    //     darken: 0.2
+    //   }
+    // }
+    //
+    // As you can see 'color.background.button.primary.hover' is a variation
+    // of 'color.background.button.primary.base' which is a variation of
+    // 'color.base.green'. This transitive dependencies are solved by running
+    // this loop.
+    loopCount++;
+
+    const transformationsCountBefore = transformedPropRefs.length;
+    const deferredPropValueTransformsCountBefore = deferredPropValueTransforms.length;
+
+    // We need to transform the object before we resolve the
+    // variable names because if a value contains concatenated
+    // values like "1px solid {color.border.base}" we want to
+    // transform the original value (color.border.base) before
+    // replacing that value in the string.
+    const transformed = transformObject(exportableResult, platformConfig, transformationContext);
+
+    // referenced values, that have not (yet) been transformed should be excluded from resolving
+    const ignorePathsToResolve = deferredPropValueTransforms.map(p => getName([p, 'value']));
+
+    exportableResult = resolveObject(transformed, {ignorePaths: ignorePathsToResolve});
+
+    // nothing transformed and deferred props transforms has not changed? -> ready
+    if (
+      loopCount > 1 &&
+      transformedPropRefs.length === transformationsCountBefore &&
+      deferredPropValueTransforms.length === deferredPropValueTransformsCountBefore
+    ) {
+      break;
+    }
+  }
+
+  if (GroupMessages.count(PROPERTY_REFERENCE_WARNINGS) > 0) {
+    const warnings = GroupMessages.flush(PROPERTY_REFERENCE_WARNINGS).join('\n');
     console.log(`\n${PROPERTY_REFERENCE_WARNINGS}:\n${warnings}\n\n`);
     throw new Error('Problems were found when trying to resolve property references');
   }
 
-  return to_ret;
+  return exportableResult;
 }
 
 

--- a/lib/transform/object.js
+++ b/lib/transform/object.js
@@ -12,8 +12,10 @@
  */
 
 var _ = require('lodash'),
-    transformProperty = require('./property'),
-    propertySetup = require('./propertySetup');
+  usesValueReference = require('../utils/references/usesReference'),
+  getName = require('../utils/references/getName'),
+  transformProperty = require('./property'),
+  propertySetup = require('./propertySetup');
 
 /**
  * Applies transforms on all properties. This
@@ -24,33 +26,70 @@ var _ = require('lodash'),
  * @private
  * @param {Object} obj
  * @param {Object} options
+ * @param {Object} [transformationContext={}]
  * @param {Array} [path=[]]
- * @param {Object} [to_ret={}]
+ * @param {Object} [transformedObj={}]
  * @returns {Object}
  */
-function transformObject(obj, options, path, to_ret) {
-  to_ret = to_ret || {};
+function transformObject(obj, options, transformationContext = {}, path, transformedObj) {
+  transformedObj = transformedObj || {};
   path = path || [];
+  const {transformedPropRefs = [], deferredPropValueTransforms = []} = transformationContext;
 
-  for(var name in obj) {
-    if (obj.hasOwnProperty(name)) {
-      path.push(name);
-      // Need better logic
-      if (_.isPlainObject(obj[name]) && ('value' in obj[name])) {
-        to_ret[name] = transformProperty(
-          propertySetup(obj[name], name, path),
-          options
-        );
-      } else if (_.isPlainObject(obj[name])) {
-        to_ret[name] = transformObject(obj[name], options, path, to_ret[name]);
-      } else {
-        to_ret[name] = obj[name];
-      }
-      path.pop();
+  for (const name in obj) {
+    if (!obj.hasOwnProperty(name)) {
+      continue;
     }
+
+    path.push(name);
+
+    const pathName = getName(path);
+    const objProp = obj[name];
+    const alreadyTransformed = transformedPropRefs.indexOf(pathName) !== -1;
+    const isPlainObject = _.isPlainObject(objProp);
+    const transformationNeeded = !alreadyTransformed && isPlainObject;
+
+    if (!transformationNeeded) {
+      transformedObj[name] = objProp;
+      path.pop();
+      continue;
+    }
+
+    // is the objProp a style property?
+    // {
+    //   value: "#ababab"
+    //   ...
+    // }
+    if ('value' in objProp) {
+      const setupProperty = propertySetup(objProp, name, path);
+
+      if (usesValueReference(setupProperty.value, options)) {
+        deferredPropValueTransforms.push(pathName);
+        transformedObj[name] = setupProperty;
+        path.pop();
+        continue;
+      }
+
+      const transformedObjectValue = transformProperty(setupProperty, options);
+      _.pull(deferredPropValueTransforms, pathName);
+
+      // transformed anything?
+      if (setupProperty.value !== transformedObjectValue.value) {
+        transformedPropRefs.push(pathName);
+      }
+
+      transformedObj[name] = transformedObjectValue;
+      path.pop();
+      continue;
+    }
+
+    // objectValue is not a property -> go deeper down the object tree
+    transformedObj[name] = {};
+    transformObject(objProp, options, transformationContext, path, transformedObj[name]);
+    path.pop();
   }
 
-  return to_ret;
+  return transformedObj;
 }
 
 

--- a/lib/transform/property.js
+++ b/lib/transform/property.js
@@ -11,7 +11,8 @@
  * and limitations under the License.
  */
 
-var _ = require('lodash');
+const _ = require('lodash'),
+  usesReference = require('../utils/references/usesReference');
 
 /**
  * Applies all transforms to a property. This is a pure function,
@@ -22,18 +23,18 @@ var _ = require('lodash');
  * @returns {Object} - A new property object with transforms applied.
  */
 function transformProperty(property, options) {
-  var to_ret = _.clone(property);
-  var transforms = options.transforms;
+  const to_ret = _.clone(property);
+  const transforms = options.transforms;
 
-  for(var i = 0; i < transforms.length; i++ ) {
-    var transform = transforms[i];
+  for (let i = 0; i < transforms.length; i++ ) {
+    const transform = transforms[i];
 
     if (!transform.matcher || transform.matcher(to_ret)) {
       if (transform.type === 'name')
         to_ret.name = transform.transformer(to_ret, options);
       // Don't try to transform the value if it is referencing another value
       // Only try to transform if the value is not a string or if it has '{}'
-      if (transform.type === 'value' && (!_.isString(property.value) || property.value.indexOf('{') < 0))
+      if (transform.type === 'value' && !usesReference(property.value, options))
         to_ret.value = transform.transformer(to_ret, options);
       if (transform.type === 'attribute')
         to_ret.attributes = _.extend({}, to_ret.attributes, transform.transformer(to_ret, options));

--- a/lib/transform/propertySetup.js
+++ b/lib/transform/propertySetup.js
@@ -32,7 +32,7 @@ function propertySetup(property, name, path) {
   if (!path || !_.isArray(path))
     throw new Error('Path must be an array');
 
-  var to_ret = _.clone(property);
+  let to_ret = _.clone(property);
 
   // Only do this once
   if (!property.original) {

--- a/lib/utils/references/createReferenceRegex.js
+++ b/lib/utils/references/createReferenceRegex.js
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+const defaults = require('./defaults');
+
+function createReferenceRegex(opts = {}) {
+  const options = Object.assign({}, defaults, opts);
+
+  return new RegExp(
+    '\\' +
+    options.opening_character +
+    '([^' +
+    options.closing_character +
+    ']+)' +
+    '\\' +
+    options.closing_character, 'g'
+  );
+}
+
+module.exports = createReferenceRegex;

--- a/lib/utils/references/defaults.js
+++ b/lib/utils/references/defaults.js
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+const defaults = {
+  opening_character: '{',
+  closing_character: '}',
+  separator: '.'
+};
+
+module.exports = defaults;

--- a/lib/utils/references/getName.js
+++ b/lib/utils/references/getName.js
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+const defaults = require('./defaults');
+
+/**
+ * Returns the paths name be joining its parts with a given separator.
+ *
+ * @private
+ * @param {Array} path
+ * @param {Object} opts
+ * @returns {string} - The paths name
+ */
+function getName(path, opts = {}) {
+  const options = Object.assign({}, defaults, opts);
+  if (!path || !(path instanceof Array)) {
+    throw new Error('Getting name for path failed. Path must be an array');
+  }
+  return path.join(options.separator);
+}
+
+
+module.exports = getName;

--- a/lib/utils/references/getPathFromName.js
+++ b/lib/utils/references/getPathFromName.js
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+const defaults = require('./defaults');
+
+/**
+ * Returns the path from a path name be splitting the name by a given separator.
+ *
+ * @private
+ * @param {string} pathName
+ * @param {Object} opts
+ * @returns {Array} - The path
+ */
+function getPathFromName(pathName, opts = {}) {
+  const options = Object.assign({}, defaults, opts);
+  if (typeof pathName !== 'string') {
+    throw new Error('Getting path from name failed. Name must be a string');
+  }
+  return pathName.split(options.separator);
+}
+
+
+module.exports = getPathFromName;

--- a/lib/utils/references/usesReference.js
+++ b/lib/utils/references/usesReference.js
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+const createRegex = require('./createReferenceRegex');
+
+/**
+ * Checks if the value uses a value reference.
+ * @private
+ * @param {string} value
+ * @param {Object|RegExp} regexOrOptions
+ * @returns {boolean} - True, if the value uses a value reference
+ */
+function usesReference(value, regexOrOptions = {}) {
+  if (typeof value !== 'string') {
+    return false;
+  }
+
+  const regex = regexOrOptions instanceof RegExp ? regexOrOptions : createRegex(regexOrOptions);
+  return regex.test(value);
+}
+
+module.exports = usesReference;

--- a/lib/utils/resolveObject.js
+++ b/lib/utils/resolveObject.js
@@ -11,35 +11,29 @@
  * and limitations under the License.
  */
 
-var _ = require('lodash'),
-    GroupMessages = require('./groupMessages');
+const _ = require('lodash'),
+    GroupMessages = require('./groupMessages'),
+    usesReference = require('./../utils/references/usesReference'),
+    getName = require('./../utils/references/getName'),
+    getPath = require('./../utils/references/getPathFromName'),
+    createReferenceRegex = require('./../utils/references/createReferenceRegex');
 
-var PROPERTY_REFERENCE_WARNINGS = GroupMessages.GROUP.PropertyReferenceWarnings;
+const PROPERTY_REFERENCE_WARNINGS = GroupMessages.GROUP.PropertyReferenceWarnings;
 
-var current_context = []; // To maintain the context to be able to test for circular definitions
-var defaults = {
-  opening_character: '{',
-  closing_character: '}',
-  separator: '.',
-  ignoreKeys: ['original']
+let current_context = []; // To maintain the context to be able to test for circular definitions
+const defaults = {
+  ignoreKeys: ['original'],
+  ignorePaths: [],
 };
-var updated_object, regex, options;
+let updated_object, regex, options;
 
 
 function resolveObject(object, opts) {
-  options = _.extend({}, defaults, opts);
+  options = Object.assign({}, defaults, opts);
 
   updated_object = _.cloneDeep(object);  // This object will be edited
 
-  regex = new RegExp(
-    '\\' +
-    options.opening_character +
-    '([^' +
-    options.closing_character +
-    ']+)' +
-    '\\' +
-    options.closing_character, 'g'
-  );
+  regex = createReferenceRegex(options);
 
   if (typeof object === 'object') {
     current_context = [];
@@ -52,48 +46,59 @@ function resolveObject(object, opts) {
 
 
 function traverseObj(obj) {
-  var key;
+  let key;
 
   for (key in obj) {
+    if (!obj.hasOwnProperty(key)) {
+      continue;
+    }
+
     // We want to check for ignoredKeys, this is to
     // skip over attributes that should not be
     // mutated, like a copy of the original property.
-    if (obj.hasOwnProperty(key) && (options.ignoreKeys||[]).indexOf(key) < 0) {
-      current_context.push(key);
-      if (typeof obj[key] === 'object') {
-        traverseObj( obj[key] );
-      } else {
-        if (typeof obj[key] === 'string' && obj[key].indexOf('{') > -1) {
-          obj[key] = compile_value( obj[key], [current_context.join('.')] );
-        }
-      }
-      current_context.pop();
+    if (options.ignoreKeys && options.ignoreKeys.indexOf(key) !== -1) {
+      continue;
     }
+
+    current_context.push(key);
+    if (typeof obj[key] === 'object') {
+      traverseObj( obj[key] );
+    } else {
+      if (typeof obj[key] === 'string' && obj[key].indexOf('{') > -1) {
+        obj[key] = compile_value( obj[key], [getName(current_context)] );
+      }
+    }
+    current_context.pop();
   }
 
   return obj;
 }
 
 
-var foundCirc = {};
+let foundCirc = {};
 function compile_value(value, stack) {
 
-  var to_ret, ref;
+  let to_ret = value, ref;
 
   // Replace the reference inline, but don't replace the whole string because
   // references can be part of the value such as "1px solid {color.border.light}"
   value.replace(regex, function(match, variable) {
+    variable = variable.trim();
+    if (options.ignorePaths.indexOf(variable) !== -1) {
+      return value;
+    }
+
     stack.push(variable);
 
     // Find what the value is referencing
-    ref = selfRef(variable.trim(), updated_object);
+    ref = selfRef(variable, updated_object);
 
     if (typeof ref !== 'undefined') {
       if (typeof ref === 'string') {
         to_ret = value.replace(match, ref);
 
         // Recursive, therefore we can compute multi-layer variables like a = b, b = c, eventually a = c
-        if ( to_ret.indexOf('{') > -1 ) {
+        if (usesReference(to_ret, regex)) {
           var reference = to_ret.slice(1, -1);
 
           // Compare to found circular references
@@ -143,16 +148,16 @@ function compile_value(value, stack) {
 }
 
 
-function selfRef(str, obj) {
-  var i,
-      ref=obj,
-      array = str.split(options.separator),
-      context = current_context.join(options.separator);
+function selfRef(pathName, obj) {
+  let i,
+      ref = obj,
+      path = getPath(pathName, options),
+      context = getName(current_context, options);
 
-  for (i = 0; i < array.length; i++) {
+  for (i = 0; i < path.length; i++) {
     // Check for undefined as 0 is a valid, truthy value
-    if (typeof ref[array[i]] !== 'undefined') {
-      ref = ref[array[i]];
+    if (typeof ref[path[i]] !== 'undefined') {
+      ref = ref[path[i]];
     } else {
       // set the reference as undefined if we don't find anything
       ref = undefined;
@@ -163,11 +168,11 @@ function selfRef(str, obj) {
   if (typeof ref === 'undefined') {
     GroupMessages.add(
       PROPERTY_REFERENCE_WARNINGS,
-      "Reference doesn't exist: " + context + " tries to reference " + str + ", which is not defined"
+      "Reference doesn't exist: " + context + " tries to reference " + pathName + ", which is not defined"
     );
-  } else {
-    return ref;
   }
+
+  return ref;
 }
 
 


### PR DESCRIPTION
Issue #208 

Transformations can only be executed, if the value to be transformed, has no references in it. So resolving may lead to enable further transformations, and sub sequent resolving may enable even more transformations - and so on.

Unfortunately the current implementation only transforms and resolves once, and transformation on values containing references *do not work*. This change enables this transitive dependencies, by executing "transform & resolve" until all transformations are executed.

Take the following example (the `color: {...}` object might setup your custom color transformation)

```
color.brand = {
  value: "{color.base.green}"
}

color.background.button.primary.base = {
  value: "{color.brand.value}",
  color: {
    desaturate: 0.5
  }
}

color.background.button.primary.hover = {
  value: "{color.background.button.primary.base}",
  color: {
    darken: 0.2
  }
}
```

As you can see `color.background.button.primary.hover` is a variation of `color.background.button.primary.base` which is a variation of `color.base.green`. This transitive dependencies are solved by running this loop.
