### PR TITLE
fix(formats): align scss/map-* with scss/variables on asset category

### DIFF
--- a/__tests__/formats/__snapshots__/scssMaps.test.js.snap
+++ b/__tests__/formats/__snapshots__/scssMaps.test.js.snap
@@ -11,6 +11,7 @@ $size-font-small: 12rem !default;
 $size-font-large: 18rem !default;
 $color-base-red: #ff0000 !default; // comment
 $color-white: #ffffff !default;
+$asset-icon-book: \\"PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9ImN1cnJlbnRDb2xvciIgc3Ryb2tlLXdpZHRoPSIyIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIGNsYXNzPSJmZWF0aGVyIGZlYXRoZXItYm9vayI+PHBhdGggZD0iTTQgMTkuNUEyLjUgMi41IDAgMCAxIDYuNSAxN0gyMCI+PC9wYXRoPjxwYXRoIGQ9Ik02LjUgMkgyMHYyMEg2LjVBMi41IDIuNSAwIDAgMSA0IDE5LjV2LTE1QTIuNSAyLjUgMCAwIDEgNi41IDJ6Ij48L3BhdGg+PC9zdmc+\\" !default;
 
 $tokens: (
   'size': (
@@ -24,6 +25,11 @@ $tokens: (
       'red': $color-base-red
     ),
     'white': $color-white
+  ),
+  'asset': (
+    'icon': (
+      'book': $asset-icon-book
+    )
   )
 );
 "
@@ -41,7 +47,8 @@ $tokens: (
   'size-font-large': 18rem,
   // comment
   'color-base-red': #ff0000,
-  'color-white': #ffffff
+  'color-white': #ffffff,
+  'asset-icon-book': \\"PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9ImN1cnJlbnRDb2xvciIgc3Ryb2tlLXdpZHRoPSIyIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIGNsYXNzPSJmZWF0aGVyIGZlYXRoZXItYm9vayI+PHBhdGggZD0iTTQgMTkuNUEyLjUgMi41IDAgMCAxIDYuNSAxN0gyMCI+PC9wYXRoPjxwYXRoIGQ9Ik02LjUgMkgyMHYyMEg2LjVBMi41IDIuNSAwIDAgMSA0IDE5LjV2LTE1QTIuNSAyLjUgMCAwIDEgNi41IDJ6Ij48L3BhdGg+PC9zdmc+\\"
 );
 "
 `;

--- a/__tests__/formats/scssMaps.test.js
+++ b/__tests__/formats/scssMaps.test.js
@@ -92,6 +92,27 @@ var dictionary = {
           "white"
         ]
       }
+    },
+    "asset": {
+      "icon": {
+        "book": {
+          "value": "PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9ImN1cnJlbnRDb2xvciIgc3Ryb2tlLXdpZHRoPSIyIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIGNsYXNzPSJmZWF0aGVyIGZlYXRoZXItYm9vayI+PHBhdGggZD0iTTQgMTkuNUEyLjUgMi41IDAgMCAxIDYuNSAxN0gyMCI+PC9wYXRoPjxwYXRoIGQ9Ik02LjUgMkgyMHYyMEg2LjVBMi41IDIuNSAwIDAgMSA0IDE5LjV2LTE1QTIuNSAyLjUgMCAwIDEgNi41IDJ6Ij48L3BhdGg+PC9zdmc+",
+          "original": {
+            "value": "./test/__assets/icons/book.svg"
+          },
+          "name": "asset-icon-book",
+          "attributes": {
+            "category": "asset",
+            "type": "icon",
+            "item": "book"
+          },
+          "path": [
+            "asset",
+            "icon",
+            "book"
+          ]
+        }
+      }
     }
   },
   "allProperties": [
@@ -161,6 +182,23 @@ var dictionary = {
       "path": [
         "color",
         "white"
+      ]
+    },
+    {
+      "value": "PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9ImN1cnJlbnRDb2xvciIgc3Ryb2tlLXdpZHRoPSIyIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIGNsYXNzPSJmZWF0aGVyIGZlYXRoZXItYm9vayI+PHBhdGggZD0iTTQgMTkuNUEyLjUgMi41IDAgMCAxIDYuNSAxN0gyMCI+PC9wYXRoPjxwYXRoIGQ9Ik02LjUgMkgyMHYyMEg2LjVBMi41IDIuNSAwIDAgMSA0IDE5LjV2LTE1QTIuNSAyLjUgMCAwIDEgNi41IDJ6Ij48L3BhdGg+PC9zdmc+",
+      "original": {
+        "value": "./test/__assets/icons/book.svg"
+      },
+      "name": "asset-icon-book",
+      "attributes": {
+        "category": "asset",
+        "type": "icon",
+        "item": "book"
+      },
+      "path": [
+        "asset",
+        "icon",
+        "book"
       ]
     }
   ]

--- a/lib/common/templates/scss/map-deep.template
+++ b/lib/common/templates/scss/map-deep.template
@@ -31,7 +31,7 @@
     //
     _.each(allProperties, function(prop) {
         var output = '';
-        output += '$' + prop.name + ': ' + prop.value + ' !default;'
+        output += '$' + prop.name + ': ' + (prop.attributes.category==='asset' ? '"'+prop.value+'"' : prop.value) + ' !default;'
         if(prop.comment) {
         output += ' // ' + prop.comment;
         }

--- a/lib/common/templates/scss/map-flat.template
+++ b/lib/common/templates/scss/map-flat.template
@@ -34,7 +34,7 @@
         if(prop.comment) {
         line += '  // ' + prop.comment + '\n';
         }
-        line += '  \'' + prop.name + '\': ' + prop.value
+        line += '  \'' + prop.name + '\': ' + (prop.attributes.category==='asset' ? '"'+prop.value+'"' : prop.value)
         return line;
     }).join(',\n');
     output += '\n);';


### PR DESCRIPTION
*Issue #, if available:*

A part of #298 :blush:

*Description of changes:*

To be more in accordance with the expected output in the same language (Scss), it is important that the behaviours of all formats try to follow the same way.

Now, `scss/map-*` formats handle the "asset" category like `scss/variables` and wrap the values in a double-quoted string.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
