### PR TITLE
chore: dropped node 8 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: node_js
 node_js:
-  - "8"
   - "10"
   - "12"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 node_js:
-  - "10"
   - "12"
+  - "14"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "style-dictionary": "./bin/style-dictionary"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "files": [
     "bin",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "style-dictionary": "./bin/style-dictionary"
   },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "files": [
     "bin",


### PR DESCRIPTION
*Issue #437:*

*Dropped Node 8 support by modifying [package.json](https://github.com/amzn/style-dictionary/blob/master/package.json#L27) and [.travis.yml](https://github.com/amzn/style-dictionary/blob/master/.travis.yml#L3) files*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
