### PR TITLE
feat(transforms): adds 'px to rem' transform

### DIFF
--- a/__tests__/common/transforms.test.js
+++ b/__tests__/common/transforms.test.js
@@ -544,6 +544,28 @@ describe('common', () => {
       });
     });
 
+    describe('size/pxToRem', () => {
+      const pxToRemTransformer = transforms["size/pxToRem"].transformer;
+
+      it('converts pixel to rem', () => {
+          expect(pxToRemTransformer({value: '12px'})).toBe('0.75rem');
+      });
+      it('converts pixel to rem using custom base font', () => {
+        expect(pxToRemTransformer({value: '14px'}, {basePxFontSize: 14})).toBe('1rem');
+      });
+      it('nonzero rem value not changed', () => {
+          expect(pxToRemTransformer({value: '2rem'})).toBe('2rem');
+      });
+      ['0px', '0', '0rem'].forEach((value) => {
+          it(`zero value "${value}" is returned without a unit`, () => {
+              expect(pxToRemTransformer({value})).toBe('0');
+          });
+      });
+      it('should throw an error if prop value is Nan', () => {
+        expect( () => pxToRemTransformer({value: "a"})).toThrow();
+      });
+    });
+
     describe('size/rem', () => {
       it('should work', () => {
         var value = transforms["size/rem"].transformer({

--- a/__tests__/common/transforms.test.js
+++ b/__tests__/common/transforms.test.js
@@ -547,16 +547,15 @@ describe('common', () => {
     describe('size/pxToRem', () => {
       const pxToRemTransformer = transforms["size/pxToRem"].transformer;
 
-      it('converts pixel to rem', () => {
-          expect(pxToRemTransformer({value: '12px'})).toBe('0.75rem');
+      ['12', '12px', '12rem'].forEach((value) => {
+        it(`ignoring unit, scales "${value}" to rem`, () => {
+          expect(pxToRemTransformer({value})).toBe('0.75rem');
+        });
       });
       it('converts pixel to rem using custom base font', () => {
         expect(pxToRemTransformer({value: '14px'}, {basePxFontSize: 14})).toBe('1rem');
       });
-      it('nonzero rem value not changed', () => {
-          expect(pxToRemTransformer({value: '2rem'})).toBe('2rem');
-      });
-      ['0px', '0', '0rem'].forEach((value) => {
+      ['0', '0px', '0rem'].forEach((value) => {
           it(`zero value "${value}" is returned without a unit`, () => {
               expect(pxToRemTransformer({value})).toBe('0');
           });

--- a/docs/transforms.md
+++ b/docs/transforms.md
@@ -475,20 +475,6 @@ Scales the number by 16 (default web font size) and adds 'px' to the end.
 
 * * *
 
-### size/pxToRem
-
-Scales the pixel value to rem, and adds 'rem' to the end of non-zero values. If you define a "basePxFontSize" on the platform in your config, it will be used to scale the pixel value, otherwise 16 (default web font size) will be used.
-
-```js
-// Matches: prop.attributes.category === 'size'
-// Returns:
-"0"
-"1rem"
-```
-
-
-* * *
-
 ### content/icon 
 
 

--- a/docs/transforms.md
+++ b/docs/transforms.md
@@ -475,6 +475,20 @@ Scales the number by 16 (default web font size) and adds 'px' to the end.
 
 * * *
 
+### size/pxToRem
+
+Scales the pixel value to rem, and adds 'rem' to the end of non-zero values. If you define a "basePxFontSize" on the platform in your config, it will be used to scale the pixel value, otherwise 16 (default web font size) will be used.
+
+```js
+// Matches: prop.attributes.category === 'size'
+// Returns:
+"0"
+"1rem"
+```
+
+
+* * *
+
 ### content/icon 
 
 

--- a/lib/common/transforms.js
+++ b/lib/common/transforms.js
@@ -697,6 +697,40 @@ module.exports = {
   },
 
   /**
+   * Scales the pixel value to rem, and adds 'rem' to the end of non-zero values. If you define a "basePxFontSize" on the platform in your config, it will be used to scale the pixel value, otherwise 16 (default web font size) will be used.
+   *
+   * ```js
+   * // Matches: prop.attributes.category === 'size'
+   * // Returns:
+   * "0"
+   * "1rem"
+   * ```
+   */
+  'size/pxToRem': {
+    type: 'value',
+    matcher: (prop) => prop.attributes.category === 'size',
+    transformer: (prop, options) => {
+      const baseFont = (options && options.basePxFontSize) || 16;
+      const floatVal = parseFloat(prop.value);
+
+      if (isNaN(floatVal)) {
+        throwSizeError(prop.name, prop.value, 'rem');
+      }
+
+      if (floatVal === 0) {
+        return '0';
+      }
+
+      if (String(prop.value).indexOf('px') === -1) {
+        // ignore anything without a "px" unit
+        return prop.value;
+      }
+
+      return `${floatVal / baseFont}rem`;
+    }
+  },
+
+  /**
    * Takes a unicode point and transforms it into a form CSS can use.
    *
    * ```js

--- a/lib/common/transforms.js
+++ b/lib/common/transforms.js
@@ -697,7 +697,7 @@ module.exports = {
   },
 
   /**
-   * Scales the pixel value to rem, and adds 'rem' to the end of non-zero values. If you define a "basePxFontSize" on the platform in your config, it will be used to scale the pixel value, otherwise 16 (default web font size) will be used.
+   * Scales non-zero numbers to rem, and adds 'rem' to the end. If you define a "basePxFontSize" on the platform in your config, it will be used to scale the value, otherwise 16 (default web font size) will be used.
    *
    * ```js
    * // Matches: prop.attributes.category === 'size'
@@ -719,11 +719,6 @@ module.exports = {
 
       if (floatVal === 0) {
         return '0';
-      }
-
-      if (String(prop.value).indexOf('px') === -1) {
-        // ignore anything without a "px" unit
-        return prop.value;
       }
 
       return `${floatVal / baseFont}rem`;

--- a/lib/common/transforms.js
+++ b/lib/common/transforms.js
@@ -708,7 +708,7 @@ module.exports = {
    */
   'size/pxToRem': {
     type: 'value',
-    matcher: (prop) => prop.attributes.category === 'size',
+    matcher: isSize,
     transformer: (prop, options) => {
       const baseFont = (options && options.basePxFontSize) || 16;
       const floatVal = parseFloat(prop.value);


### PR DESCRIPTION
*Issue #, if available:* NA

*Description of changes:*

Adds a transform for converting a pixel value to rem.

```
// config.json
{
    ...
    "platforms": {
        "scss": {
            ...
            "basePxFontSize": 16  // optional, defaults to 16
        }
    }
}

// properties.json
{
    "size": {
        "font": {
            "heading-1": { "value": "18px" }
        },
        "spacing": {
            "small": { "value": "12px" }
        }
    }
}
```

I'm not thrilled with the config property name `basePxFontSize`, and open to suggestions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
