### PR TITLE
fix(formats): bringing mapName back to scss formats

### DIFF
--- a/__integration__/__snapshots__/iOSObjectiveC.test.js.snap
+++ b/__integration__/__snapshots__/iOSObjectiveC.test.js.snap
@@ -12,7 +12,7 @@ exports[`integration ios objective-c ios/color.h should match snapshot 1`] = `
 
 #import <UIKit/UIKit.h>
 
-typedef NS_ENUM(NSInteger, ) {
+typedef NS_ENUM(NSInteger, StyleDictionaryColorName) {
 ColorBackgroundPrimary,
 ColorBackgroundSecondary,
 ColorBackgroundTertiary,
@@ -170,7 +170,7 @@ ColorFontSuccess
 
 @interface StyleDictionaryColor : NSObject
 + (NSArray *)values;
-+ (UIColor *)color:()color;
++ (UIColor *)color:(StyleDictionaryColorName)color;
 @end
 "
 `;
@@ -189,7 +189,7 @@ exports[`integration ios objective-c ios/color.m should match snapshot 1`] = `
 
 @implementation StyleDictionaryColor
 
-+ (UIColor *)color:()colorEnum{
++ (UIColor *)color:(StyleDictionaryColorName)colorEnum{
   return [[self values] objectAtIndex:colorEnum];
 }
 

--- a/__integration__/__snapshots__/scss.test.js.snap
+++ b/__integration__/__snapshots__/scss.test.js.snap
@@ -170,7 +170,7 @@ $size-padding-medium: 1rem !default;
 $size-padding-large: 1rem !default;
 $size-padding-xl: 1rem !default;
 
-$tokens: (
+$design-system-tokens: (
   'color': (
     'background': (
       'primary': $color-background-primary,
@@ -396,7 +396,7 @@ exports[`integration scss scss/map-flat should match snapshot 1`] = `
  * Generated on Sat, 01 Jan 2000 00:00:00 GMT
  */
 
-$tokens: (
+$design-system-tokens: (
   'color-background-primary': #ffffff,
   'color-background-secondary': #f3f4f4,
   'color-background-tertiary': #dee1e1,

--- a/__integration__/iOSObjectiveC.test.js
+++ b/__integration__/iOSObjectiveC.test.js
@@ -35,11 +35,13 @@ describe('integration', () => {
             destination: "color.h",
             format: "ios/colors.h",
             className: "StyleDictionaryColor",
+            type: "StyleDictionaryColorName",
             filter: (token) => token.attributes.category === 'color'
           },{
             destination: "color.m",
             format: "ios/colors.m",
             className: "StyleDictionaryColor",
+            type: "StyleDictionaryColorName",
             filter: (token) => token.attributes.category === 'color'
           },{
             destination: "macros.h",

--- a/__integration__/scss.test.js
+++ b/__integration__/scss.test.js
@@ -42,10 +42,12 @@ describe(`integration`, () => {
             }
           },{
             destination: `map-flat.scss`,
-            format: `scss/map-flat`
+            format: `scss/map-flat`,
+            mapName: 'design-system-tokens'
           },{
             destination: `map-deep.scss`,
-            format: `scss/map-deep`
+            format: `scss/map-deep`,
+            mapName: 'design-system-tokens'
           }]
         }
       }

--- a/lib/common/templates/ios/colors.h.template
+++ b/lib/common/templates/ios/colors.h.template
@@ -19,7 +19,7 @@
 <%= fileHeader({file, commentStyle: 'short'}) %>
 #import <UIKit/UIKit.h>
 
-typedef NS_ENUM(NSInteger, <%= this.type %>) {
+typedef NS_ENUM(NSInteger, <%= file.type %>) {
 <%= dictionary.allProperties.map(function(prop) { return prop.name; }).join(',\n') %>
 };
 

--- a/lib/common/templates/scss/map-deep.template
+++ b/lib/common/templates/scss/map-deep.template
@@ -31,7 +31,7 @@
     // output the list of tokens as a Sass nested map
     // (the values are pointing to the variables)
     //
-    print(`$${this.mapName||'tokens'}: ${processJsonNode(dictionary.properties, 0)};\n`);
+    print(`$${file.mapName||'tokens'}: ${processJsonNode(dictionary.properties, 0)};\n`);
 
     // recursive function to process a properties JSON node
     //

--- a/lib/common/templates/scss/map-flat.template
+++ b/lib/common/templates/scss/map-flat.template
@@ -16,7 +16,7 @@
 %>
 <%= fileHeader({file, commentStyle: 'long'}) %><%
     var output = '';
-    output += `$${this.mapName||'tokens'}: (\n`;
+    output += `$${file.mapName||'tokens'}: (\n`;
     output += allProperties.map(function(prop){
         var line = '';
         if(prop.comment) {


### PR DESCRIPTION
*Issue #, if available:* #610

*Description of changes:* When we were cleaning up the built-in formats, we broke `mapName` option on the `scss/map-flat` and `scss/map-deep` formats. This brings that back.

![backstreet's back](https://media.giphy.com/media/65GiuFnyEuMjm/giphy.gif)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
