### PR TITLE
fix(formats): fix max call stack issue on json/nested format

### DIFF
--- a/__tests__/formats/jsonNested.test.js
+++ b/__tests__/formats/jsonNested.test.js
@@ -24,6 +24,8 @@ var dictionary = {
   properties: {
     color: {
       base: {
+        comment: 'This is a comment',
+        metadata: [1,2,3],
         red: {
           primary: { value: '#611D1C' },
           secondary: {
@@ -55,5 +57,17 @@ describe('formats', function() {
       expect(test.color.base.red.secondary.inverse)
         .toEqual(dictionary.properties.color.base.red.secondary.inverse.value);
     });
+
+    it('should handle non-token data', function() {
+      // non-token data is anything in the dictionary object that is not a token object
+      // i.e. anything in the rest of the object that doesn't have a 'value'
+
+      fs.writeFileSync('./__tests__/__output/json-nested.json', formatter(dictionary));
+      var test = require('../__output/json-nested.json');
+      expect(test.color.base.comment)
+        .toEqual(dictionary.properties.color.base.comment);
+      expect(test.color.base.metadata)
+        .toEqual(dictionary.properties.color.base.metadata);
+    })
   });
 });

--- a/lib/common/formats.js
+++ b/lib/common/formats.js
@@ -71,7 +71,12 @@ function iconsWithPrefix(prefix, properties, config) {
 }
 
 function minifyDictionary(obj) {
+  if (typeof obj !== 'object' || Array.isArray(obj)) {
+    return obj;
+  }
+
   var toRet = {};
+
   if (obj.hasOwnProperty('value')) {
     return obj.value;
   } else {
@@ -784,14 +789,14 @@ module.exports = {
    * @example
    * ```dart
    * import 'package:flutter/material.dart';
-   * 
+   *
    * class StyleDictionary {
    *   StyleDictionary._();
-   *   
+   *
    *     static const colorBrandPrimary = Color(0x00ff5fff);
    *     static const sizeFontSizeMedium = 16.00;
    *     static const contentFontFamily1 = "NewJune";
-   * ```   
+   * ```
    */
   'flutter/class.dart': _.template(
     fs.readFileSync(__dirname + '/templates/flutter/class.dart.template')


### PR DESCRIPTION
*Issue #, if available:* #464 

*Description of changes:* Fixing max call stack on `json/nested` format when the dictionary object contains non-token data. The issue was we were using `for (var name in obj)` assuming `obj` was an object, but if it was a string it would get in an infinite loop. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
