### PR TITLE
chore(tests): fix test output files in commits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,6 @@ xcuserdata/
 
 # Mac directory hidden files
 *.DS_Store
+
+# Temporary build output directory for unit tests
+__tests__/__output

--- a/__tests__/formats/jsonNested.test.js
+++ b/__tests__/formats/jsonNested.test.js
@@ -39,7 +39,11 @@ var formatter = formats['json/nested'].bind(file);
 
 describe('formats', function() {
   describe('json/nested', function() {
-    beforeEach(function() {
+    beforeEach(() => {
+      helpers.clearOutput();
+    });
+
+    afterEach(() => {
       helpers.clearOutput();
     });
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Sometimes PRs include a random file in `__tests__/__output` directory. The reason is a test file wasn't cleaning up after it ran. This is exacerbated in VSCode when it tries to keep tests always running in the background. This fix adds that directory to the gitignore and fixes the issue by cleaning up that directory after a test is run. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
