### PR TITLE
docs: add sketchpalette plugin links to format page

### DIFF
--- a/docs/formats.md
+++ b/docs/formats.md
@@ -674,7 +674,7 @@ Creates a JSON flat file of the style dictionary.
 ### sketch/palette 
 
 
-Creates a sketchpalette file of all the base colors
+Creates a [sketchpalette](https://github.com/andrewfiorillo/sketch-palettes/releases/tag/1.5) file of all the base colors
 
 **Example**  
 ```json
@@ -694,7 +694,7 @@ Creates a sketchpalette file of all the base colors
 ### sketch/palette/v2 
 
 
-Creates a sketchpalette file compatible with version 2 of
+Creates a [sketchpalette](https://github.com/andrewfiorillo/sketch-palettes) file compatible with version 2 of
 the sketchpalette plugin. To use this you should use the
 'color/sketch' transform to get the correct value for the colors.
 


### PR DESCRIPTION
*Description of changes:*
There are a myriad of sketch plugins with the name "palette." This should make it easier to find the one that's compatible with style dictionary.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
