### PR TITLE
change typescript types for properties to be recursive

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -16,19 +16,12 @@
 declare namespace StyleDictionary {
   interface Property {
     value: string;
+    comment?: string;
     [key: string]: any;
   }
 
   interface Properties {
-    [category: string]: {
-      [type: string]:
-        | Property
-        | {
-            [item: string]:
-              | Property
-              | { [subItem: string]: Property | { [state: string]: Property } };
-          };
-    };
+    [key: string]: Properties | Property;
   }
 
   interface Options {


### PR DESCRIPTION
Hi! This changes the typescript types so it can represent any level of nesting! PS Love Style Dictionary; thanks for all you do!

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.