### PR TITLE
feat(formats): adding custom file headers

### DIFF
--- a/__integration__/__snapshots__/customFileHeader.test.js.snap
+++ b/__integration__/__snapshots__/customFileHeader.test.js.snap
@@ -1,0 +1,114 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`integration valid custom file headers file options config file header should match snapshot 1`] = `
+"/**
+ * Do not edit directly
+ * Generated on Sat, 01 Jan 2000 00:00:00 GMT
+ * built by Danny
+ */
+
+:root {
+  --color-red: #ff0000;
+}
+"
+`;
+
+exports[`integration valid custom file headers file options inline file header should match snapshot 1`] = `
+"/**
+ * build version 1.0.0
+ */
+
+:root {
+  --color-red: #ff0000;
+}
+"
+`;
+
+exports[`integration valid custom file headers file options registered file header should match snapshot 1`] = `
+"/**
+ * hello
+ * Do not edit directly
+ * Generated on Sat, 01 Jan 2000 00:00:00 GMT
+ */
+
+:root {
+  --color-red: #ff0000;
+}
+"
+`;
+
+exports[`integration valid custom file headers platform options file header override should match snapshot 1`] = `
+"/**
+ * Header overridden
+ */
+
+module.exports = {
+  \\"color\\": {
+    \\"red\\": {
+      \\"value\\": \\"#ff0000\\",
+      \\"original\\": {
+        \\"value\\": \\"#ff0000\\"
+      },
+      \\"name\\": \\"ColorRed\\",
+      \\"attributes\\": {
+        \\"category\\": \\"color\\",
+        \\"type\\": \\"red\\"
+      },
+      \\"path\\": [
+        \\"color\\",
+        \\"red\\"
+      ]
+    }
+  }
+};"
+`;
+
+exports[`integration valid custom file headers platform options no file options should match snapshot 1`] = `
+"/**
+ * Do not edit directly
+ * Generated on Sat, 01 Jan 2000 00:00:00 GMT
+ * built by Danny
+ */
+
+module.exports = {
+  \\"color\\": {
+    \\"red\\": {
+      \\"value\\": \\"#ff0000\\",
+      \\"original\\": {
+        \\"value\\": \\"#ff0000\\"
+      },
+      \\"name\\": \\"ColorRed\\",
+      \\"attributes\\": {
+        \\"category\\": \\"color\\",
+        \\"type\\": \\"red\\"
+      },
+      \\"path\\": [
+        \\"color\\",
+        \\"red\\"
+      ]
+    }
+  }
+};"
+`;
+
+exports[`integration valid custom file headers platform options showFileHeader should match snapshot 1`] = `
+"module.exports = {
+  \\"color\\": {
+    \\"red\\": {
+      \\"value\\": \\"#ff0000\\",
+      \\"original\\": {
+        \\"value\\": \\"#ff0000\\"
+      },
+      \\"name\\": \\"ColorRed\\",
+      \\"attributes\\": {
+        \\"category\\": \\"color\\",
+        \\"type\\": \\"red\\"
+      },
+      \\"path\\": [
+        \\"color\\",
+        \\"red\\"
+      ]
+    }
+  }
+};"
+`;

