### PR TITLE
feat(formats): add CommonJS format

### DIFF
--- a/__tests__/formats/__snapshots__/all.test.js.snap
+++ b/__tests__/formats/__snapshots__/all.test.js.snap
@@ -405,6 +405,15 @@ public enum  {
 "
 `;
 
+exports[`formats all should match javascript/cjs snapshot 1`] = `
+"/**
+ * Do not edit directly
+ * Generated on Sat, 01 Jan 2000 00:00:00 GMT
+ */
+
+module.exports.color_red = \\"#FF0000\\"; // comment"
+`;
+
 exports[`formats all should match javascript/es6 snapshot 1`] = `
 "/**
  * Do not edit directly

--- a/__tests__/formats/cjsConstants.test.js
+++ b/__tests__/formats/cjsConstants.test.js
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+var fs = require('fs-extra');
+var helpers = require('../__helpers');
+var formats = require('../../lib/common/formats');
+
+var file = {
+  "destination": "__output/",
+  "format": "javascript/cjs",
+  "filter": {
+    "attributes": {
+      "category": "color"
+    }
+  }
+};
+
+var dictionary = {
+  "allProperties": [{
+    "name": "red",
+    "value": "#EF5350",
+    "original": {
+      "value": "#EF5350"
+    },
+    "attributes": {
+      "category": "color",
+      "type": "base",
+      "item": "red",
+      "subitem": "400"
+    },
+    "path": [
+      "color",
+      "base",
+      "red",
+      "400"
+    ]
+  }]
+};
+
+var formatter = formats['javascript/cjs'].bind(file);
+
+describe('formats', () => {
+  describe('javascript/cjs', () => {
+    beforeEach(() => {
+      helpers.clearOutput();
+    });
+
+    afterEach(() => {
+      helpers.clearOutput();
+    });
+
+    it('should be a valid JS file', () => {
+      fs.writeFileSync('./__tests__/__output/output.js', formatter(dictionary) );
+      var test = require('../__output/output.js');
+      expect(test.red).toEqual(dictionary.allProperties[0].value);
+    });
+  });
+
+});

--- a/docs/formats.md
+++ b/docs/formats.md
@@ -353,6 +353,40 @@ export const ColorBackgroundAlt = '#fcfcfcfc';
 
 * * *
 
+### javascript/cjs 
+
+
+Creates a CommonJS module of the style dictionary.
+
+```json
+{
+  "platforms": {
+    "cjs": {
+      "transformGroup": "js",
+      "files": [
+        {
+          "format": "javascript/cjs",
+          "destination": "colors.js",
+          "filter": {
+            "attributes": {
+              "category": "color"
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+**Example**  
+```js
+module.exports.ColorBackgroundBase = '#ffffff';
+module.exports.ColorBackgroundAlt = '#fcfcfcfc';
+```
+
+* * *
+
 ### android/colors 
 
 

--- a/lib/common/formats.js
+++ b/lib/common/formats.js
@@ -381,6 +381,57 @@ module.exports = {
       }).join('\n');
   },
 
+  /**
+   * Creates a CommonJS module of the style dictionary.
+   *
+   * ```json
+   * {
+   *   "platforms": {
+   *     "cjs": {
+   *       "transformGroup": "js",
+   *       "files": [
+   *         {
+   *           "format": "javascript/cjs",
+   *           "destination": "colors.js",
+   *           "filter": {
+   *             "attributes": {
+   *               "category": "color"
+   *             }
+   *           }
+   *         }
+   *       ]
+   *     }
+   *   }
+   * }
+   * ```
+   *
+   * @memberof Formats
+   * @kind member
+   * @example
+   * ```js
+   * module.exports.ColorBackgroundBase = '#ffffff';
+   * module.exports.ColorBackgroundAlt = '#fcfcfcfc';
+   * ```
+   */
+  "javascript/cjs": function (dictionary) {
+    return (
+      fileHeader(this.options) +
+      dictionary.allProperties
+        .map(function (prop) {
+          var to_ret_prop =
+            "module.exports." +
+            prop.name +
+            " = " +
+            JSON.stringify(prop.value) +
+            ";";
+          if (prop.comment)
+            to_ret_prop = to_ret_prop.concat(" // " + prop.comment);
+          return to_ret_prop;
+        })
+        .join("\n")
+    );
+  },
+
   // Android templates
   /**
    * Creates a color resource xml file with all the colors in your style dictionary.


### PR DESCRIPTION
*Description of changes:*

Added a CommonJS format (`javascript/cjs`) that outputs a file in a similar manner to the `javascript/es6` format. The only possible concern is that there already exists a similar format called `javascript/module`. I still believe that this new format should be added so that there is parity with the `javascript/es6` format (i.e. flattened names). If needed, I could rename the format to something like `javascript/module-flat`.

Note: This PR is very similar to https://github.com/amzn/style-dictionary/pull/47 that was never finished or merged.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
