### PR TITLE
docs(readme): fix typo in word started

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ float const SizeFontBase = 16.00f;
 
 
 ## Quick Start
-The style dictionary framework comes with some example code to get you stared. Install the node module globally, create a directory and `cd` into it.
+The style dictionary framework comes with some example code to get you started. Install the node module globally, create a directory and `cd` into it.
 ```
 $ npm i -g style-dictionary
 $ mkdir MyStyleDictionary


### PR DESCRIPTION
*Description of changes:*

Fixes a small typo in the README, where the word "started" was misspelt.