--- a/__integration__/__snapshots__/customFileHeader.test.js.snap
+++ b/__integration__/__snapshots__/customFileHeader.test.js.snap
@@ -4,7 +4,7 @@ exports[`integration valid custom file headers file options config file header s
 "/**
  * Do not edit directly
  * Generated on Sat, 01 Jan 2000 00:00:00 GMT
- * built by Danny
+ * hello, world!
  */
 
 :root {
@@ -67,7 +67,7 @@ exports[`integration valid custom file headers platform options no file options 
 "/**
  * Do not edit directly
  * Generated on Sat, 01 Jan 2000 00:00:00 GMT
- * built by Danny
+ * hello, world!
  */
 
 module.exports = {

--- a/__integration__/customFileHeader.test.js
+++ b/__integration__/customFileHeader.test.js
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+const fs = require('fs-extra');
+const StyleDictionary = require('../index');
+const {buildPath} = require('./_constants');
+
+describe(`integration`, () => {
+  describe(`valid custom file headers`, () => {
+    // Adding a custom file header with the `.registerFileHeader`
+    StyleDictionary.registerFileHeader({
+      name: `registeredFileHeader`,
+      fileHeader: (defaultMessage) => {
+        return [
+          `hello`,
+          ...defaultMessage
+        ]
+      }
+    });
+
+    StyleDictionary.extend({
+      fileHeader: {
+        configFileHeader: (defaultMessage) => {
+          return [
+            ...defaultMessage,
+            'built by Danny'
+          ];
+        }
+      },
+
+      // only testing the file header in these tests so we are
+      // using a small properties object with a single token
+      properties: {
+        color: {
+          red: { value: '#ff0000' }
+        }
+      },
+
+      platforms: {
+        css: {
+          transformGroup: `css`,
+          buildPath,
+          files: [{
+            destination: `registeredFileHeader.css`,
+            format: `css/variables`,
+            options: {
+              fileHeader: `registeredFileHeader`
+            }
+          },{
+            destination: `configFileHeader.css`,
+            format: `css/variables`,
+            options: {
+              fileHeader: `configFileHeader`
+            }
+          },{
+            destination: `inlineFileHeader.css`,
+            format: `css/variables`,
+            options: {
+              fileHeader: () => {
+                return [
+                  `build version 1.0.0`
+                ]
+              }
+            }
+          }]
+        },
+        js: {
+          transformGroup: `js`,
+          buildPath,
+          options: {
+            fileHeader: `configFileHeader`
+          },
+          files: [{
+            destination: `noOptions.js`,
+            format: `javascript/module`
+          },{
+            destination: `showFileHeader.js`,
+            format: `javascript/module`,
+            options: {
+              showFileHeader: false
+            }
+          },{
+            destination: `fileHeaderOverride.js`,
+            format: `javascript/module`,
+            options: {
+              fileHeader: () => [`Header overridden`]
+            }
+          }]
+        }
+      }
+    }).buildAllPlatforms();
+
+    describe('file options', () => {
+      it(`registered file header should match snapshot`, () => {
+        const output = fs.readFileSync(`${buildPath}registeredFileHeader.css`, {encoding:'UTF-8'});
+        expect(output).toMatchSnapshot();
+      });
+
+      it(`config file header should match snapshot`, () => {
+        const output = fs.readFileSync(`${buildPath}configFileHeader.css`, {encoding:'UTF-8'});
+        expect(output).toMatchSnapshot();
+      });
+
+      it(`inline file header should match snapshot`, () => {
+        const output = fs.readFileSync(`${buildPath}inlineFileHeader.css`, {encoding:'UTF-8'});
+        expect(output).toMatchSnapshot();
+      });
+    });
+
+    describe('platform options', () => {
+      it(`no file options should match snapshot`, () => {
+        const output = fs.readFileSync(`${buildPath}noOptions.js`, {encoding:'UTF-8'});
+        expect(output).toMatchSnapshot();
+      });
+
+      it(`showFileHeader should match snapshot`, () => {
+        const output = fs.readFileSync(`${buildPath}showFileHeader.js`, {encoding:'UTF-8'});
+        expect(output).toMatchSnapshot();
+      });
+
+      it(`file header override should match snapshot`, () => {
+        const output = fs.readFileSync(`${buildPath}fileHeaderOverride.js`, {encoding:'UTF-8'});
+        expect(output).toMatchSnapshot();
+      });
+    });
+  });
+  describe(`invalid custom file headers`, () => {
+    it(`should throw if trying to use an undefined file header`, () => {
+      expect(() => {
+        StyleDictionary.extend({
+          platforms: {
+            css: {
+              buildPath,
+              files: [{
+                destination: `variables.css`,
+                options: {
+                  fileHeader: `nonexistentFileHeader`
+                }
+              }]
+            }
+          }
+        }).buildAllPlatforms();
+      }).toThrow(`Can't find fileHeader: nonexistentFileHeader`);
+    });
+  });
+});

--- a/__integration__/customFileHeader.test.js
+++ b/__integration__/customFileHeader.test.js
@@ -33,7 +33,7 @@ describe(`integration`, () => {
         configFileHeader: (defaultMessage) => {
           return [
             ...defaultMessage,
-            'built by Danny'
+            'hello, world!'
           ];
         }
       },

--- a/__tests__/register/fileHeader.test.js
+++ b/__tests__/register/fileHeader.test.js
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+var StyleDictionary = require('../../index');
+var StyleDictionaryExtended = StyleDictionary.extend({});
+
+describe('register', () => {
+  describe('fileHeader', () => {
+
+    it('should error if name is not a string', () => {
+      expect(
+        StyleDictionaryExtended.registerFileHeader.bind(null, {
+          fileHeader: function () {}
+        })
+      ).toThrow('name must be a string');
+
+      expect(
+        StyleDictionaryExtended.registerFileHeader.bind(null, {
+          name: 1,
+          fileHeader: function () {}
+        })
+      ).toThrow('name must be a string');
+
+      expect(
+        StyleDictionaryExtended.registerFileHeader.bind(null, {
+          name: [],
+          fileHeader: function () {}
+        })
+      ).toThrow('name must be a string');
+
+      expect(
+        StyleDictionaryExtended.registerFilter.bind(null, {
+          name: {},
+          matcher: function () {}
+        })
+      ).toThrow('name must be a string');
+    });
+
+    it('should error if fileHeader is not a function', () => {
+      expect(
+        StyleDictionaryExtended.registerFileHeader.bind(null, {
+          name: 'myCustomHeader'
+        })
+      ).toThrow('fileHeader must be a function');
+
+      expect(
+        StyleDictionaryExtended.registerFileHeader.bind(null, {
+          name: 'myCustomHeader',
+          fileHeader: 1
+        })
+      ).toThrow('fileHeader must be a function');
+
+      expect(
+        StyleDictionaryExtended.registerFileHeader.bind(null, {
+          name: 'myCustomHeader',
+          fileHeader: 'name'
+        })
+      ).toThrow('fileHeader must be a function');
+
+      expect(
+        StyleDictionaryExtended.registerFileHeader.bind(null, {
+          name: 'myCustomHeader',
+          fileHeader: []
+        })
+      ).toThrow('fileHeader must be a function');
+
+      expect(
+        StyleDictionaryExtended.registerFileHeader.bind(null, {
+          name: 'myCustomHeader',
+          fileHeader: {}
+        })
+      ).toThrow('fileHeader must be a function');
+    });
+
+    it('should work if name and matcher are good', () => {
+      StyleDictionaryExtended.registerFileHeader({
+        name: 'myCustomHeader',
+        fileHeader: function() {}
+      });
+      expect(typeof StyleDictionaryExtended.fileHeader['myCustomHeader']).toBe('function');
+    });
+
+    it('should properly pass the registered fileHeader to instances', () => {
+      var SDE2 = StyleDictionaryExtended.extend({});
+      expect(typeof SDE2.fileHeader['myCustomHeader']).toBe('function');
+    });
+
+  });
+});

--- a/docs/api.md
+++ b/docs/api.md
@@ -193,7 +193,7 @@ formats to display some information about how the file was built in a comment.
 | --- | --- | --- |
 | options | <code>Object</code> |  |
 | options.name | <code>String</code> | Name of the format to be referenced in your config.json |
-| options.fileHeader | <code>function</code> | Function that returns an array of strings, which will be mapped to comment lines. Takes a single which is the default message array. See [file headers](formats.md#file-headers) for more information. |
+| options.fileHeader | <code>function</code> | Function that returns an array of strings, which will be mapped to comment lines. It takes a single argument which is the default message array. See [file headers](formats.md#file-headers) for more information. |
 
 **Example**  
 ```js
@@ -202,7 +202,7 @@ StyleDictionary.registerFileHeader({
   fileHeader: function(defaultMessage) {
     return [
       ...defaultMessage,
-      `built by Charles`
+      `hello, world!`
     ];
   }
 })

--- a/docs/api.md
+++ b/docs/api.md
@@ -179,6 +179,37 @@ StyleDictionary.registerAction({
 
 * * *
 
+### registerFileHeader 
+> StyleDictionary.registerFileHeader(options) ⇒ [<code>style-dictionary</code>](#module_style-dictionary)
+
+
+
+
+Add a custom file header to the style dictionary. File headers are used in
+formats to display some information about how the file was built in a comment.
+
+
+| Param | Type | Description |
+| --- | --- | --- |
+| options | <code>Object</code> |  |
+| options.name | <code>String</code> | Name of the format to be referenced in your config.json |
+| options.fileHeader | <code>function</code> | Function that returns an array of strings, which will be mapped to comment lines. Takes a single which is the default message array. See [file headers](formats.md#file-headers) for more information. |
+
+**Example**  
+```js
+StyleDictionary.registerFileHeader({
+  name: 'myCustomHeader',
+  fileHeader: function(defaultMessage) {
+    return [
+      ...defaultMessage,
+      `built by Charles`
+    ];
+  }
+})
+```
+
+* * *
+
 ### registerFilter 
 > StyleDictionary.registerFilter(filter) ⇒ [<code>style-dictionary</code>](#module_style-dictionary)
 

--- a/docs/formats.md
+++ b/docs/formats.md
@@ -372,8 +372,8 @@ default file header.
 ```js
 StyleDictionary.registerFormat({
   name: 'myCustomFormat',
-  formatter: function({ dictionary, options }) {
-    return fileHeader(true, 'short') +
+  formatter: function({ dictionary, file }) {
+    return fileHeader(file, 'short') +
       dictionary.allProperties.map(token => `${token.name} = ${token.value}`);
   }
 });

--- a/examples/advanced/custom-file-header/build.js
+++ b/examples/advanced/custom-file-header/build.js
@@ -1,0 +1,120 @@
+const crypto = require('crypto');
+const StyleDictionary = require('style-dictionary');
+const version = require('./package.json').version;
+
+// You can use the `fileHeader` format helper function
+// This function will use any custom file headers or the default
+// file header
+const {fileHeader} = StyleDictionary.formatHelpers;
+
+const myCustomFormat = ({ dictionary, file }) => {
+  return `${fileHeader(file, 'short')}${dictionary.allProperties.map(token => {
+    return `$${token.name}: ${token.value};`
+  }).join(`\n`)}`
+}
+
+const styleDictionary = StyleDictionary.extend({
+  // You can add custom file headers directly on the configuration by
+  // adding a `fileHeader` object. The keys inside are the names of
+  // the file headers
+  fileHeader: {
+    // defaultMessage is the built-in file header message:
+    // Do not edit directly
+    // Generated on Sat, 01 Jan 2000 00:00:00 GMT
+    myFileHeader: (defaultMessage) => {
+      // A file header function is expected to return an array of strings.
+      // This array will be mapped to the proper comment style for a given format.
+      // For example, Android XML formats use XML comments: <!-- -->,
+      // whereas other languages have short and long style comments, // and /* */
+      return [
+        ...defaultMessage,
+        'built by Danny'
+      ];
+    }
+  },
+
+  format: {
+    myCustomFormat
+  },
+
+  source: [`tokens/**/*.json`],
+
+  platforms: {
+    css: {
+      transformGroup: `css`,
+      buildPath: `build/`,
+      files: [{
+        destination: `variables.css`,
+        format: `css/variables`,
+        options: {
+          // You can now reference a custom file header in a file's options.
+          fileHeader: `myFileHeader`
+        }
+      },{
+        destination: `variables.scss`,
+        format: `myCustomFormat`,
+        options: {
+          fileHeader: `myFileHeader`
+        }
+      },{
+        destination: `variables2.css`,
+        format: `css/variables`,
+        options: {
+          // You can also directly pass a function to the `fileHeader` option:
+          fileHeader: () => {
+            return [
+              `build version ${version}`
+            ]
+          }
+        }
+      }]
+    },
+    js: {
+      transformGroup: `js`,
+      buildPath: `build/`,
+      // You can also add a header at the platform level.
+      // Platform-level options cascade down to files.
+      options: {
+        fileHeader: `customFileHeader`
+      },
+      files: [{
+        destination: `colors.js`,
+        format: `javascript/es6`
+      },{
+        destination: `colors2.js`,
+        format: `javascript/es6`,
+        // This file won't get the custom header because it defines the
+        // showFileHeader option to false
+        options: {
+          showFileHeader: false
+        }
+      },{
+        destination: `colors3.js`,
+        format: `javascript/es6`,
+        // This file will use the custom header defined here because the file's
+        // options take precedence over the platform's options.
+        options: {
+          fileHeader: () => [`Header overridden`]
+        }
+      }]
+    }
+  }
+});
+
+// Create a hash of style dictionary properties object to use in a file header
+const hash = crypto.createHash('md5')
+  .update(JSON.stringify(styleDictionary.properties))
+  .digest('hex');
+
+// Adding a custom file header with the `.registerFileHeader`
+styleDictionary.registerFileHeader({
+  name: `customFileHeader`,
+  fileHeader: () => {
+    return [
+      `Do not edit directly`,
+      `build hash ${hash}`
+    ]
+  }
+});
+
+styleDictionary.buildAllPlatforms();

--- a/examples/advanced/custom-file-header/build.js
+++ b/examples/advanced/custom-file-header/build.js
@@ -9,7 +9,7 @@ const {fileHeader} = StyleDictionary.formatHelpers;
 
 const myCustomFormat = ({ dictionary, file }) => {
   return `${fileHeader(file, 'short')}${dictionary.allProperties.map(token => {
-    return `$${token.name}: ${token.value};`
+    return `--${token.name}: ${token.value};`
   }).join(`\n`)}`
 }
 
@@ -28,7 +28,7 @@ const styleDictionary = StyleDictionary.extend({
       // whereas other languages have short and long style comments, // and /* */
       return [
         ...defaultMessage,
-        'built by Danny'
+        'hello, world!'
       ];
     }
   },
@@ -51,7 +51,7 @@ const styleDictionary = StyleDictionary.extend({
           fileHeader: `myFileHeader`
         }
       },{
-        destination: `variables.scss`,
+        destination: `variables1.css`,
         format: `myCustomFormat`,
         options: {
           fileHeader: `myFileHeader`

--- a/examples/advanced/custom-file-header/package-lock.json
+++ b/examples/advanced/custom-file-header/package-lock.json
@@ -1,0 +1,225 @@
+{
+  "name": "custom-file-header",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^2.0.1"
+      }
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "chalk": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+      "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      }
+    },
+    "color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "requires": {
+        "color-name": "~1.1.4"
+      }
+    },
+    "color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "commander": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
+      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
+      "dev": true
+    },
+    "has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "json5": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
+      "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.5"
+      }
+    },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "dev": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "style-dictionary": {
+      "version": "3.0.0-rc.6",
+      "resolved": "https://registry.npmjs.org/style-dictionary/-/style-dictionary-3.0.0-rc.6.tgz",
+      "integrity": "sha512-EI0B3n9NnL/dmMWSSg18/CEqCamG9/fxYetS0kvBDfuSkXxDuBEwLfta1+GvSKF8b+/01WweITrazaUS991VIQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.0.0",
+        "commander": "^5.1.0",
+        "fs-extra": "^8.1.0",
+        "glob": "^7.1.6",
+        "json5": "^2.1.3",
+        "lodash": "^4.17.15",
+        "tinycolor2": "^1.4.1"
+      }
+    },
+    "supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^4.0.0"
+      }
+    },
+    "tinycolor2": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.2.tgz",
+      "integrity": "sha512-vJhccZPs965sV/L2sU4oRQVAos0pQXwsvTLkWYdqJ+a8Q5kPFzJTuOFwy7UniPli44NKQGAglksjvOcpo95aZA==",
+      "dev": true
+    },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    }
+  }
+}

