### PR TITLE
fix(combine): filePath was missing for falsey values

### DIFF
--- a/__tests__/__properties/paddings.json
+++ b/__tests__/__properties/paddings.json
@@ -1,6 +1,9 @@
 {
   "size": {
     "padding": {
+      "zero": {
+        "value": 0
+      },
       "tiny": {
         "value": "3"
       },

--- a/__tests__/extend.test.js
+++ b/__tests__/extend.test.js
@@ -89,7 +89,7 @@ describe('extend', () => {
       });
       var output = helpers.fileToJSON(__dirname + "/__properties/paddings.json");
       traverseObj(output, (obj) => {
-        if (obj.value && !obj.filePath) {
+        if (obj.hasOwnProperty('value') && !obj.filePath) {
           obj.filePath = __dirname + "/__properties/paddings.json";
           obj.isSource = false;
         }
@@ -104,7 +104,7 @@ describe('extend', () => {
       });
       var output = helpers.fileToJSON(__dirname + "/__properties/paddings.json");
       traverseObj(output, (obj) => {
-        if (obj.value && !obj.filePath) {
+        if (obj.hasOwnProperty('value') && !obj.filePath) {
           obj.filePath = __dirname + "/__properties/paddings.json";
           obj.isSource = false;
         }
@@ -148,7 +148,7 @@ describe('extend', () => {
       });
       var output = helpers.fileToJSON(__dirname + "/__properties/paddings.json");
       traverseObj(output, (obj) => {
-        if (obj.value && !obj.filePath) {
+        if (obj.hasOwnProperty('value') && !obj.filePath) {
           obj.filePath = __dirname + "/__properties/paddings.json";
           obj.isSource = true;
         }
@@ -163,7 +163,7 @@ describe('extend', () => {
       });
       var output = helpers.fileToJSON(__dirname + "/__properties/paddings.json");
       traverseObj(output, (obj) => {
-        if (obj.value && !obj.filePath) {
+        if (obj.hasOwnProperty('value') && !obj.filePath) {
           obj.filePath = filePath;
           obj.isSource = true;
         }
@@ -178,7 +178,7 @@ describe('extend', () => {
       });
       var output = helpers.fileToJSON(__dirname + "/__properties/paddings.json");
       traverseObj(output, (obj) => {
-        if (obj.value && !obj.filePath) {
+        if (obj.hasOwnProperty('value') && !obj.filePath) {
           obj.filePath = __dirname + "/__properties/paddings.json";
           obj.isSource = true;
         }
@@ -197,7 +197,7 @@ describe('extend', () => {
     });
     var output = helpers.fileToJSON(__dirname + "/__properties/paddings.json");
     traverseObj(output, (obj) => {
-      if (obj.value && !obj.filePath) {
+      if (obj.hasOwnProperty('value') && !obj.filePath) {
         obj.filePath = __dirname + "/__properties/paddings.json";
         obj.isSource = true;
       }

--- a/lib/utils/combineJSON.js
+++ b/lib/utils/combineJSON.js
@@ -80,7 +80,7 @@ function combineJSON(arr, deep, collision, source, parsers=[]) {
 
     // Add some side data on each property to make filtering easier
     traverseObj(file_content, (obj) => {
-      if (obj.value && !obj.filePath) {
+      if (obj.hasOwnProperty('value') && !obj.filePath) {
         obj.filePath = filePath;
 
         obj.isSource = source || source === undefined ? true : false;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* When merging source token files we were doing a simple truthy check for `.value` which does not work if given something like `0`. Now we are checking if the token `.hasOwnProperty('value')` instead which will return true for any value. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
