### PR TITLE
chore(refactor): only including lodash template function

### DIFF
--- a/lib/common/formats.js
+++ b/lib/common/formats.js
@@ -11,12 +11,12 @@
  * and limitations under the License.
  */
 
-var fs = require('fs'),
-    _  = require('lodash'),
-    GroupMessages = require('../utils/groupMessages'),
-    { fileHeader, formattedVariables, iconsWithPrefix, minifyDictionary, sortByReference, createPropertyFormatter, sortByName } = require('./formatHelpers');
+const fs = require('fs');
+const _template = require('lodash/template');
+const GroupMessages = require('../utils/groupMessages');
+const { fileHeader, formattedVariables, iconsWithPrefix, minifyDictionary, sortByReference, createPropertyFormatter, sortByName } = require('./formatHelpers');
 
-var SASS_MAP_FORMAT_DEPRECATION_WARNINGS = GroupMessages.GROUP.SassMapFormatDeprecationWarnings;
+const SASS_MAP_FORMAT_DEPRECATION_WARNINGS = GroupMessages.GROUP.SassMapFormatDeprecationWarnings;
 
 /**
  * @namespace Formats
@@ -64,7 +64,7 @@ module.exports = {
    * ```
    */
   'scss/map-flat': function({dictionary, options, file}) {
-    const template = _.template(fs.readFileSync(__dirname + '/templates/scss/map-flat.template'));
+    const template = _template(fs.readFileSync(__dirname + '/templates/scss/map-flat.template'));
     const { allProperties } = dictionary;
     return template({allProperties, file, options, fileHeader});
   },