--- a/examples/advanced/custom-file-header/package.json
+++ b/examples/advanced/custom-file-header/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "custom-file-header",
+  "version": "1.0.0",
+  "description": "",
+  "main": "sd.config.js",
+  "scripts": {
+    "build": "node build.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "style-dictionary": "^3.0.0-rc.6"
+  }
+}

--- a/examples/advanced/custom-file-header/tokens/color.json
+++ b/examples/advanced/custom-file-header/tokens/color.json
@@ -1,0 +1,9 @@
+{
+  "color": {
+    "core": {
+      "red": { "value": "#ff0000" },
+      "blue": { "value": "#00ff00" },
+      "green": { "value": "#0000ff" }
+    }
+  }
+}

--- a/index.js
+++ b/index.js
@@ -41,6 +41,7 @@ var StyleDictionary = {
   formatHelpers: require('./lib/common/formatHelpers'),
   filter: {}, // we need to initialise the object, since we don't have built-in filters
   parsers: [], // ditto ^
+  fileHeader: {},
 
   registerTransform: require('./lib/register/transform'),
   registerTransformGroup: require('./lib/register/transformGroup'),
@@ -49,6 +50,7 @@ var StyleDictionary = {
   registerAction: require('./lib/register/action'),
   registerFilter: require('./lib/register/filter'),
   registerParser: require('./lib/register/parser'),
+  registerFileHeader: require('./lib/register/fileHeader'),
 
   exportPlatform: require('./lib/exportPlatform'),
   buildPlatform: require('./lib/buildPlatform'),

--- a/lib/common/formatHelpers.js
+++ b/lib/common/formatHelpers.js
@@ -17,41 +17,69 @@
  * @module formatHelpers
  */
 
+// no-op default
+const defaultFileHeader = (arr) => arr
+
 /**
  *
  * This is for creating the comment at the top of generated files with the generated at date.
+ * It will use the custom file header if defined on the configuration, or use the
+ * default file header.
  * @memberof module:formatHelpers
- * @param {Boolean} showFileHeader - Whether or not to show the file header. If false will return an empty string.
- * @param {String} commentStyle - The only option is 'short', which will use the // style comments. Anything else will use \/\* style comments.
+ * @param {File} file - The file object that is passed to the formatter.
+ * @param {String} commentStyle - The only options are 'short' and 'xml', which will use the // or \<!-- --> style comments respectively. Anything else will use \/\* style comments.
  * @returns {String}
  * @example
  * ```js
  * StyleDictionary.registerFormat({
  *   name: 'myCustomFormat',
- *   formatter: function({ dictionary, options }) {
- *     return fileHeader(true, 'short') +
+ *   formatter: function({ dictionary, file }) {
+ *     return fileHeader(file, 'short') +
  *       dictionary.allProperties.map(token => `${token.name} = ${token.value}`);
  *   }
  * });
  * ```
  */
-function fileHeader(showFileHeader = true, commentStyle) {
-  var to_ret = '';
+function fileHeader(file, commentStyle) {
+  // showFileHeader is true by default
+  let showFileHeader = true;
+  if (file.options && typeof file.options.showFileHeader !== 'undefined') {
+    showFileHeader = file.options.showFileHeader;
+  }
+
+  // Return empty string if the showFileHeader is false
+  if (!showFileHeader) return '';
+
+  let fn = defaultFileHeader;
+  if (file.options && typeof file.options.fileHeader === 'function') {
+    fn = file.options.fileHeader;
+  }
+
+  // default header
+  const defaultHeader = [
+    `Do not edit directly`,
+    `Generated on ${new Date().toUTCString()}`
+  ];
+  let commentPrefix, commentHeader, commentFooter;
   if (showFileHeader) {
     if (commentStyle === 'short') {
-      to_ret += '\n';
-      to_ret += '// Do not edit directly\n';
-      to_ret += '// Generated on ' + new Date().toUTCString() + '\n';
-      to_ret += '\n';
+      commentPrefix = '// ';
+      commentHeader = '\n';
+      commentFooter = '\n\n';
+    } else if (commentStyle === 'xml') {
+      commentPrefix = ' ';
+      commentHeader = '<!--\n';
+      commentFooter = '\n-->\n';
     } else {
-      to_ret += '/**\n';
-      to_ret += ' * Do not edit directly\n';
-      to_ret += ' * Generated on ' + new Date().toUTCString() + '\n';
-      to_ret += ' */\n\n';
+      commentPrefix = ' * ';
+      commentHeader = '/**\n';
+      commentFooter = '\n */\n\n';
     }
   }
 
-  return to_ret;
+  return `${commentHeader}${fn(defaultHeader)
+    .map(line => `${commentPrefix}${line}`)
+    .join('\n')}${commentFooter}`;
 }
 
 /**

--- a/lib/common/formats.js
+++ b/lib/common/formats.js
@@ -39,8 +39,8 @@ module.exports = {
    * }
    * ```
    */
-  'css/variables': function({dictionary, options}) {
-    return fileHeader(options.showFileHeader) +
+  'css/variables': function({dictionary, options, file}) {
+    return fileHeader(file) +
       ':root {\n' +
       formattedVariables('css', dictionary, options.outputReferences) +
       '\n}\n';
@@ -128,8 +128,8 @@ module.exports = {
    * $color-background-alt: #eeeeee !default;
    * ```
    */
-  'scss/variables': function({dictionary, options}) {
-    return fileHeader(options.showFileHeader, 'short') +
+  'scss/variables': function({dictionary, options, file}) {
+    return fileHeader(file, 'short') +
       formattedVariables('sass', dictionary, options.outputReferences);
   },
 
@@ -144,8 +144,8 @@ module.exports = {
    * .icon.email:before { content:$content-icon-email; }
    * ```
    */
-  'scss/icons': function({dictionary, options}) {
-    return fileHeader(options.showFileHeader, 'short') + iconsWithPrefix('$', dictionary.allProperties, options);
+  'scss/icons': function({dictionary, options, file}) {
+    return fileHeader(file, 'short') + iconsWithPrefix('$', dictionary.allProperties, options);
   },
 
   /**
@@ -162,8 +162,8 @@ module.exports = {
    * \@color-background-alt: #eeeeee;
    * ```
    */
-  'less/variables': function({dictionary, options}) {
-    return fileHeader(options.showFileHeader, 'short') +
+  'less/variables': function({dictionary, options, file}) {
+    return fileHeader(file, 'short') +
       formattedVariables('less', dictionary, options.outputReferences);
   },
 
@@ -178,8 +178,8 @@ module.exports = {
    * .icon.email:before { content:\@content-icon-email; }
    * ```
    */
-  'less/icons': function({dictionary, options}) {
-    return fileHeader(options.showFileHeader, 'short') + iconsWithPrefix('@', dictionary.allProperties, options);
+  'less/icons': function({dictionary, options, file}) {
+    return fileHeader(file, 'short') + iconsWithPrefix('@', dictionary.allProperties, options);
   },
 
   /**
@@ -193,8 +193,8 @@ module.exports = {
    * $color-background-alt= #eeeeee;
    * ```
    */
-  'stylus/variables': function({dictionary, options}) {
-    return fileHeader(options.showFileHeader, 'short') +
+  'stylus/variables': function({dictionary, options, file}) {
+    return fileHeader(file, 'short') +
       formattedVariables('stylus', dictionary, options.outputReferences);
   },
 
@@ -216,8 +216,8 @@ module.exports = {
    * }
    * ```
    */
-  'javascript/module': function({dictionary, options}) {
-    return fileHeader(options) +
+  'javascript/module': function({dictionary, file}) {
+    return fileHeader(file) +
     'module.exports = ' +
       JSON.stringify(dictionary.properties, null, 2) + ';';
   },
@@ -234,8 +234,8 @@ module.exports = {
    *}
    *```
    */
-  'javascript/module-flat': function({dictionary}) {
-    return fileHeader(this.options) +
+  'javascript/module-flat': function({dictionary, file}) {
+    return fileHeader(file) +
       'module.exports = ' +
         module.exports['json/flat']({dictionary}) + ';';
   },
@@ -259,8 +259,8 @@ module.exports = {
    * }
    * ```
    */
-  'javascript/object': function({dictionary, options, file}) {
-    return  fileHeader(options) +
+  'javascript/object': function({dictionary, file}) {
+    return  fileHeader(file) +
       'var ' +
       (file.name || '_styleDictionary') +
       ' = ' +
@@ -298,9 +298,9 @@ module.exports = {
    * }))
    * ```
    */
-  'javascript/umd': function({dictionary, options, file}) {
+  'javascript/umd': function({dictionary, file}) {
     var name = file.name || '_styleDictionary'
-    return fileHeader(options) +
+    return fileHeader(file) +
       '(function(root, factory) {\n' +
       '  if (typeof module === "object" && module.exports) {\n' +
       '    module.exports = factory();\n' +
@@ -348,8 +348,8 @@ module.exports = {
    * export const ColorBackgroundAlt = '#fcfcfcfc';
    * ```
    */
-  'javascript/es6': function({dictionary, options}) {
-    return fileHeader(options) +
+  'javascript/es6': function({dictionary, file}) {
+    return fileHeader(file) +
       dictionary.allProperties.map(function(prop) {
         var to_ret_prop = 'export const ' + prop.name + ' = ' + JSON.stringify(prop.value) + ';';
         if (prop.comment)

--- a/lib/register/fileHeader.js
+++ b/lib/register/fileHeader.js
@@ -18,7 +18,7 @@
  * @memberof module:style-dictionary
  * @param {Object} options
  * @param {String} options.name - Name of the format to be referenced in your config.json
- * @param {function} options.fileHeader - Function that returns an array of strings, which will be mapped to comment lines. Takes a single which is the default message array. See [file headers](formats.md#file-headers) for more information.
+ * @param {function} options.fileHeader - Function that returns an array of strings, which will be mapped to comment lines. It takes a single argument which is the default message array. See [file headers](formats.md#file-headers) for more information.
  * @returns {module:style-dictionary}
  * @example
  * ```js
@@ -27,7 +27,7 @@
  *   fileHeader: function(defaultMessage) {
  *     return [
  *       ...defaultMessage,
- *       `built by Charles`
+ *       `hello, world!`
  *     ];
  *   }
  * })

--- a/lib/register/fileHeader.js
+++ b/lib/register/fileHeader.js
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+/**
+ * Add a custom file header to the style dictionary. File headers are used in
+ * formats to display some information about how the file was built in a comment.
+ * @static
+ * @memberof module:style-dictionary
+ * @param {Object} options
+ * @param {String} options.name - Name of the format to be referenced in your config.json
+ * @param {function} options.fileHeader - Function that returns an array of strings, which will be mapped to comment lines. Takes a single which is the default message array. See [file headers](formats.md#file-headers) for more information.
+ * @returns {module:style-dictionary}
+ * @example
+ * ```js
+ * StyleDictionary.registerFileHeader({
+ *   name: 'myCustomHeader',
+ *   fileHeader: function(defaultMessage) {
+ *     return [
+ *       ...defaultMessage,
+ *       `built by Charles`
+ *     ];
+ *   }
+ * })
+ * ```
+ */
+
+function registerFileHeader(options) {
+  if (typeof options.name !== 'string')
+    throw new Error('Can\'t register file header; options.name must be a string');
+  if (typeof options.fileHeader !== 'function')
+    throw new Error('Can\'t register file header; options.fileHeader must be a function');
+
+  this.fileHeader[options.name] = options.fileHeader;
+
+  return this;
+}
+
+module.exports = registerFileHeader;

--- a/lib/transform/config.js
+++ b/lib/transform/config.js
@@ -12,6 +12,7 @@
  */
 
 var _     = require('lodash'),
+    deepExtend = require('../utils/deepExtend'),
     GroupMessages = require('../utils/groupMessages');
 
 var TEMPLATE_DEPRECATION_WARNINGS = GroupMessages.GROUP.TemplateDeprecationWarnings;
@@ -84,8 +85,39 @@ None of ${transform_warnings} match the name of a registered transform.
     throw new Error(err);
   }
 
+  // Apply registered fileHeaders onto the platform options
+  if (config.options && config.options.fileHeader) {
+    const fileHeader = config.options.fileHeader;
+    if (typeof fileHeader === 'string') {
+      if (dictionary.fileHeader[fileHeader]) {
+        to_ret.options.fileHeader = dictionary.fileHeader[fileHeader];
+      } else {
+        throw new Error(`Can't find fileHeader: ${fileHeader}`);
+      }
+    } else if (typeof fileHeader !== 'function') {
+      throw new Error(`fileHeader must be a string or a function`)
+    } else {
+      to_ret.options.fileHeader = fileHeader;
+    }
+  }
+
   to_ret.files = (config.files || []).map(function(file) {
-    const ext = {};
+    const ext = { options: {} };
+    if (file.options && file.options.fileHeader) {
+      const fileHeader = file.options.fileHeader;
+      if (typeof fileHeader === 'string') {
+        if (dictionary.fileHeader[fileHeader]) {
+          ext.options.fileHeader = dictionary.fileHeader[fileHeader];
+        } else {
+          throw new Error(`Can't find fileHeader: ${fileHeader}`);
+        }
+      } else if (typeof fileHeader !== 'function') {
+        throw new Error(`fileHeader must be a string or a function`)
+      } else {
+        ext.options.fileHeader = fileHeader;
+      }
+    }
+
     if (file.filter) {
       if(typeof file.filter === 'string') {
         if (dictionary.filter[file.filter]) {
@@ -101,6 +133,7 @@ None of ${transform_warnings} match the name of a registered transform.
         throw new Error('Filter format not valid: ' + typeof file.filter);
       }
     }
+
     if (file.template) {
       if (dictionary.format[file.template]) {
         GroupMessages.add(
@@ -120,7 +153,7 @@ None of ${transform_warnings} match the name of a registered transform.
     } else {
       throw new Error('Please supply a format for file: ' + JSON.stringify(file));
     }
-    return _.extend({}, file, ext);
+    return deepExtend([{}, file, ext]);
   });
 
   to_ret.actions = (config.actions || []).map(function(action) {

--- a/scripts/handlebars/templates/formats.hbs
+++ b/scripts/handlebars/templates/formats.hbs
@@ -139,6 +139,71 @@ Not all formats use the `outputReferences` option because that file format might
 
 You can create custom formats that output references as well. See the [Custom format with output references](#custom-format-with-output-references) section.
 
+## File headers
+
+By default Style Dictionary adds a file header comment in the top of files built using built-in formats like this:
+
+```js
+// Do not edit directly
+// Generated on Sat, 01 Jan 2000 00:00:00 GMT
+```
+
+You can remove these comments with the option: `showFileHeader: false` if you do not want them in your generated files. You can also create your own file header or extend the default one. This could be useful if you want to put a version number or hash of the source files rather than a timestamp.
+
+Custom file headers can be added the same way you would add a custom format, either by using the [`registerFileHeader`](api.md#registerfileheader) function or adding the fileHeader object directly in the Style Dictionary [configuration](config.md). Your custom file header can be used in built-in formats as well as custom formats. To use a custom file header in a custom format see the [`fileHeader`](formats.md#fileheader) format helper method.
+
+```js
+const StyleDictionary = require('style-dictionary');
+StyleDictionary.registerFileHeader({
+  name: 'myCustomHeader',
+  fileHeader: (defaultMessage) => {
+    // defaultMessage are the 2 lines above that appear in the default file header
+    // you can use this to add a message before or after the default message 👇
+
+    // the fileHeader function should return an array of strings
+    // which will be formatted in the proper comment style for a given format
+    return [
+      ...defaultMessage,
+      `hello?`,
+      `is it me you're looking for?`,
+    ]
+  }
+});
+```
+
+Then you can use your custom file header in a file similar to a custom format:
+
+```json5
+{
+  source: ['tokens/**/*.json'],
+  platforms: {
+    css: {
+      transformGroup: 'css',
+      files: [{
+        destination: 'variables.css',
+        format: 'css/variables',
+        options: {
+          fileHeader: 'myCustomHeader'
+        }
+      }]
+    }
+  }
+}
+```
+
+Which should output a file that will start like this:
+
+```css
+/**
+ * Do not edit directly
+ * Generated on Thu, 18 Mar 2021 21:30:47 GMT
+ * hello?
+ * is it me you're looking for?
+ */
+```
+
+For an in-depth example see the [custom-file-header](https://github.com/amzn/style-dictionary/examples/advanced/custom-file-header) example.
+
 ## Custom formats
 
 You can create custom formats using the [`registerFormat`](api.md#registerformat) function or by directly including them in your [configuration](config.md). A format has a name and a formatter function, which takes an object as the argument and should return a string which is then written to a file.
@@ -214,8 +279,8 @@ const { fileHeader, formattedVariables } = StyleDictionary.formatHelpers;
 
 StyleDictionary.registerFormat({
   name: 'myCustomFormat',
-  formatter: function({dictionary, options}) {
-    return fileHeader(options.showFileHeader) +
+  formatter: function({dictionary, file, options}) {
+    return fileHeader(file) +
       ':root {\n' +
       formattedVariables('css', dictionary, options.outputReferences) +
       '\n}\n';


### PR DESCRIPTION
*Issue #, if available:* #566

*Description of changes:* Adding custom file headers to output files. You can add custom file headers with a register method, `.registerFileHeader` or directly on the Style Dictionary configuration, similar to custom formats. Custom file headers can be used in custom formats as well with the `StyleDictionary.formatHelpers.fileHeader()` method.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
