### PR TITLE
fix(messages): flushing the filtered references warnings

### DIFF
--- a/lib/buildFile.js
+++ b/lib/buildFile.js
@@ -126,7 +126,7 @@ function buildFile(file = {}, platform = {}, dictionary = {}) {
     }
 
     if (filteredReferencesCount > 0) {
-      let filteredReferencesWarnings = GroupMessages.fetchMessages(GroupMessages.GROUP.FilteredOutputReferences).join('\n    ');
+      let filteredReferencesWarnings = GroupMessages.flush(GroupMessages.GROUP.FilteredOutputReferences).join('\n    ');
       let title = `While building ${chalk.keyword('orangered').bold(destination)}, filtered out token references were found; output may be unexpected. Here are the references that are used but not defined in the file`;
       let help = chalk.keyword('orange')([
         'This is caused when combining a filter and `outputReferences`.',


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* I was just fetching the messages without clearing or flushing them so they would show up multiple times in the console. This fixes that. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
