### PR TITLE
fix(types): Change transforms to transform in Core

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -167,7 +167,7 @@ declare namespace StyleDictionary {
     allProperties: Prop[];
     options: Config;
 
-    transforms: Transforms;
+    transform: Transforms;
     transformGroup: TransformGroups;
     format: Formats;
     action: Actions;


### PR DESCRIPTION
*Description of changes:*

By looking [at the source](https://github.com/amzn/style-dictionary/blob/3.0/index.js#L37), and by accessing the default import at runtime, it seems like the `transforms` property of `Core` should be `transform`.

This PR makes that tiny fix so there are no issues when trying to access the default transforms on the default import.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
