### PR TITLE
feat(build-file): add escape return if properties is empty

### DIFF
--- a/__tests__/buildFile.test.js
+++ b/__tests__/buildFile.test.js
@@ -85,6 +85,26 @@ describe('buildFile', () => {
     expect(JSON.stringify(GroupMessages.fetchMessages(PROPERTY_NAME_COLLISION_WARNINGS))).toBe(expectJSON);
   });
 
+  let destEmptyProperties = './__tests__/__output/test.emptyProperties';
+  it('should warn when a file is not created because of empty properties', () => {
+    let properties = {
+      allProperties: [{
+        name: 'someName',
+        attributes: { category: 'category1' },
+        path: ['some', 'name', 'path1'],
+        value: 'value1'
+      }]
+    };
+
+    let filter = function(prop) {
+      let { attributes } = prop;
+      return attributes.category === 'category2';
+    }
+
+    buildFile(destEmptyProperties, format, {}, properties, filter);
+    expect(helpers.fileExists('./__tests__/__output/test.emptyProperties')).toBeFalsy();
+  });
+
   it('should write to a file properly', () => {
     buildFile('test.txt', format, {buildPath: '__tests__/__output/'}, {});
     expect(helpers.fileExists('./__tests__/__output/test.txt')).toBeTruthy();

--- a/__tests__/buildFile.test.js
+++ b/__tests__/buildFile.test.js
@@ -97,8 +97,7 @@ describe('buildFile', () => {
     };
 
     let filter = function(prop) {
-      let { attributes } = prop;
-      return attributes.category === 'category2';
+      return prop.attributes.category === 'category2';
     }
 
     buildFile(destEmptyProperties, format, {}, properties, filter);

--- a/lib/buildFile.js
+++ b/lib/buildFile.js
@@ -47,9 +47,13 @@ function buildFile(destination, format, platform, dictionary, filter) {
 
   var filteredProperties = filterProperties(dictionary, filter);
 
-  // if allProperties array is empty, return early so no empty file is built
-  if (filteredProperties.allProperties && !filteredProperties.allProperties.length) {
-    return null
+  // if properties object is empty, return without creating a file
+  if (
+    filteredProperties.hasOwnProperty('properties') &&
+    Object.keys(filteredProperties.properties).length === 0 &&
+    filteredProperties.properties.constructor === Object
+  ) {
+    return null;
   }
 
   // Check for property name Collisions

--- a/lib/buildFile.js
+++ b/lib/buildFile.js
@@ -53,6 +53,8 @@ function buildFile(destination, format, platform, dictionary, filter) {
     Object.keys(filteredProperties.properties).length === 0 &&
     filteredProperties.properties.constructor === Object
   ) {
+    let warnNoFile = `No properties for ${destination}. File not created.`;
+    console.log(chalk.keyword('darkorange')(warnNoFile));
     return null;
   }
 

--- a/lib/buildFile.js
+++ b/lib/buildFile.js
@@ -47,6 +47,11 @@ function buildFile(destination, format, platform, dictionary, filter) {
 
   var filteredProperties = filterProperties(dictionary, filter);
 
+  // if allProperties array is empty, return early so no empty file is built
+  if (filteredProperties.allProperties && !filteredProperties.allProperties.length) {
+    return null
+  }
+
   // Check for property name Collisions
   var nameCollisionObj = {};
   filteredProperties.allProperties && filteredProperties.allProperties.forEach((propertyData) => {


### PR DESCRIPTION
### Context 

I have a setup where tokens are generated for multiple apps. There is a global "app" for all the shared tokens and then each app has its own unique tokens. The transformations for the platforms are run for each app.

### Problem

The problem I'm running into is for example the global app has tokens for colors and gradients that are output with custom formats but then for say "App A" when the transformations are run and App A doesn't have any color or gradient tokens the custom formatter is run for each with no data which causes two things happen:

1. For the color tokens, an empty file is created.
2. For the gradient tokens, an error occurs because of the template logic trying to operate on undefined variables.

### Solution

The solution I came up with was to add a check in `lib/buildFile.js` after `filteredProperties()` is run to see if the resulting `allProperties` array is empty. If it's empty then the function returns null before the custom format file is built.

I've tested it in my Style Dictionary project and it works as intended. The build process produces only the final files for the tokens present. However, there may be large issues here that I'm not aware of; or perhaps it's more of an issue with my setup than the need for extra code in the core?

I'm happy to make further changes, etc. if required.

Thanks!

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.