### PR TITLE
feat(formats): add support for `selector` option in `css/variables` f…

### DIFF
--- a/__tests__/formats/__snapshots__/cssVariables.test.js.snap
+++ b/__tests__/formats/__snapshots__/cssVariables.test.js.snap
@@ -1,0 +1,8 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`formats css/variables supports the "selector" option 1`] = `
+".my-theme {
+  --color-base-red-400: #EF5350;
+}
+"
+`;

--- a/__tests__/formats/cssVariables.test.js
+++ b/__tests__/formats/cssVariables.test.js
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+var formats = require('../../lib/common/formats');
+
+var file = {
+  "destination": "__output/",
+  "format": "scss/variables",
+  "options":{
+    "showFileHeader": false
+  },
+  "name": "foo"
+};
+
+var propertyName = "color-base-red-400";
+var propertyValue = "#EF5350";
+
+var dictionary = {
+  "allProperties": [{
+    "name": propertyName,
+    "value": propertyValue,
+    "original": {
+      "value": propertyValue
+    },
+    "attributes": {
+      "category": "color",
+      "type": "base",
+      "item": "red",
+      "subitem": "400"
+    },
+    "path": [
+      "color",
+      "base",
+      "red",
+      "400"
+    ]
+  }]
+};
+
+
+
+describe('formats', () => {
+  describe('css/variables', () => {
+
+    it('supports the "selector" option', done => {
+      var formatter = formats['css/variables'].bind(Object.assign({}, file, {
+        selector: ".my-theme",
+      }));
+      const cssOutput = formatter(dictionary);
+      expect(cssOutput).toContain('.my-theme')
+      expect(cssOutput).toMatchSnapshot()
+      return done();
+    });
+
+  });
+});

--- a/docs/formats.md
+++ b/docs/formats.md
@@ -151,6 +151,19 @@ Creates a CSS file with variable definitions based on the style dictionary
 }
 ```
 
+You can pass `selector` option to change the default `:root` selector:
+```json
+{
+  "files": [
+    {
+      "format": "css/variables",
+      "destination": "variables.css",
+      "selector": ".my-theme"
+    }
+  ]
+}
+```
+
 * * *
 
 ### scss/map-flat 

--- a/lib/common/formats.js
+++ b/lib/common/formats.js
@@ -107,10 +107,10 @@ module.exports = {
    * ```
    */
   'css/variables': function(dictionary) {
-    return fileHeader(this.options) +
-      ':root {\n' +
-      variablesWithPrefix('  --', dictionary.allProperties) +
-      '\n}\n';
+    return `${fileHeader(this.options)}${this.selector || ':root'} {
+${variablesWithPrefix('  --', dictionary.allProperties)}
+}
+`;
   },
 
   /**


### PR DESCRIPTION
…ormat

closes #626

*Issue #, if available:* #626

*Description of changes:*
A new option is added to `css/variables` format to control the css selector, which is `:root` by default.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
