### PR TITLE
The parseFloat() has only one argument

### DIFF
--- a/lib/common/transforms.js
+++ b/lib/common/transforms.js
@@ -463,7 +463,7 @@ module.exports = {
     type: 'value',
     matcher: isFontSize,
     transformer: function(prop) {
-      return parseFloat(prop.value, 10).toFixed(2) + 'sp';
+      return parseFloat(prop.value).toFixed(2) + 'sp';
     }
   },
 
@@ -482,7 +482,7 @@ module.exports = {
     type: 'value',
     matcher: isNotFontSize,
     transformer: function(prop) {
-      return parseFloat(prop.value, 10).toFixed(2) + 'dp';
+      return parseFloat(prop.value).toFixed(2) + 'dp';
     }
   },
 
@@ -501,7 +501,7 @@ module.exports = {
     type: 'value',
     matcher: isFontSize,
     transformer: function(prop) {
-      return (parseFloat(prop.value, 10) * 16).toFixed(2) + 'sp';
+      return (parseFloat(prop.value) * 16).toFixed(2) + 'sp';
     }
   },
 
@@ -521,7 +521,7 @@ module.exports = {
     type: 'value',
     matcher: isNotFontSize,
     transformer: function(prop) {
-      return (parseFloat(prop.value, 10) * 16).toFixed(2) + 'dp';
+      return (parseFloat(prop.value) * 16).toFixed(2) + 'dp';
     }
   },
 
@@ -541,7 +541,7 @@ module.exports = {
     type: 'value',
     matcher: isSize,
     transformer: function(prop) {
-      return parseFloat(prop.value, 10) + 'px';
+      return parseFloat(prop.value) + 'px';
     }
   },
 
@@ -560,7 +560,7 @@ module.exports = {
     type: 'value',
     matcher: isSize,
     transformer: function(prop) {
-      return parseFloat(prop.value, 10) + 'rem';
+      return parseFloat(prop.value) + 'rem';
     }
   },
 
@@ -579,7 +579,7 @@ module.exports = {
     type: 'value',
     matcher: isSize,
     transformer: function(prop) {
-      return (parseFloat(prop.value, 10) * 16).toFixed(2) + 'f';
+      return (parseFloat(prop.value) * 16).toFixed(2) + 'f';
     }
   },
 
@@ -597,7 +597,7 @@ module.exports = {
     type: 'value',
     matcher: isSize,
     transformer: function(prop) {
-      return `CGFloat(${(parseFloat(prop.value, 10) * 16).toFixed(2)})`;
+      return `CGFloat(${(parseFloat(prop.value) * 16).toFixed(2)})`;
     }
   },
 
@@ -616,7 +616,7 @@ module.exports = {
     type: 'value',
     matcher: isSize,
     transformer: function(prop) {
-      return (parseFloat(prop.value, 10) * 16).toFixed(0) + 'px';
+      return (parseFloat(prop.value) * 16).toFixed(0) + 'px';
     }
   },
 


### PR DESCRIPTION
Removed the second argument of parseFloat(). It has only one argument. The confusion probably comes from parseInt() which has radix as the second optional argument.

*Issue #416 , if available:*
#416 
*Description of changes:*
Fixed the minor bug in lib/common/transforms.js

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
