### PR TITLE
fix(property setup): original property being mutated if the value is an object

### DIFF
--- a/__tests__/exportPlatform.test.js
+++ b/__tests__/exportPlatform.test.js
@@ -100,6 +100,32 @@ describe('exportPlatform', () => {
     expect(dictionary.color.font.link.original.value).toEqual(properties.color.font.link.value);
   });
 
+  it('should not mutate original value if value is an object', () => {
+    const dictionary = StyleDictionary.extend({
+      properties: {
+        color: {
+          red: {
+            value: {
+              h: "{hue.red}",
+              s: 50,
+              l: 50
+            }
+          }
+        },
+        hue: {
+          red: 20
+        }
+      },
+      platforms: {
+        web: {
+          transformGroup: 'web'
+        }
+      }
+    }).exportPlatform('web');
+    expect(dictionary.color.red.original.value.h).toEqual("{hue.red}");
+    expect(dictionary.color.red.value.h).toEqual(20);
+  });
+
   describe('reference warnings', () => {
     const errorMessage = `Problems were found when trying to resolve property references`;
     const platforms = {

--- a/__tests__/transform/propertySetup.test.js
+++ b/__tests__/transform/propertySetup.test.js
@@ -88,5 +88,15 @@ describe('transform', () => {
       expect(test).toHaveProperty('name', 'white');
     });
 
+    it('should handle objects', () => {
+      const test = propertySetup({
+        value: {
+          h: 20, s: 50, l: 50
+        }
+      }, 'red', ['color','red']);
+      expect(test).toHaveProperty('value.h', 20);
+      expect(test).toHaveProperty('original.value.h', 20);
+    })
+
   });
 });

--- a/lib/transform/propertySetup.js
+++ b/lib/transform/propertySetup.js
@@ -11,7 +11,8 @@
  * and limitations under the License.
  */
 
-var _ = require('lodash');
+const _ = require('lodash');
+const deepExtend = require('../utils/deepExtend');
 
 /**
  * Takes a property object, a leaf node in a properties object, and
@@ -32,14 +33,15 @@ function propertySetup(property, name, path) {
   if (!path || !_.isArray(path))
     throw new Error('Path must be an array');
 
-  let to_ret = _.clone(property);
+  let to_ret = property;
 
   // Only do this once
   if (!property.original) {
     // Initial property setup
     // Keep the original object properties like it was in file (whitout additional data)
     // so we can key off them in the transforms
-    var to_ret_original = _.clone(property);
+    to_ret = deepExtend([{}, property]);
+    let to_ret_original = deepExtend([{},property]);
     delete to_ret_original.filePath;
     delete to_ret_original.isSource;
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* In propertySetup we were using lodash's `clone` method which only performs a shallow clone of the object, so if a `value` was an object as well, the pristine `original` value was being mutated as well. This fixes that behavior. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
