### PR TITLE
fix(transforms): color/sketch didnt have the specificity for hex values

### DIFF
--- a/__tests__/common/transforms.test.js
+++ b/__tests__/common/transforms.test.js
@@ -13,6 +13,7 @@
 
 var transforms = require('../../lib/common/transforms');
 var path = require('path');
+var Color = require('tinycolor2');
 
 describe('common', () => {
   describe('transforms', () => {
@@ -341,6 +342,23 @@ describe('common', () => {
           value: "#aaaaaa99"
         });
         expect(value).toBe("rgba(170, 170, 170, 0.6)");
+      });
+    });
+
+    describe('color/sketch', () => {
+      it('should retain hex specificity', () => {
+        var originalHex = "#0b7dbb";
+        var value = transforms["color/sketch"].transformer({
+          original: {
+            value: originalHex
+          }
+        });
+        var newHex = Color({
+          r: value.red * 255,
+          g: value.green * 255,
+          b: value.blue * 255
+        });
+        expect(originalHex).toEqual(newHex.toHexString());
       });
     });
 

--- a/lib/common/transforms.js
+++ b/lib/common/transforms.js
@@ -440,9 +440,9 @@ module.exports = {
     transformer: function(prop) {
       let color = Color(prop.original.value).toRgb();
       return {
-        red: (color.r / 255).toFixed(2),
-        green: (color.g / 255).toFixed(2),
-        blue: (color.b / 255).toFixed(2),
+        red: (color.r / 255).toFixed(5),
+        green: (color.g / 255).toFixed(5),
+        blue: (color.b / 255).toFixed(5),
         alpha: color.a
       }
     }


### PR DESCRIPTION
*Issue #, if available:* 407

*Description of changes:* Fixing `color/sketch` transform to provide the proper significant digits to retain proper hex values. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
