### PR TITLE
fix(format): remove token filtering in android formats

### DIFF
--- a/__tests__/formats/__snapshots__/all.test.js.snap
+++ b/__tests__/formats/__snapshots__/all.test.js.snap
@@ -22,6 +22,7 @@ exports[`formats all should match android/dimens snapshot 1`] = `
   Generated on Sat, 01 Jan 2000 00:00:00 GMT
 -->
 <resources>
+  <dimen name=\\"color_red\\">#FF0000</dimen><!-- comment -->
   
 </resources>
 "
@@ -35,6 +36,7 @@ exports[`formats all should match android/fontDimens snapshot 1`] = `
   Generated on Sat, 01 Jan 2000 00:00:00 GMT
 -->
 <resources>
+  <dimen name=\\"color_red\\">#FF0000</dimen><!-- comment -->
   
 </resources>
 "
@@ -48,6 +50,7 @@ exports[`formats all should match android/integers snapshot 1`] = `
   Generated on Sat, 01 Jan 2000 00:00:00 GMT
 -->
 <resources>
+  <integer name=\\"color_red\\">#FF0000</integer><!-- comment -->
   
 </resources>
 "
@@ -61,6 +64,7 @@ exports[`formats all should match android/strings snapshot 1`] = `
   Generated on Sat, 01 Jan 2000 00:00:00 GMT
 -->
 <resources>
+  <string name=\\"color_red\\">#FF0000</string><!-- comment -->
   
 </resources>
 "

--- a/lib/common/templates/android/colors.template
+++ b/lib/common/templates/android/colors.template
@@ -13,10 +13,6 @@
 // on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
-
-var props = _.filter(allProperties, function(prop) {
- return prop.attributes.category === 'color';
-});
 %>
 <%
   // for backward compatibility we need to have the user explicitly hide it
@@ -29,7 +25,7 @@ var props = _.filter(allProperties, function(prop) {
   }
 %>
 <resources>
-  <% _.each(props, function(prop) {
+  <% _.each(allProperties, function(prop) {
   %><color name="<%= prop.name %>"><%= prop.value %></color><% if (prop.comment) { %><!-- <%= prop.comment %> --><% } %>
   <% }); %>
 </resources>

--- a/lib/common/templates/android/dimens.template
+++ b/lib/common/templates/android/dimens.template
@@ -13,10 +13,7 @@
 // on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
-
-var props = _.filter(allProperties, function(prop) {
-  return prop.attributes.category === 'size' && prop.attributes.type !== 'font'
-}); %>
+%>
 <%
   // for backward compatibility we need to have the user explicitly hide it
   var showFileHeader = (this.options && this.options.hasOwnProperty('showFileHeader')) ? this.options.showFileHeader : true;
@@ -28,7 +25,7 @@ var props = _.filter(allProperties, function(prop) {
   }
 %>
 <resources>
-  <% _.each(props, function(prop) {
+  <% _.each(allProperties, function(prop) {
   %><dimen name="<%= prop.name %>"><%= prop.value %></dimen><% if (prop.comment) { %><!-- <%= prop.comment %> --><% } %>
   <% }); %>
 </resources>

--- a/lib/common/templates/android/fontDimens.template
+++ b/lib/common/templates/android/fontDimens.template
@@ -13,10 +13,7 @@
 // on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
-
-var props = _.filter(allProperties, function(prop) {
-  return prop.attributes.category === 'size' && prop.attributes.type === 'font';
-}); %>
+%>
 <%
   // for backward compatibility we need to have the user explicitly hide it
   var showFileHeader = (this.options && this.options.hasOwnProperty('showFileHeader')) ? this.options.showFileHeader : true;
@@ -28,7 +25,7 @@ var props = _.filter(allProperties, function(prop) {
   }
 %>
 <resources>
-  <% _.each(props, function(prop) {
+  <% _.each(allProperties, function(prop) {
   %><dimen name="<%= prop.name %>"><%= prop.value %></dimen><% if (prop.comment) { %><!-- <%= prop.comment %> --><% } %>
   <% }); %>
 </resources>

--- a/lib/common/templates/android/integers.template
+++ b/lib/common/templates/android/integers.template
@@ -13,10 +13,7 @@
 // on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
-
-var props = _.filter(allProperties, function(prop) {
-  return prop.attributes.category === 'time';
-}); %>
+%>
 <%
   // for backward compatibility we need to have the user explicitly hide it
   var showFileHeader = (this.options && this.options.hasOwnProperty('showFileHeader')) ? this.options.showFileHeader : true;
@@ -28,7 +25,7 @@ var props = _.filter(allProperties, function(prop) {
   }
 %>
 <resources>
-  <% _.each(props, function(prop) {
+  <% _.each(allProperties, function(prop) {
   %><integer name="<%= prop.name %>"><%= prop.value %></integer><% if (prop.comment) { %><!-- <%= prop.comment %> --><% } %>
   <% }); %>
 </resources>

--- a/lib/common/templates/android/strings.template
+++ b/lib/common/templates/android/strings.template
@@ -13,10 +13,7 @@
 // on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
-
-var props = _.filter(allProperties, function(prop) {
-  return prop.attributes.category === 'content';
-}); %>
+%>
 <%
   // for backward compatibility we need to have the user explicitly hide it
   var showFileHeader = (this.options && this.options.hasOwnProperty('showFileHeader')) ? this.options.showFileHeader : true;
@@ -28,7 +25,7 @@ var props = _.filter(allProperties, function(prop) {
   }
 %>
 <resources>
-  <% _.each(props, function(prop) {
+  <% _.each(allProperties, function(prop) {
   %><string name="<%= prop.name %>"><%= prop.value %></string><% if (prop.comment) { %><!-- <%= prop.comment %> --><% } %>
   <% }); %>
 </resources>


### PR DESCRIPTION
*Issue #, if available:* #453

*Description of changes:* Removing token filters in the Android formats because we have added filters earlier. This is a breaking change in Android formats, but will make them more flexible for people who don't use the CTI structure. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
