### PR TITLE
fix: update `style-dictionary clean` config path

### DIFF
--- a/bin/style-dictionary
+++ b/bin/style-dictionary
@@ -14,6 +14,25 @@ function collect(val, arr) {
   return arr;
 }
 
+function getConfigPath(options) {
+  var configPath = options.config;
+
+  if(!configPath) {
+    if(fs.existsSync('./config.json')) {
+      configPath = './config.json';
+    }
+    else if(fs.existsSync('./config.js')) {
+      configPath = './config.js';
+    }
+    else {
+      console.error('Build failed; unable to find config file.');
+      process.exit(1);
+    }
+  }
+  
+  return configPath;
+}
+
 program
   .version(pkg.version)
   .description(pkg.description)
@@ -59,20 +78,7 @@ program.on('command:*', function () {
 
 function styleDictionaryBuild(options) {
   options = options || {};
-  var configPath = options.config;
-
-  if(!configPath) {
-    if(fs.existsSync('./config.json')) {
-      configPath = './config.json';
-    }
-    else if(fs.existsSync('./config.js')) {
-      configPath = './config.js';
-    }
-    else {
-      console.error('Build failed; unable to find config file.');
-      process.exit(1);
-    }
-  }
+  var configPath = getConfigPath(options);
 
   // Create a style dictionary object with the config
   var styleDictionary = StyleDictionary.extend( configPath );
@@ -88,7 +94,7 @@ function styleDictionaryBuild(options) {
 
 function styleDictionaryClean(options) {
   options = options || {};
-  var configPath = options.config ? options.config : './config.json';
+  var configPath = getConfigPath(options);
 
   // Create a style dictionary object with the config
   var styleDictionary = StyleDictionary.extend( configPath );


### PR DESCRIPTION
`style-dictionary build` and `style-dictionary clean` should use the same default config paths

*Description of changes:*
Ran into an issue where running `style-dictionary build` worked but `style-dictionary clean` threw an error because I was using config.js instead of config.json

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
