### PR TITLE
chore: replace resolve-cwd with platform capabilities

### DIFF
--- a/lib/extend.js
+++ b/lib/extend.js
@@ -15,7 +15,7 @@ require('json5/lib/register');
 
 var combineJSON = require('./utils/combineJSON'),
     deepExtend = require('./utils/deepExtend'),
-    resolveCwd = require('resolve-cwd'),
+    path = require('path'),
     _ = require('lodash'),
     GroupMessages = require('./utils/groupMessages');
 
@@ -88,7 +88,7 @@ function extend(opts) {
   // Overloaded method, can accept a string as a path that points to a JS or
   // JSON file or a plain object. Potentially refactor.
   if (_.isString(opts)) {
-    options = require(resolveCwd(opts));
+    options = require(path.resolve(process.cwd(), opts));
   } else {
     options = opts;
   }

--- a/lib/utils/combineJSON.js
+++ b/lib/utils/combineJSON.js
@@ -17,7 +17,6 @@ var glob = require('glob'),
   deepExtend = require('./deepExtend'),
   extend = require('lodash/extend'),
   path = require('path'),
-  resolveCwd = require('resolve-cwd'),
   fs = require('fs');
 
 function traverseObj(obj, fn) {
@@ -51,7 +50,9 @@ function combineJSON(arr, deep, collision, source, parsers=[]) {
 
   for (i = 0; i < files.length; i++) {
     var filePath = files[i];
-    var resolvedPath = resolveCwd(path.isAbsolute(filePath) ? filePath : './' + filePath);
+    var resolvedPath = path.isAbsolute(files[i])
+      ? files[i]
+      : path.resolve(process.cwd(), files[i]);
     var file_content = null;
 
     try {

--- a/package.json
+++ b/package.json
@@ -122,7 +122,6 @@
     "glob": "^7.1.6",
     "json5": "^2.1.3",
     "lodash": "^4.17.15",
-    "resolve-cwd": "^3.0.0",
     "tinycolor2": "^1.4.1"
   },
   "devDependencies": {


### PR DESCRIPTION
*Issue #, if available:*
In order to make it possible to mock the filesystem in my tests, I would need a small change. For an explanation, see: https://github.com/amzn/style-dictionary/issues/528

*Description of changes:*
Replaced all occurences of `resolveCwd(myPath)` with `path.resolve(process.cwd(), myPath)`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
