### PR TITLE
feat(formats): add javascript/es6-ts-declarations formats for .d.ts

### DIFF
--- a/__tests__/formats/__snapshots__/all.test.js.snap
+++ b/__tests__/formats/__snapshots__/all.test.js.snap
@@ -414,6 +414,15 @@ exports[`formats all should match javascript/es6 snapshot 1`] = `
 export const color_red = \\"#FF0000\\"; // comment"
 `;
 
+exports[`formats all should match javascript/es6-ts-declarations snapshot 1`] = `
+"/**
+ * Do not edit directly
+ * Generated on Sat, 01 Jan 2000 00:00:00 GMT
+ */
+
+export const color_red : string; // comment"
+`;
+
 exports[`formats all should match javascript/module snapshot 1`] = `
 "/**
  * Do not edit directly

--- a/__tests__/formats/es6TypeScriptDeclarations.test.js
+++ b/__tests__/formats/es6TypeScriptDeclarations.test.js
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+var fs = require('fs-extra');
+var helpers = require('../__helpers');
+var formats = require('../../lib/common/formats');
+
+var file = {
+  "destination": "__output/",
+  "format": "javascript/es6-ts-declarations",
+  "filter": {
+    "attributes": {
+      "category": "color"
+    }
+  }
+};
+
+var dictionary = {
+  "allProperties": [{
+    "name": "red",
+    "value": "#EF5350",
+    "original": {
+      "value": "#EF5350"
+    },
+    "attributes": {
+      "category": "color",
+      "type": "base",
+      "item": "red",
+      "subitem": "400"
+    },
+    "path": [
+      "color",
+      "base",
+      "red",
+      "400"
+    ]
+  }]
+};
+
+var formatter = formats['javascript/es6-ts-declarations'].bind(file);
+
+describe('formats', () => {
+  describe('javascript/es6-ts-declarations', () => {
+    beforeEach(() => {
+      helpers.clearOutput();
+    });
+
+    afterEach(() => {
+      helpers.clearOutput();
+    });
+
+    it('should be a valid JS file', () => {
+      const declarations = './__tests__/__output/output.d.ts';
+      fs.writeFileSync(declarations, formatter(dictionary) );
+
+      // get all lines that begin with export
+      const lines = fs.readFileSync(declarations, 'utf-8')
+        .split('\n')
+        .filter(l => l.indexOf('export') >= 0);
+
+      // assert that any lines have a string type definition
+      lines.forEach(l => {
+          expect(l.match(/^export.* : string;$/g).length).toEqual(1);
+      });
+    });
+  });
+
+});

--- a/lib/common/formats.js
+++ b/lib/common/formats.js
@@ -375,6 +375,42 @@ module.exports = {
         return to_ret_prop;
       }).join('\n');
   },
+  /**
+   * Creates TypeScript declarations for ES6 modules
+   *
+   * ```json
+   * {
+   *   "platforms": {
+   *     "js": {
+   *       "transformGroup": "js",
+   *       "files": [
+   *         {
+   *           "format": "javascript/es6-ts-declarations",
+   *           "destination": "colors.d.ts"
+   *         }
+   *       ]
+   *     }
+   *   }
+   * }
+   * ```
+   *
+   * @memberof Formats
+   * @kind member
+   * @example
+   * ```js
+   * export const ColorBackgroundBase : string;
+   * export const ColorBackgroundAlt : string;
+   * ```
+   */
+  'javascript/es6-ts-declarations': function(dictionary) {
+    return fileHeader(this.options) +
+      dictionary.allProperties.map(function(prop) {
+        var to_ret_prop = 'export const ' + prop.name + ' : string;';
+        if (prop.comment)
+          to_ret_prop = to_ret_prop.concat(' // ' + prop.comment);
+        return to_ret_prop;
+      }).join('\n');
+  },
 
   // Android templates
   /**


### PR DESCRIPTION
Possibly resolves #425 

*Description of changes:*
Adds a format for exporting es6-ts-declarations

Usage (config.json):
```
...
  {
    "format": "javascript/es6-ts-declarations",
    "destination": "colors.d.ts"
  }
...
```

Output (colors.d.ts):
```
export const ColorBackgroundBase : string;
export const ColorBackgroundAlt : string;
```



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
