### PR TITLE
chore(deprecation): updating buffer call in base64 converter

### DIFF
--- a/__tests__/utils/convertToBase64.test.js
+++ b/__tests__/utils/convertToBase64.test.js
@@ -36,5 +36,10 @@ describe('utils', () => {
     it('should return a string', () => {
       expect(typeof convertToBase64('__tests__/__configs/test.json')).toBe('string');
     });
+
+    it('should be a valid base64 string', () => {
+      expect(convertToBase64('__tests__/__json_files/simple.json'))
+        .toEqual('ewogICJmb28iOiAiYmFyIiwKICAiYmFyIjogIntmb299Igp9');
+    });
   });
 });

--- a/lib/utils/convertToBase64.js
+++ b/lib/utils/convertToBase64.js
@@ -24,7 +24,7 @@ function convertToBase64(filePath) {
     throw new Error('filePath name must be a string');
 
   var body = fs.readFileSync(filePath, 'binary');
-  return new Buffer(body, 'binary').toString('base64');
+  return Buffer.from(body, 'binary').toString('base64');
 }
 
 module.exports = convertToBase64;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Running the base64 transform outputs a deprecation warning in the console. Let's get rid of it.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
