### PR TITLE
chore(types): adds filePath and isSource to Prop and descriptions to Props keys

### DIFF
--- a/docs/properties.md
+++ b/docs/properties.md
@@ -116,7 +116,7 @@ Style Dictionary adds some metadata on each property that helps with transforms 
 | Attribute | Type | Description |
 | :--- | :--- | :--- |
 | name | String | A default name of the property that is set to the key of the property.
-| path | Array[String] | The object path of the property. `color: { background: primary: {value: "#fff"}}` will have a path of `['color','background', 'primary']`.
+| path | Array[String] | The object path of the property. `color: { background: { primary: { value: "#fff" } } }` will have a path of `['color','background', 'primary']`.
 | original | Object | A pristine copy of the original property object. This is to make sure transforms and formats always have the unmodified version of the original property.
 | filePath | String | The file path of the file the token is defined in. This file path is derived from the `source` or `include` file path arrays defined in the [configuration](config.md).
 | isSource | Boolean | If the token is from a file defined in the `source` array as opposed to `include` in the [configuration](config.md).

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -71,6 +71,10 @@ declare namespace StyleDictionary {
     attributes: Attributes;
     path: string[];
     value: string;
+    /** A string representing the absolute path of the file that defines the token. */
+    filePath: string;
+    /** Represents if this file was defined as ‘source’ in the configuration as opposed to ‘include’ (or directly setting the ‘properties’ object). */
+    isSource: boolean;
     [key: string]: any;
   }
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -66,15 +66,31 @@ declare namespace StyleDictionary {
   }
 
   interface Prop {
-    original: Property;
+    /** A default name of the property that is set to the key of the property. */
     name: string;
-    attributes: Attributes;
-    path: string[];
     value: string;
-    /** A string representing the absolute path of the file that defines the token. */
+    /** The object path of the property.
+     *
+     * `color: { background: { primary: { value: "#fff" } } }` will have a path of `['color', 'background', 'primary']`.
+     */
+    path: string[];
+    /**
+     * A pristine copy of the original property object.
+     *
+     * This is to make sure transforms and formats always have the unmodified version of the original property.
+     */
+    original: Property;
+    /**
+     * The file path of the file the token is defined in.
+     *
+     * This file path is derived from the source or include file path arrays defined in the configuration.
+     */
     filePath: string;
-    /** Represents if this file was defined as ‘source’ in the configuration as opposed to ‘include’ (or directly setting the ‘properties’ object). */
+    /**
+     * If the token is from a file defined in the source array as opposed to include in the [configuration](https://amzn.github.io/style-dictionary/#/config).
+     */
     isSource: boolean;
+    attributes: Attributes;
     [key: string]: any;
   }
 


### PR DESCRIPTION
*Description of changes:*

Adds the new isSource and filePath to the type of Prop.

Also added descriptions to the keys of Prop interface based off the docs added in https://github.com/amzn/style-dictionary/pull/499.

(note: these were still usable pre this change due to the "catch all" index signature `[key: string]: any;` on `Prop`).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
