### PR TITLE
feat(formats): javascript/module-flat format

### DIFF
--- a/__tests__/formats/__snapshots__/all.test.js.snap
+++ b/__tests__/formats/__snapshots__/all.test.js.snap
@@ -442,6 +442,17 @@ module.exports = {
 };"
 `;
 
+exports[`formats all should match javascript/module-flat snapshot 1`] = `
+"/**
+ * Do not edit directly
+ * Generated on Sat, 01 Jan 2000 00:00:00 GMT
+ */
+
+module.exports = {
+  \\"color_red\\": \\"#FF0000\\"
+};"
+`;
+
 exports[`formats all should match javascript/object snapshot 1`] = `
 "/**
  * Do not edit directly

--- a/__tests__/formats/javascriptModuleFlat.test.js
+++ b/__tests__/formats/javascriptModuleFlat.test.js
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+var fs = require('fs-extra');
+var helpers = require('../__helpers');
+var formats = require('../../lib/common/formats');
+
+var file = {
+  "destination": "__output/",
+  "format": "javascript/module-flat",
+};
+
+var dictionary = {
+  "allProperties": [{
+    "name": "ColorRed",
+    "value": "#EF5350",
+    "original": {
+      "value": "#EF5350"
+    },
+    "attributes": {
+      "category": "color",
+      "type": "base",
+      "item": "red"
+    },
+    "path": [
+      "color",
+      "base",
+      "red"
+    ]
+  }]
+};
+
+var formatter = formats['javascript/module-flat'].bind(file);
+
+describe('formats', () => {
+  describe('javascript/module-flat', () => {
+
+    beforeEach(() => {
+      helpers.clearOutput();
+    });
+
+    afterEach(() => {
+      helpers.clearOutput();
+    });
+
+    it('should be a valid JS file', () => {
+      fs.writeFileSync('./__tests__/__output/output.js', formatter(dictionary) );
+      var test = require('../__output/output.js');
+      expect(test.ColorRed).toEqual(dictionary.allProperties[0].value);
+    });
+
+  });
+});

--- a/lib/common/formats.js
+++ b/lib/common/formats.js
@@ -259,6 +259,24 @@ module.exports = {
   },
 
   /**
+   * Creates a CommonJS module with the whole style dictionary flattened to a single level.
+   *
+   * @memberof Formats
+   * @kind member
+   * @example
+   * ```js
+   * module.exports = {
+   *  "ColorBaseRed": "#ff0000"
+   *}
+   *```
+   */
+  'javascript/module-flat': function(dictionary) {
+    return fileHeader(this.options) +
+      'module.exports = ' +
+        module.exports['json/flat'](dictionary) + ';';
+  },
+
+  /**
    * Creates a JS file a global var that is a plain javascript object of the style dictionary.
    * Name the variable by adding a 'name' attribute on the file object in your config.
    *


### PR DESCRIPTION
*Description of changes:*
Adds a new `javascript/module-flat` format that's just like the `json/flat` format, but exported as a cjs module. We have a use case in a project, and this seemed generic enough to consider for the core.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
