### PR TITLE
chore(types): fix transform options type

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -77,19 +77,19 @@ declare namespace StyleDictionary {
   interface NameTransform {
     type: "name";
     matcher?: (prop: Prop) => boolean;
-    transformer: (prop: Prop, options: Options) => string;
+    transformer: (prop: Prop, options: Platform) => string;
   }
 
   interface ValueTransform {
     type: "value";
     matcher?: (prop: Prop) => boolean;
-    transformer: (prop: Prop, options: Options) => string;
+    transformer: (prop: Prop, options: Platform) => string;
   }
 
   interface AttributeTransform {
     type: "attribute";
     matcher?: (prop: Prop) => boolean;
-    transformer: (prop: Prop, options: Options) => { [key: string]: any };
+    transformer: (prop: Prop, options: Platform) => { [key: string]: any };
   }
 
   type Transform = NameTransform | ValueTransform | AttributeTransform;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Based on the code [here](https://github.com/amzn/style-dictionary/blob/3.0/lib/exportPlatform.js#L96) and in the tests for transforms, it looks like the correct type for transformer functions should be `Platform` instead of `Options`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
