### PR TITLE
fix(template): remove blank lines in scss/map-deep and scss/map-flat templates

### DIFF
--- a/lib/common/templates/scss/map-deep.template
+++ b/lib/common/templates/scss/map-deep.template
@@ -13,19 +13,16 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-%>
-<%
+%><%
     // for backward compatibility we need to have the user explicitly hide it
     var showFileHeader = (this.options && this.options.hasOwnProperty('showFileHeader')) ? this.options.showFileHeader : true;
     if(showFileHeader) {
         var header = '';
-        header += "/*\n  Do not edit directly";
+        header += "\n/*\n  Do not edit directly";
         header += "\n  Generated on " + new Date().toUTCString();
-        header += "\n*/\n";
+        header += "\n*/\n\n";
         print(header);
     }
-
-    print("\n");
 
     // output the list of tokens as Sass variables
     //

--- a/lib/common/templates/scss/map-flat.template
+++ b/lib/common/templates/scss/map-flat.template
@@ -13,19 +13,16 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-%>
-<%
+%><%
     // for backward compatibility we need to have the user explicitly hide it
     var showFileHeader = (this.options && this.options.hasOwnProperty('showFileHeader')) ? this.options.showFileHeader : true;
     if(showFileHeader) {
         var header = '';
-        header += "/*\n  Do not edit directly";
+        header += "\n/*\n  Do not edit directly";
         header += "\n  Generated on " + new Date().toUTCString();
-        header += "\n*/\n";
+        header += "\n*/\n\n";
         print(header);
     }
-
-    print('\n');
 
     var output = '';
     output += `$${this.mapName||'tokens'}: (\n`;


### PR DESCRIPTION
*Issue #, if available:* https://github.com/amzn/style-dictionary/issues/418

*Description of changes:* Setting `"showFileHeader": false` generates two blank lines in scss/map-deep and scss/map-flat files. scss/variables does not generate blank lines. This PR should remove two blank lines.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

*Reproduction:* 
`config.json`
```json
{
  "source": ["properties/**/*.json"],
  "platforms": {
    "scss:variables": {
      "transformGroup": "scss",
      "buildPath": "build/scss/",
      "files": [
        {
          "destination": "variables.scss",
          "format": "scss/variables",
          "options": { "showFileHeader": false }
        }
      ]
    },
    "scss:map-deep": {
      "transformGroup": "scss",
      "buildPath": "build/scss/",
      "files": [
        {
          "destination": "mapdeep.scss",
          "format": "scss/map-deep",
          "options": { "showFileHeader": false }
        }
      ]
    },
    "scss:map-flat": {
      "transformGroup": "scss",
      "buildPath": "build/scss/",
      "files": [
        {
          "destination": "mapflat.scss",
          "format": "scss/map-flat",
          "options": { "showFileHeader": false }
        }
      ]
    }
  }
}
```