### PR TITLE
Extended path trailing slash check to also work on Windows

### DIFF
--- a/lib/buildFiles.js
+++ b/lib/buildFiles.js
@@ -25,7 +25,7 @@ var _ = require('lodash'),
  * @returns {null}
  */
 function buildFiles(dictionary, platform) {
-  if (platform.buildPath && platform.buildPath.slice(-1) !== '/') {
+  if (platform.buildPath && (platform.buildPath.slice(-1) !== '/' || platform.buildPath.slice(-1) !== '\')) {
     throw new Error('Build path must end in a trailing slash or you will get weird file names.')
   }
 

--- a/lib/buildFiles.js
+++ b/lib/buildFiles.js
@@ -25,7 +25,7 @@ var _ = require('lodash'),
  * @returns {null}
  */
 function buildFiles(dictionary, platform) {
-  if (platform.buildPath && (platform.buildPath.slice(-1) !== '/' || platform.buildPath.slice(-1) !== '\\')) {
+  if (platform.buildPath && (platform.buildPath.slice(-1) !== '/' && platform.buildPath.slice(-1) !== '\\')) {
     throw new Error('Build path must end in a trailing slash or you will get weird file names.')
   }
 

--- a/lib/buildFiles.js
+++ b/lib/buildFiles.js
@@ -25,7 +25,7 @@ var _ = require('lodash'),
  * @returns {null}
  */
 function buildFiles(dictionary, platform) {
-  if (platform.buildPath && (platform.buildPath.slice(-1) !== '/' || platform.buildPath.slice(-1) !== '\')) {
+  if (platform.buildPath && (platform.buildPath.slice(-1) !== '/' || platform.buildPath.slice(-1) !== '\\')) {
     throw new Error('Build path must end in a trailing slash or you will get weird file names.')
   }
 


### PR DESCRIPTION
On Windows, the passed in paths don't end with a forward slash, but instead with a backward slash. This causes `styled-dictionary` to fail when building on Windows. New check is less strict, and also allows the path to end in a backslash.