@@ -98,7 +98,7 @@ module.exports = {
    * ```
    */
   'scss/map-deep': function({dictionary, options, file}) {
-    const template = _.template(fs.readFileSync(__dirname + '/templates/scss/map-deep.template'));
+    const template = _template(fs.readFileSync(__dirname + '/templates/scss/map-deep.template'));
     return template({dictionary, file, options, fileHeader});
   },
 
@@ -385,7 +385,7 @@ module.exports = {
    * ```
    */
   'android/resources': function({dictionary, options, file}) {
-    const template = _.template(
+    const template = _template(
       fs.readFileSync(__dirname + '/templates/android/resources.template')
     );
     return template({dictionary, file, options, fileHeader});
@@ -416,7 +416,7 @@ module.exports = {
    * ```
    */
   'android/colors': function({dictionary, options, file}) {
-    const template = _.template(
+    const template = _template(
       fs.readFileSync(__dirname + '/templates/android/colors.template')
     );
     return template({dictionary, file, options, fileHeader});
@@ -447,7 +447,7 @@ module.exports = {
    * ```
    */
   'android/dimens': function({dictionary, options, file}) {
-    const template = _.template(
+    const template = _template(
       fs.readFileSync(__dirname + '/templates/android/dimens.template')
     );
     return template({dictionary, file, options, fileHeader});
@@ -478,7 +478,7 @@ module.exports = {
    * ```
    */
   'android/fontDimens': function({dictionary, options, file}) {
-    const template = _.template(
+    const template = _template(
       fs.readFileSync(__dirname + '/templates/android/fontDimens.template')
     );
     return template({dictionary, file, options, fileHeader});
@@ -511,7 +511,7 @@ module.exports = {
    * ```
    */
   'android/integers': function({dictionary, options, file}) {
-    const template = _.template(
+    const template = _template(
       fs.readFileSync(__dirname + '/templates/android/integers.template')
     );
     return template({dictionary, file, options, fileHeader});
@@ -543,7 +543,7 @@ module.exports = {
    * ```
    */
   'android/strings': function({dictionary, options, file}) {
-    const template = _.template(
+    const template = _template(
       fs.readFileSync(__dirname + '/templates/android/strings.template')
     );
     return template({dictionary, file, options, fileHeader});
@@ -565,7 +565,7 @@ module.exports = {
    * ```
    */
   'ios/macros': function({dictionary, options, file}) {
-    const template = _.template(
+    const template = _template(
       fs.readFileSync(__dirname + '/templates/ios/macros.template')
     );
 
@@ -580,7 +580,7 @@ module.exports = {
    * @todo Fix this template and add example and usage
    */
   'ios/plist': function({dictionary, options, file}) {
-    const template = _.template(
+    const template = _template(
       fs.readFileSync(__dirname + '/templates/ios/plist.template')
     );
 
@@ -595,7 +595,7 @@ module.exports = {
    * @todo Add example and usage
    */
   'ios/singleton.m': function({dictionary, options, file}) {
-    const template = _.template(
+    const template = _template(
       fs.readFileSync(__dirname + '/templates/ios/singleton.m.template')
     );
 
@@ -610,7 +610,7 @@ module.exports = {
    * @todo Add example and usage
    */
   'ios/singleton.h': function({dictionary, options, file}) {
-    const template = _.template(
+    const template = _template(
       fs.readFileSync(__dirname + '/templates/ios/singleton.h.template')
     );
 
@@ -625,7 +625,7 @@ module.exports = {
    * @todo Add example and usage
    */
   'ios/static.h': function({dictionary, options, file}) {
-    const template = _.template(
+    const template = _template(
       fs.readFileSync(__dirname + '/templates/ios/static.h.template')
     );
 
@@ -640,7 +640,7 @@ module.exports = {
    * @todo Add example and usage
    */
   'ios/static.m': function({dictionary, options, file}) {
-    const template = _.template(
+    const template = _template(
       fs.readFileSync(__dirname + '/templates/ios/static.m.template')
     );
 
@@ -655,7 +655,7 @@ module.exports = {
    * @todo Add example and usage
    */
   'ios/colors.h': function({dictionary, options, file}) {
-    const template = _.template(
+    const template = _template(
       fs.readFileSync(__dirname + '/templates/ios/colors.h.template')
     );
 
@@ -670,7 +670,7 @@ module.exports = {
    * @todo Add example and usage
    */
   'ios/colors.m': function({dictionary, options, file}) {
-    const template = _.template(
+    const template = _template(
       fs.readFileSync(__dirname + '/templates/ios/colors.m.template')
     );
 
@@ -685,7 +685,7 @@ module.exports = {
    * @todo Add example and usage
    */
   'ios/strings.h': function({dictionary, options, file}) {
-    const template = _.template(
+    const template = _template(
       fs.readFileSync(__dirname + '/templates/ios/strings.h.template')
     );
 
@@ -700,7 +700,7 @@ module.exports = {
    * @todo Add example and usage
    */
   'ios/strings.m': function({dictionary, options, file}) {
-    const template = _.template(
+    const template = _template(
       fs.readFileSync(__dirname + '/templates/ios/strings.m.template')
     );
 
@@ -723,7 +723,7 @@ module.exports = {
    * ```
    */
   'ios-swift/class.swift': function({dictionary, options, file}) {
-    const template = _.template(
+    const template = _template(
       fs.readFileSync(__dirname + '/templates/ios-swift/class.swift.template')
     );
     let allProperties;
@@ -753,7 +753,7 @@ module.exports = {
    * @todo Add example and usage
    */
   'ios-swift/enum.swift': function({dictionary, options, file}) {
-    const template = _.template(
+    const template = _template(
       fs.readFileSync(__dirname + '/templates/ios-swift/enum.swift.template')
     );
     let allProperties;
@@ -782,7 +782,7 @@ module.exports = {
    * @kind member
    * @todo Add example and usage
    */
-  'css/fonts.css': _.template(
+  'css/fonts.css': _template(
     fs.readFileSync(__dirname + '/templates/css/fonts.css.template')
   ),
 
@@ -893,14 +893,13 @@ module.exports = {
       'compatibleVersion':'1.0',
       'pluginVersion':'1.1'
     };
-    to_ret.colors = _.chain(dictionary.allProperties)
+    to_ret.colors = dictionary.allProperties
       .filter(function(prop) {
         return prop.attributes.category === 'color' && prop.attributes.type === 'base';
       })
       .map(function(prop) {
         return prop.value;
-      })
-      .value();
+      });
     return JSON.stringify(to_ret, null, 2);
   },
 
@@ -961,7 +960,7 @@ module.exports = {
    * ```
    */
   'flutter/class.dart': function({dictionary, options, file}) {
-    const template = _.template(
+    const template = _template(
       fs.readFileSync(__dirname + '/templates/flutter/class.dart.template')
     );
     let allProperties;

--- a/lib/common/templates/css/fonts.css.template
+++ b/lib/common/templates/css/fonts.css.template
@@ -1,4 +1,4 @@
-<% _.forIn(properties && properties.asset && properties.asset.font, function(font) {
+<% Object.values(properties && properties.asset && properties.asset.font || {}).forEach(function(font) {
   var fileFormatArr = [];
   if (font.eot) {
   	fileFormatArr.push("url('../" + font.eot.value + "');\n\tsrc: url('../" + font.eot.value + "?#iefix') format('embedded-opentype')");

--- a/lib/common/templates/scss/map-deep.template
+++ b/lib/common/templates/scss/map-deep.template
@@ -16,7 +16,7 @@
 <%= fileHeader({file, commentStyle: 'long'}) %><%
     // output the list of tokens as Sass variables
     //
-    _.each(dictionary.allProperties, function(prop) {
+    dictionary.allProperties.forEach(function(prop) {
         var output = '';
         output += '$' + prop.name + ': ' + (prop.attributes.category==='asset' ? '"'+prop.value+'"' : prop.value) + ' !default;'
         if(prop.comment) {

--- a/lib/register/template.js
+++ b/lib/register/template.js
@@ -11,10 +11,10 @@
  * and limitations under the License.
  */
 
-var fs = require('fs'),
-    _  = require('lodash'),
-    chalk = require('chalk'),
-    GroupMessages = require('../utils/groupMessages');
+const fs = require('fs');
+const _template = require('lodash/template');
+const chalk = require('chalk');
+const GroupMessages = require('../utils/groupMessages');
 
 var REGISTER_TEMPLATE_DEPRECATION_WARNINGS = GroupMessages.GROUP.RegisterTemplateDeprecationWarnings;
 
@@ -50,7 +50,7 @@ function registerTemplate(options) {
 
   var template_string = fs.readFileSync( options.template );
 
-  this.format[options.name] = _.template( template_string );
+  this.format[options.name] = _template( template_string );
   return this;
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Directly consuming the lodash template function and not the whole library. This does mean that code inside templates can no longer use lodash methods. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
