### PR TITLE
docs(readme): fix a couple of small typos

### DIFF
--- a/examples/advanced/custom-transforms/README.md
+++ b/examples/advanced/custom-transforms/README.md
@@ -9,7 +9,7 @@ Transforms are functions that transform a property (in a non-destructive way). T
 The need for custom transforms is that Style Dictionary expects the properties to be declared according to certain criteria, to use the pre-defined transforms and formats/templates. For example, the *web* transformGroup consists of the *attribute/cti*, *name/cti/kebab*, *size/px* and *color/css* transforms.
 The *size/px* adds 'px' to the end of the number, and is applied only if `prop.attributes.category === 'size'`. This means that your property needs to be expressed without units, and be under the *'size'* "category. If you need a different logic or you want to organise your properties differently, probably you can't use the out-of-the-box transformation groups, but you have to declare your custom ones.
 
-If [custom formats](../custom-formats-with-templates/) are the way to allow users to customise the format of the *output* of Style Dictionary, custom transforms are the way to allow them to customise both the *input* (the property names/values/attributes) and the *output* (the actual values expressed in the design tokens). For this reasons, custom transforms are probably one of the **most powerful features** of Style Dictionary: they make it extremely versatile, allowing limitless possibilities of extension and customisation of the entire pipeline from properties to design tokens.
+If [custom formats](../custom-formats-with-templates/) are the way to allow users to customise the format of the *output* of Style Dictionary, custom transforms are the way to allow them to customise both the *input* (the property names/values/attributes) and the *output* (the actual values expressed in the design tokens). For these reasons, custom transforms are probably one of the **most powerful features** of Style Dictionary: they make it extremely versatile, allowing limitless possibilities of extension and customisation of the entire pipeline from properties to design tokens.
 
 #### Running the example
 
@@ -73,9 +73,9 @@ in your code and look the array of transforms associated with the it, directly i
 
 #### What to look at
 
-Open the `config.js` file and see how for each platform there is a `transformGroup` declaration. In this specific example, all the transformGroups applied to the platforms are custom.
+Open the `config.json` file and see how for each platform there is a `transformGroup` declaration. In this specific example, all the transformGroups applied to the platforms are custom.
 
-Now open a property file (eg. `colors/font/spacing.json`) to see how we have associated custom attributes to the properties, to be used later in the matchers functions. See also how the values are unitless, where the units are applied at build time accordingly to the destination platform. Compare the values in the input JSON files, and the values that appear in the files generated in `build`, and you will see where and how the transformations have been applied.
+Now open a property file (eg. `colors|font|spacing.json`) to see how we have associated custom attributes to the properties, to be used later in the matcher functions. See also how the values are unitless, where the units are applied at build time accordingly to the destination platform. Compare the values in the input JSON files, and the values that appear in the files generated in `build`, and you will see where and how the transformations have been applied.
 
 Now open the `build.js` script and look at how these custom transforms/transformGroups are declared and registered via the `registerTransform` and `registerTransform` API methods. We have added as many comments as possible to make the code clear and show the interesting parts of it.
 


### PR DESCRIPTION
*Description of changes:*
Fixed a couple of typos in the README for the custom transform advanced example.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
