### PR TITLE
fix(types): add `transitive` type

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -102,6 +102,7 @@ declare namespace StyleDictionary {
 
   interface ValueTransform {
     type: "value";
+    transitive?: boolean;
     matcher?: (prop: Prop) => boolean;
     transformer: (prop: Prop, options: Platform) => string;
   }


### PR DESCRIPTION
Adds missing type `transitive` to the `ValueTransform`.

fixes #537