### PR TITLE
chore(export platform): cleaning up transitive transform code

### DIFF
--- a/lib/exportPlatform.js
+++ b/lib/exportPlatform.js
@@ -53,10 +53,9 @@ function exportPlatform(platform) {
     deferredPropValueTransforms
   };
 
-  let loopCount = 0;
+  let finished;
 
-  // eslint-disable-next-line no-constant-condition
-  while(true) {
+  while(typeof finished === "undefined") {
     // We keep up transforming and resolving until all props are resolved
     // and every defined transformation was executed. Remember: transformations
     // can only be executed, if the value to be transformed, has no references
@@ -86,12 +85,8 @@ function exportPlatform(platform) {
     //
     // As you can see 'color.background.button.primary.hover' is a variation
     // of 'color.background.button.primary.base' which is a variation of
-    // 'color.base.green'. This transitive dependencies are solved by running
-    // this loop.
-    loopCount++;
-
-    const transformationsCountBefore = transformedPropRefs.length;
-    const deferredPropValueTransformsCountBefore = deferredPropValueTransforms.length;
+    // 'color.base.green'. These transitive references are solved by running
+    // this loop until all properties are transformed and resolved.
 
     // We need to transform the object before we resolve the
     // variable names because if a value contains concatenated
@@ -102,16 +97,11 @@ function exportPlatform(platform) {
 
     // referenced values, that have not (yet) been transformed should be excluded from resolving
     const ignorePathsToResolve = deferredPropValueTransforms.map(p => getName([p, 'value']));
-
     exportableResult = resolveObject(transformed, {ignorePaths: ignorePathsToResolve});
 
-    // nothing transformed and deferred props transforms has not changed? -> ready
-    if (
-      loopCount > 1 &&
-      transformedPropRefs.length === transformationsCountBefore &&
-      deferredPropValueTransforms.length === deferredPropValueTransformsCountBefore
-    ) {
-      break;
+    // nothing left to transform -> ready
+    if (deferredPropValueTransforms.length === 0) {
+      finished = true;
     }
   }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* I forgot to add this change to #476... This change will reduce the number of passes the loop that transforms and resolves does, the old code ran too many times (no effect on output, just unnecessary). Also better while loop logic so we don't have to disable eslint on that line. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
