### PR TITLE
fix: add direct injection of props

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,6 @@ xcuserdata/
 
 # Temporary build output directory for unit tests
 __tests__/__output
+
+# Disposable test file ( user: @Meiuca )
+meiuca-test.js

--- a/lib/extend.js
+++ b/lib/extend.js
@@ -11,14 +11,14 @@
  * and limitations under the License.
  */
 
-require('json5/lib/register');
+require("json5/lib/register");
 
-var combineJSON = require('./utils/combineJSON'),
-    deepExtend = require('./utils/deepExtend'),
-    resolveCwd = require('resolve-cwd'),
-    _ = require('lodash'),
-    chalk = require('chalk'),
-    GroupMessages = require('./utils/groupMessages');
+var combineJSON = require("./utils/combineJSON"),
+  deepExtend = require("./utils/deepExtend"),
+  resolveCwd = require("resolve-cwd"),
+  _ = require("lodash"),
+  chalk = require("chalk"),
+  GroupMessages = require("./utils/groupMessages");
 
 var PROPERTY_VALUE_COLLISIONS = GroupMessages.GROUP.PropertyValueCollisions;
 
@@ -96,12 +96,12 @@ function extend(opts) {
 
   // Creating a new object and copying over the options
   // Also keeping an options object in case
-  to_ret = deepExtend([{}, this, {options: options}, options]);
+  to_ret = deepExtend([{}, this, { options: options }, options]);
 
   // Update properties with includes from dependencies
   if (options.include) {
     if (!_.isArray(options.include))
-      throw new Error('include must be an array');
+      throw new Error("include must be an array");
 
     to_ret.properties = combineJSON(options.include, true);
 
@@ -111,21 +111,27 @@ function extend(opts) {
   // Update properties with current package's source
   // These highest precedence
   if (options.source) {
-    if (!_.isArray(options.source))
-      throw new Error('source must be an array');
+    // Inject objects directly
+    // To be used in backend projects
+    if (!_.isArray(options.source) && typeof options.source != "object")
+      throw new Error("source must be an array or an object");
 
     var props = combineJSON(options.source, true, function Collision(prop) {
       GroupMessages.add(
         PROPERTY_VALUE_COLLISIONS,
-        `Collision detected at: ${prop.path.join('.')}! Original value: ${prop.target[prop.key]}, New value: ${prop.copy[prop.key]}`
+        `Collision detected at: ${prop.path.join(".")}! Original value: ${
+          prop.target[prop.key]
+        }, New value: ${prop.copy[prop.key]}`
       );
     });
 
-    if(GroupMessages.count(PROPERTY_VALUE_COLLISIONS) > 0) {
-      var collisions = GroupMessages.flush(PROPERTY_VALUE_COLLISIONS).join('\n');
+    if (GroupMessages.count(PROPERTY_VALUE_COLLISIONS) > 0) {
+      var collisions = GroupMessages.flush(PROPERTY_VALUE_COLLISIONS).join(
+        "\n"
+      );
       console.log(`\n${PROPERTY_VALUE_COLLISIONS}:\n${collisions}\n\n`);
-      if (options.log === 'error') {
-        throw new Error('Collisions detected');
+      if (options.log === "error") {
+        throw new Error("Collisions detected");
       }
     }
 

--- a/lib/utils/combineJSON.js
+++ b/lib/utils/combineJSON.js
@@ -11,49 +11,64 @@
  * and limitations under the License.
  */
 
-require('json5/lib/register');
+require("json5/lib/register");
 
-var glob = require('glob'),
-  deepExtend = require('./deepExtend'),
-  extend = require('lodash/extend'),
-  path = require('path'),
-  resolveCwd = require('resolve-cwd');
+var glob = require("glob"),
+  deepExtend = require("./deepExtend"),
+  _ = require("lodash"),
+  path = require("path"),
+  resolveCwd = require("resolve-cwd");
 
 /**
  * Takes an array of json files and merges
  * them together. Optionally does a deep extend.
  * @private
- * @param {String[]} arr - Array of paths to json (or node modules that export objects) files
+ * @param {String[] | Object} obj - Array of paths to json (or node modules that export objects) files or an Object
  * @param {Boolean} [deep=false] - If it should perform a deep merge
  * @param {Function} collision - A function to be called when a name collision happens that isn't a normal deep merge of objects
  * @returns {Object}
  */
-function combineJSON(arr, deep, collision) {
-  var i, files = [],
+function combineJSON(obj, deep, collision) {
+  var i,
+    files = [],
     to_ret = {};
 
-  for (i = 0; i < arr.length; i++) {
-    var new_files = glob.sync(arr[i], {});
+  // Inject objects directly
+  // To be used in backend projects
+  if (!_.isArray(obj)) {
+    if (deep) {
+      deepExtend([to_ret, obj], collision);
+    } else {
+      _.extend(to_ret, obj);
+    }
+
+    return to_ret;
+  }
+
+  for (i = 0; i < obj.length; i++) {
+    var new_files = glob.sync(obj[i], {});
     files = files.concat(new_files);
   }
 
   for (i = 0; i < files.length; i++) {
-    var resolvedPath = resolveCwd(path.isAbsolute(files[i]) ? files[i] : './' + files[i]);
+    var resolvedPath = resolveCwd(
+      path.isAbsolute(files[i]) ? files[i] : "./" + files[i]
+    );
     var file_content;
 
     try {
       // This delete force require(resolvedPath) to take the latest version of the file. It's handfull when using the node package along chokidar.
-      delete require.cache[resolvedPath]
+      delete require.cache[resolvedPath];
       file_content = require(resolvedPath);
     } catch (e) {
-      e.message = 'Failed to load or parse JSON or JS Object: ' + e.message;
+      e.message = "Failed to load or parse JSON or JS Object: " + e.message;
       throw e;
     }
 
     if (deep) {
       deepExtend([to_ret, file_content], collision);
     } else {
-      extend(to_ret, file_content);
+      _.extend(to_ret, file_content);
     }
   }
 


### PR DESCRIPTION
To be used in backend projects, to avoid unnecessary file generation.

*Description of changes:*

- Added a shortcut in lib/utils/combineJson ( lines 36 to 46 ) to inject properties directly.
- Changed lib/extend ( lines 114 to 117 ) to avoid throwing errors since `_.isArray({})` returns false


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
