### PR TITLE
fix(extend): remove prototype pollution

### DIFF
--- a/__tests__/extend.test.js
+++ b/__tests__/extend.test.js
@@ -171,7 +171,7 @@ describe('extend', () => {
     var StyleDictionaryExtended = StyleDictionary.extend(__dirname + '/__configs/test.json5');
     expect(StyleDictionaryExtended).toHaveProperty('platforms.web');
   });
-  
+
   it('should allow for chained extends and not mutate the original', function() {
     var StyleDictionary1 = StyleDictionary.extend({
       foo: 'bar'
@@ -188,5 +188,14 @@ describe('extend', () => {
     expect(StyleDictionary2.foo).toBe('baz');
     expect(StyleDictionary3.foo).toBe('boo');
     expect(StyleDictionary).not.toHaveProperty('foo');
+  });
+
+  it(`should not pollute the prototype`, () => {
+    const obj = {};
+    let opts = JSON.parse('{"__proto__":{"polluted":"yes"}}');
+    console.log("Before : " + obj.polluted);
+    StyleDictionary.extend(opts);
+    console.log("After : " + obj.polluted);
+    expect(obj.polluted).toBeUndefined();
   });
 });

--- a/lib/utils/deepExtend.js
+++ b/lib/utils/deepExtend.js
@@ -44,6 +44,8 @@ function deepExtend(objects, collision, path) {
       for (name in options) {
         if (!options.hasOwnProperty(name))
           continue;
+        if (name === '__proto__')
+          continue;
 
         src = target[name];
         copy = options[name];


### PR DESCRIPTION
Issue #, if available:

Description of changes: Fixing the prototype pollution vulnerability when Style Dictionary merges objects.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.