### PR TITLE
chore(examples): fix output references example to use options

### DIFF
--- a/examples/advanced/variables-in-outputs/sd.config.js
+++ b/examples/advanced/variables-in-outputs/sd.config.js
@@ -1,18 +1,22 @@
 module.exports = {
   format: {
     // Adding a custom format to show how to get an alias's name.
-    customFormat: function(dictionary) {
+    customFormat: function({dictionary, options}) {
       return dictionary.allProperties.map(token => {
         let value = JSON.stringify(token.value);
-        // the `dictionary` object now has `usesReference()` and
-        // `getReference()` methods. `usesReference()` will return true if
-        // the value has a reference in it. `getReference()` will return
-        // the reference to the whole token so that you can access its
-        // name or any other attributes.
-        if (dictionary.usesReference(token.original.value)) {
-          const reference = dictionary.getReference(token.original.value);
-          value = reference.name;
+        // new option added to decide whether or not to output references
+        if (options.outputReferences) {
+          // the `dictionary` object now has `usesReference()` and
+          // `getReference()` methods. `usesReference()` will return true if
+          // the value has a reference in it. `getReference()` will return
+          // the reference to the whole token so that you can access its
+          // name or any other attributes.
+          if (dictionary.usesReference(token.original.value)) {
+            const reference = dictionary.getReference(token.original.value);
+            value = reference.name;
+          }
         }
+
         return `export const ${token.name} = ${value};`
       }).join(`\n`)
     }
@@ -32,7 +36,10 @@ module.exports = {
       transformGroup: 'js',
       files: [{
         destination: 'tokens.js',
-        format: 'customFormat'
+        format: 'customFormat',
+        options: {
+          outputReferences: true
+        }
       }]
     },
     css: {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Updating the variables-in-outputs example to use the `outputReferences` option in the custom format. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
