### PR TITLE
feat(types): cleaning up our type definitions

### DIFF
--- a/__tests__/formats/__snapshots__/all.test.js.snap
+++ b/__tests__/formats/__snapshots__/all.test.js.snap
@@ -744,7 +744,23 @@ exports[`formats all should match typescript/module-declarations snapshot 1`] = 
  */
 
 export default tokens;
-declare interface DesignToken { value: string; name?: string; path?: string[]; comment?: string; attributes?: any; original?: any; }
+
+declare interface DesignToken {
+  value: any;
+  name?: string;
+  comment?: string;
+  themeable?: boolean;
+  attributes?: {
+    category?: string;
+    type?: string;
+    item?: string;
+    subitem?: string;
+    state?: string;
+    [key: string]: any;
+  };
+  [key: string]: any;
+}
+
 declare const tokens: {
   \\"color\\": {
     \\"red\\": DesignToken

--- a/__tests__/formats/typeScriptEs6Declarations.test.js
+++ b/__tests__/formats/typeScriptEs6Declarations.test.js
@@ -10,11 +10,11 @@
  * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
  * and limitations under the License.
  */
-var fs = require('fs-extra');
-var helpers = require('../__helpers');
-var formats = require('../../lib/common/formats');
+const formats = require('../../lib/common/formats');
+const createDictionary = require('../../lib/utils/createDictionary');
+const createFormatArgs = require('../../lib/utils/createFormatArgs');
 
-var file = {
+const file = {
   "destination": "__output/",
   "format": "typescript/es6-declarations",
   "filter": {
@@ -24,46 +24,26 @@ var file = {
   }
 };
 
-var dictionary = {
-  "allProperties": [{
-    "name": "red",
-    "value": "#EF5350",
-    "original": {
-      "value": "#EF5350"
-    },
-    "attributes": {
-      "category": "color",
-      "type": "base",
-      "item": "red",
-      "subitem": "400"
-    },
-    "path": [
-      "color",
-      "base",
-      "red",
-      "400"
-    ]
-  }]
+const properties = {
+  "color": {
+    "red": {"value": "#FF0000"}
+  }
 };
 
-var formatter = formats['typescript/es6-declarations'].bind(file);
+const formatter = formats['typescript/es6-declarations'].bind(file);
 
 describe('formats', () => {
   describe('typescript/es6-declarations', () => {
-    beforeEach(() => {
-      helpers.clearOutput();
-    });
-
-    afterEach(() => {
-      helpers.clearOutput();
-    });
-
     it('should be a valid TS file', () => {
-      const declarations = './__tests__/__output/output.d.ts';
-      fs.writeFileSync(declarations, formatter(dictionary) );
+      const dictionary = createDictionary({ properties });
+      const output = formatter(createFormatArgs({
+        dictionary,
+        file,
+        platform: {},
+      }), {}, file);
 
       // get all lines that begin with export
-      const lines = fs.readFileSync(declarations, 'utf-8')
+      const lines = output
         .split('\n')
         .filter(l => l.indexOf('export') >= 0);
 

--- a/__tests__/formats/typeScriptModuleDeclarations.test.js
+++ b/__tests__/formats/typeScriptModuleDeclarations.test.js
@@ -10,11 +10,11 @@
  * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
  * and limitations under the License.
  */
-var fs = require('fs-extra');
-var helpers = require('../__helpers');
-var formats = require('../../lib/common/formats');
+const formats = require('../../lib/common/formats');
+const createDictionary = require('../../lib/utils/createDictionary');
+const createFormatArgs = require('../../lib/utils/createFormatArgs');
 
-var file = {
+const file = {
   "destination": "__output/",
   "format": "typescript/module-declarations",
   "filter": {
@@ -24,11 +24,9 @@ var file = {
   }
 };
 
-var dictionary = {
-  "properties": {
-    "color": {
-      "red": {"value": "#FF0000"}
-    }
+const properties = {
+  "color": {
+    "red": {"value": "#FF0000"}
   }
 };
 
@@ -37,20 +35,16 @@ var formatter = formats['typescript/module-declarations'].bind(file);
 
 describe('formats', () => {
   describe('typescript/module-declarations', () => {
-    beforeEach(() => {
-      helpers.clearOutput();
-    });
-
-    afterEach(() => {
-      helpers.clearOutput();
-    });
-
     it('should be a valid TS file', () => {
-      const declarations = './__tests__/__output/output-module.d.ts';
-      fs.writeFileSync(declarations, formatter(dictionary) );
+      const dictionary = createDictionary({ properties });
+      const output = formatter(createFormatArgs({
+        dictionary,
+        file,
+        platform: {},
+      }), {}, file);
 
       // get all lines that have DesignToken
-      const lines = fs.readFileSync(declarations, 'utf-8')
+      const lines = output
         .split('\n')
         .filter(l => l.indexOf(': DesignToken') >= 0);
 
@@ -60,5 +54,4 @@ describe('formats', () => {
       });
     });
   });
-
 });

--- a/lib/common/formats.js
+++ b/lib/common/formats.js
@@ -484,7 +484,7 @@ module.exports = {
     const output = fileHeader({file}) +
 `export default ${moduleName};
 
-${lines.slice(firstLine, lastLine).join(`\n`)}
+declare ${lines.slice(firstLine, lastLine).join(`\n`)}
 
 declare const ${moduleName}: ${JSON.stringify(treeWalker(dictionary.tokens), null, 2)}`;
 

--- a/lib/common/formats.js
+++ b/lib/common/formats.js
@@ -12,6 +12,7 @@
  */
 
 const fs = require('fs');
+const path = require('path');
 const _template = require('lodash/template');
 const GroupMessages = require('../utils/groupMessages');
 const { fileHeader, formattedVariables, iconsWithPrefix, minifyDictionary, sortByReference, createPropertyFormatter, sortByName } = require('./formatHelpers');
@@ -389,8 +390,8 @@ module.exports = {
    * export const ColorBackgroundAlt : string;
    * ```
    */
-  'typescript/es6-declarations': function(dictionary) {
-    return fileHeader(this.options) +
+  'typescript/es6-declarations': function({dictionary, file}) {
+    return fileHeader({file}) +
       dictionary.allProperties.map(function(prop) {
         var to_ret_prop = 'export const ' + prop.name + ' : string;';
         if (prop.comment)
@@ -452,7 +453,8 @@ module.exports = {
    * });
    * ```
    */
-  'typescript/module-declarations': function(dictionary) {
+  'typescript/module-declarations': function({dictionary, file, options}) {
+    const {moduleName=`tokens`} = options;
     function treeWalker(obj) {
       let type = Object.create(null);
       let has = Object.prototype.hasOwnProperty.bind(obj);
@@ -468,13 +470,27 @@ module.exports = {
       }
       return type;
     }
+    const designTokenInterface = fs.readFileSync(
+      path.resolve(__dirname, `../../types/DesignToken.d.ts`), {encoding:'UTF-8'}
+    );
 
-    var file = fileHeader(this.options) +
-      'export default tokens;\n' +
-      'declare interface DesignToken { value: string; name?: string; path?: string[]; comment?: string; attributes?: any; original?: any; }\n' +
-      'declare const tokens: ' +
-      JSON.stringify(treeWalker(dictionary.properties), null, 2);
-    return file.replace(/"DesignToken"/g,'DesignToken');
+    // get the first and last lines to add to the format by
+    // looking for the first and last single-line comment
+    const lines = designTokenInterface
+      .split('\n');
+    const firstLine = lines.indexOf(`//start`) + 1;
+    const lastLine = lines.indexOf(`//end`);
+
+    const output = fileHeader({file}) +
+`export default ${moduleName};
+
+${lines.slice(firstLine, lastLine).join(`\n`)}
+
+declare const ${moduleName}: ${JSON.stringify(treeWalker(dictionary.tokens), null, 2)}`;
+
+    // JSON stringify will quote strings, because this is a type we need
+    // it unquoted.
+    return output.replace(/"DesignToken"/g,'DesignToken');
   },
 
   // Android templates
@@ -683,9 +699,9 @@ module.exports = {
    * @example
    * ```kotlin
    * package com.example.tokens;
-   * 
+   *
    * import androidx.compose.ui.graphics.Color
-   * 
+   *
    * object StyleDictionary {
    *  val colorBaseRed5 = Color(0xFFFAF3F2)
    * }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2133,16 +2133,6 @@
         "chalk": "^4.0.0"
       }
     },
-    "@mrmlnc/readdir-enhanced": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
-      "integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
-      "dev": true,
-      "requires": {
-        "call-me-maybe": "^1.0.1",
-        "glob-to-regexp": "^0.3.0"
-      }
-    },
     "@nodelib/fs.scandir": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
@@ -2162,9 +2152,9 @@
       }
     },
     "@nodelib/fs.stat": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
-      "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.4.tgz",
+      "integrity": "sha512-IYlHJA0clt2+Vg7bccq+TzRdJvv19c2INqBSsoOLp1je7xjtr7J26+WXR72MCdvU9q1qTzIWDfhMf+DRvQJK4Q==",
       "dev": true
     },
     "@nodelib/fs.walk": {
@@ -2242,16 +2232,6 @@
         "@babel/types": "^7.3.0"
       }
     },
-    "@types/glob": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
-      "integrity": "sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==",
-      "dev": true,
-      "requires": {
-        "@types/minimatch": "*",
-        "@types/node": "*"
-      }
-    },
     "@types/graceful-fs": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.4.tgz",
@@ -2289,12 +2269,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.6.tgz",
       "integrity": "sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==",
-      "dev": true
-    },
-    "@types/minimatch": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
-      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
       "dev": true
     },
     "@types/minimist": {
@@ -2759,18 +2733,9 @@
       "dev": true
     },
     "array-union": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-      "dev": true,
-      "requires": {
-        "array-uniq": "^1.0.1"
-      }
-    },
-    "array-uniq": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
       "dev": true
     },
     "array-unique": {
@@ -3978,12 +3943,6 @@
         "get-intrinsic": "^1.0.0"
       }
     },
-    "call-me-maybe": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
-      "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
-      "dev": true
-    },
     "callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -4054,12 +4013,6 @@
       "requires": {
         "rsvp": "^4.8.4"
       }
-    },
-    "capture-stack-trace": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz",
-      "integrity": "sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw==",
-      "dev": true
     },
     "caseless": {
       "version": "0.12.0",
@@ -5585,15 +5538,6 @@
         "p-event": "^4.1.0"
       }
     },
-    "create-error-class": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
-      "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
-      "dev": true,
-      "requires": {
-        "capture-stack-trace": "^1.0.0"
-      }
-    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -5884,23 +5828,12 @@
       "dev": true
     },
     "dir-glob": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.2.2.tgz",
-      "integrity": "sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
       "dev": true,
       "requires": {
-        "path-type": "^3.0.0"
-      },
-      "dependencies": {
-        "path-type": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-          "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-          "dev": true,
-          "requires": {
-            "pify": "^3.0.0"
-          }
-        }
+        "path-type": "^4.0.0"
       }
     },
     "dmd": {
@@ -6357,6 +6290,12 @@
       "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
       "dev": true
     },
+    "escape-goat": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/escape-goat/-/escape-goat-2.1.1.tgz",
+      "integrity": "sha512-8/uIhbG12Csjy2JEW7D9pHbreaVaS/OpN3ycnyvElTdwM5n6GY6W6e2IPemfvGZeUMqZ9A/3GqIZMgKnBhAw/Q==",
+      "dev": true
+    },
     "escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -6546,114 +6485,18 @@
       }
     },
     "eslint-formatter-pretty": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-formatter-pretty/-/eslint-formatter-pretty-1.3.0.tgz",
-      "integrity": "sha512-5DY64Y1rYCm7cfFDHEGUn54bvCnK+wSUVF07N8oXeqUJFSd+gnYOTXbzelQ1HurESluY6gnEQPmXOIkB4Wa+gA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-formatter-pretty/-/eslint-formatter-pretty-4.0.0.tgz",
+      "integrity": "sha512-QgdeZxQwWcN0TcXXNZJiS6BizhAANFhCzkE7Yl9HKB7WjElzwED6+FbbZB2gji8ofgJTGPqKm6VRCNT3OGCeEw==",
       "dev": true,
       "requires": {
-        "ansi-escapes": "^2.0.0",
-        "chalk": "^2.1.0",
-        "log-symbols": "^2.0.0",
-        "plur": "^2.1.2",
-        "string-width": "^2.0.0"
-      },
-      "dependencies": {
-        "ansi-escapes": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-2.0.0.tgz",
-          "integrity": "sha1-W65SvkJIeN2Xg+iRDj/Cki6DyBs=",
-          "dev": true
-        },
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "color-convert": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "dev": true,
-          "requires": {
-            "color-name": "1.1.3"
-          }
-        },
-        "color-name": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        },
-        "log-symbols": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
-          "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.0.1"
-          }
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^3.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.1.0",
+        "eslint-rule-docs": "^1.1.5",
+        "log-symbols": "^4.0.0",
+        "plur": "^4.0.0",
+        "string-width": "^4.2.0",
+        "supports-hyperlinks": "^2.0.0"
       }
     },
     "eslint-plugin-jest": {
@@ -6664,6 +6507,12 @@
       "requires": {
         "@typescript-eslint/experimental-utils": "^4.0.1"
       }
+    },
+    "eslint-rule-docs": {
+      "version": "1.1.226",
+      "resolved": "https://registry.npmjs.org/eslint-rule-docs/-/eslint-rule-docs-1.1.226.tgz",
+      "integrity": "sha512-Wnn0ETzE2v2UT0OdRCcdMNPkQtbzyZr3pPPXnkreP0l6ZJaKqnl88dL1DqZ6nCCZZwDGBAnN0Y+nCvGxxLPQLQ==",
+      "dev": true
     },
     "eslint-scope": {
       "version": "5.1.1",
@@ -7006,143 +6855,17 @@
       "dev": true
     },
     "fast-glob": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.7.tgz",
-      "integrity": "sha512-g1KuQwHOZAmOZMuBtHdxDtju+T2RT8jgCC9aANsbpdiDDTSnjgfuVsIBNKbUeJI3oKMRExcfNDtJl4OhbffMsw==",
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.5.tgz",
+      "integrity": "sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==",
       "dev": true,
       "requires": {
-        "@mrmlnc/readdir-enhanced": "^2.2.1",
-        "@nodelib/fs.stat": "^1.1.2",
-        "glob-parent": "^3.1.0",
-        "is-glob": "^4.0.0",
-        "merge2": "^1.2.3",
-        "micromatch": "^3.1.10"
-      },
-      "dependencies": {
-        "braces": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-          "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-          "dev": true,
-          "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            }
-          }
-        },
-        "fill-range": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-          "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-          "dev": true,
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            }
-          }
-        },
-        "glob-parent": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-          "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
-          "dev": true,
-          "requires": {
-            "is-glob": "^3.1.0",
-            "path-dirname": "^1.0.0"
-          },
-          "dependencies": {
-            "is-glob": {
-              "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-              "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-              "dev": true,
-              "requires": {
-                "is-extglob": "^2.1.0"
-              }
-            }
-          }
-        },
-        "is-number": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "dev": true,
-          "requires": {
-            "kind-of": "^3.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
-            }
-          }
-        },
-        "micromatch": {
-          "version": "3.1.10",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-          "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-          "dev": true,
-          "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.1",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "extglob": "^2.0.4",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.2",
-            "nanomatch": "^1.2.9",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.2"
-          }
-        },
-        "to-regex-range": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
-          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
-          "dev": true,
-          "requires": {
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1"
-          }
-        }
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.0",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.2",
+        "picomatch": "^2.2.1"
       }
     },
     "fast-json-stable-stringify": {
@@ -7795,12 +7518,6 @@
         "is-glob": "^4.0.1"
       }
     },
-    "glob-to-regexp": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
-      "integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=",
-      "dev": true
-    },
     "global-dirs": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
@@ -7817,31 +7534,23 @@
       "dev": true
     },
     "globby": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-9.2.0.tgz",
-      "integrity": "sha512-ollPHROa5mcxDEkwg6bPt3QbEf4pDQSNtd6JPL1YvOvAo/7/0VAm9TccUeoTmarjPw4pfUthSCqcyfNB1I3ZSg==",
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.3.tgz",
+      "integrity": "sha512-ffdmosjA807y7+lA1NM0jELARVmYul/715xiILEjo3hBLPTcirgQNnXECn5g3mtR8TOLCVbkfua1Hpen25/Xcg==",
       "dev": true,
       "requires": {
-        "@types/glob": "^7.1.1",
-        "array-union": "^1.0.2",
-        "dir-glob": "^2.2.2",
-        "fast-glob": "^2.2.6",
-        "glob": "^7.1.3",
-        "ignore": "^4.0.3",
-        "pify": "^4.0.1",
-        "slash": "^2.0.0"
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.1.1",
+        "ignore": "^5.1.4",
+        "merge2": "^1.3.0",
+        "slash": "^3.0.0"
       },
       "dependencies": {
-        "pify": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-          "dev": true
-        },
-        "slash": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
-          "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+        "ignore": {
+          "version": "5.1.8",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+          "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
           "dev": true
         }
       }
@@ -8273,9 +7982,9 @@
       "dev": true
     },
     "irregular-plurals": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-1.4.0.tgz",
-      "integrity": "sha1-LKmwM2UREYVUEvFr5dd8YqRYp2Y=",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-3.3.0.tgz",
+      "integrity": "sha512-MVBLKUTangM3EfRPFROhmWQQKRDsrgI83J8GS3jXy+OwYqiR2/aoWndYQ5416jLE3uaGgLH7ncme3X9y09gZ3g==",
       "dev": true
     },
     "is-accessor-descriptor": {
@@ -8474,22 +8183,10 @@
         "isobject": "^3.0.1"
       }
     },
-    "is-redirect": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
-      "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
-      "dev": true
-    },
     "is-regexp": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
       "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
-      "dev": true
-    },
-    "is-retry-allowed": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
-      "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==",
       "dev": true
     },
     "is-stream": {
@@ -12040,12 +11737,6 @@
         }
       }
     },
-    "path-dirname": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
-      "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
-      "dev": true
-    },
     "path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -12142,12 +11833,12 @@
       }
     },
     "plur": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/plur/-/plur-2.1.2.tgz",
-      "integrity": "sha1-dIJFLBoPUI4+NE6uwxLJHCncZVo=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/plur/-/plur-4.0.0.tgz",
+      "integrity": "sha512-4UGewrYgqDFw9vV6zNV+ADmPAUAfJPKtGvb/VdpQAx25X5f3xXdGdyOEVFwkl8Hl/tl7+xbeHqSEM+D5/TirUg==",
       "dev": true,
       "requires": {
-        "irregular-plurals": "^1.0.0"
+        "irregular-plurals": "^3.2.0"
       }
     },
     "pn": {
@@ -12291,6 +11982,15 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
+    },
+    "pupa": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/pupa/-/pupa-2.1.1.tgz",
+      "integrity": "sha512-l1jNAspIBSFqbT+y+5FosojNpVpF94nlI+wDUpqP9enwOTfHx9f0gh5nB96vl+6yTpsJsypeNrwfzPrKuHB41A==",
+      "dev": true,
+      "requires": {
+        "escape-goat": "^2.0.0"
+      }
     },
     "q": {
       "version": "1.5.1",
@@ -14353,12 +14053,6 @@
         }
       }
     },
-    "timed-out": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
-      "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
-      "dev": true
-    },
     "tiny-emitter": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
@@ -14493,298 +14187,133 @@
       }
     },
     "tsd": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/tsd/-/tsd-0.11.0.tgz",
-      "integrity": "sha512-klKMNC0KRzUIaLJG8XqkvH/9rKwYX74xpqJBN8spWjYUDojAesd6AfDCT5dray+yhLfTGkem7O3nU6i4KwzNDw==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/tsd/-/tsd-0.15.1.tgz",
+      "integrity": "sha512-8ADO2rPntfNiJV4KiqJiiiitfkXLxCbKEFN672JgwNiaEIuiyurTc1+w3InZ+0DqBz73B6Z3UflZcNGw5xMaDA==",
       "dev": true,
       "requires": {
-        "eslint-formatter-pretty": "^1.3.0",
-        "globby": "^9.1.0",
-        "meow": "^5.0.0",
-        "path-exists": "^3.0.0",
-        "read-pkg-up": "^4.0.0",
-        "update-notifier": "^2.5.0"
+        "eslint-formatter-pretty": "^4.0.0",
+        "globby": "^11.0.1",
+        "meow": "^7.0.1",
+        "path-exists": "^4.0.0",
+        "read-pkg-up": "^7.0.0",
+        "update-notifier": "^4.1.0"
       },
       "dependencies": {
-        "ansi-align": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
-          "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
-          "dev": true,
-          "requires": {
-            "string-width": "^2.0.0"
-          }
-        },
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
         "boxen": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
-          "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
-          "dev": true,
-          "requires": {
-            "ansi-align": "^2.0.0",
-            "camelcase": "^4.0.0",
-            "chalk": "^2.0.1",
-            "cli-boxes": "^1.0.0",
-            "string-width": "^2.0.0",
-            "term-size": "^1.2.0",
-            "widest-line": "^2.0.0"
-          }
-        },
-        "camelcase": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-          "dev": true
-        },
-        "camelcase-keys": {
           "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
-          "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
+          "resolved": "https://registry.npmjs.org/boxen/-/boxen-4.2.0.tgz",
+          "integrity": "sha512-eB4uT9RGzg2odpER62bBwSLvUeGC+WbRjjyyFhGsKnc8wp/m0+hQsMUvUe3H2V0D5vw0nBdO1hCJoZo5mKeuIQ==",
           "dev": true,
           "requires": {
-            "camelcase": "^4.1.0",
-            "map-obj": "^2.0.0",
-            "quick-lru": "^1.0.0"
-          }
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "ci-info": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz",
-          "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==",
-          "dev": true
-        },
-        "cli-boxes": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
-          "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
-          "dev": true
-        },
-        "color-convert": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "dev": true,
-          "requires": {
-            "color-name": "1.1.3"
-          }
-        },
-        "color-name": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-          "dev": true
-        },
-        "configstore": {
-          "version": "3.1.5",
-          "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.5.tgz",
-          "integrity": "sha512-nlOhI4+fdzoK5xmJ+NY+1gZK56bwEaWZr8fYuXohZ9Vkc1o3a4T/R3M+yE/w7x/ZVJ1zF8c+oaOvF0dztdUgmA==",
-          "dev": true,
-          "requires": {
-            "dot-prop": "^4.2.1",
-            "graceful-fs": "^4.1.2",
-            "make-dir": "^1.0.0",
-            "unique-string": "^1.0.0",
-            "write-file-atomic": "^2.0.0",
-            "xdg-basedir": "^3.0.0"
-          }
-        },
-        "dot-prop": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.1.tgz",
-          "integrity": "sha512-l0p4+mIuJIua0mhxGoh4a+iNL9bmeK5DvnSVQa6T0OhrVmaEa1XScX5Etc673FePCJOArq/4Pa2cLGODUWTPOQ==",
-          "dev": true,
-          "requires": {
-            "is-obj": "^1.0.0"
-          }
-        },
-        "find-up": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-          "dev": true,
-          "requires": {
-            "locate-path": "^2.0.0"
-          }
-        },
-        "get-stream": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-          "dev": true
-        },
-        "got": {
-          "version": "6.7.1",
-          "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
-          "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
-          "dev": true,
-          "requires": {
-            "create-error-class": "^3.0.0",
-            "duplexer3": "^0.1.4",
-            "get-stream": "^3.0.0",
-            "is-redirect": "^1.0.0",
-            "is-retry-allowed": "^1.0.0",
-            "is-stream": "^1.0.0",
-            "lowercase-keys": "^1.0.0",
-            "safe-buffer": "^5.0.1",
-            "timed-out": "^4.0.0",
-            "unzip-response": "^2.0.1",
-            "url-parse-lax": "^1.0.0"
-          }
-        },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-          "dev": true
-        },
-        "hosted-git-info": {
-          "version": "2.8.8",
-          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-          "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==",
-          "dev": true
-        },
-        "indent-string": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
-          "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
-          "dev": true
-        },
-        "is-ci": {
-          "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.2.1.tgz",
-          "integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
-          "dev": true,
-          "requires": {
-            "ci-info": "^1.5.0"
-          }
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        },
-        "is-npm": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
-          "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
-          "dev": true
-        },
-        "is-obj": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-          "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
-          "dev": true
-        },
-        "latest-version": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
-          "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
-          "dev": true,
-          "requires": {
-            "package-json": "^4.0.0"
-          }
-        },
-        "load-json-file": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
-          "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^4.0.0",
-            "pify": "^3.0.0",
-            "strip-bom": "^3.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-          "dev": true,
-          "requires": {
-            "p-locate": "^2.0.0",
-            "path-exists": "^3.0.0"
-          }
-        },
-        "make-dir": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
-          "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
-          "dev": true,
-          "requires": {
-            "pify": "^3.0.0"
-          }
-        },
-        "map-obj": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
-          "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
-          "dev": true
-        },
-        "meow": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/meow/-/meow-5.0.0.tgz",
-          "integrity": "sha512-CbTqYU17ABaLefO8vCU153ZZlprKYWDljcndKKDCFcYQITzWCXZAVk4QMFZPgvzrnUQ3uItnIE/LoUOwrT15Ig==",
-          "dev": true,
-          "requires": {
-            "camelcase-keys": "^4.0.0",
-            "decamelize-keys": "^1.0.0",
-            "loud-rejection": "^1.0.0",
-            "minimist-options": "^3.0.1",
-            "normalize-package-data": "^2.3.4",
-            "read-pkg-up": "^3.0.0",
-            "redent": "^2.0.0",
-            "trim-newlines": "^2.0.0",
-            "yargs-parser": "^10.0.0"
+            "ansi-align": "^3.0.0",
+            "camelcase": "^5.3.1",
+            "chalk": "^3.0.0",
+            "cli-boxes": "^2.2.0",
+            "string-width": "^4.1.0",
+            "term-size": "^2.1.0",
+            "type-fest": "^0.8.1",
+            "widest-line": "^3.1.0"
           },
           "dependencies": {
-            "read-pkg-up": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
-              "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
-              "dev": true,
-              "requires": {
-                "find-up": "^2.0.0",
-                "read-pkg": "^3.0.0"
-              }
+            "type-fest": {
+              "version": "0.8.1",
+              "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+              "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+              "dev": true
             }
           }
         },
-        "minimist-options": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-3.0.2.tgz",
-          "integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
           "dev": true,
           "requires": {
-            "arrify": "^1.0.1",
-            "is-plain-obj": "^1.1.0"
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "configstore": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/configstore/-/configstore-5.0.1.tgz",
+          "integrity": "sha512-aMKprgk5YhBNyH25hj8wGt2+D52Sw1DRRIzqBwLp2Ya9mFmY8KPvvtvmna8SxVR9JMZ4kzMD68N22vlaRpkeFA==",
+          "dev": true,
+          "requires": {
+            "dot-prop": "^5.2.0",
+            "graceful-fs": "^4.1.2",
+            "make-dir": "^3.0.0",
+            "unique-string": "^2.0.0",
+            "write-file-atomic": "^3.0.0",
+            "xdg-basedir": "^4.0.0"
+          }
+        },
+        "crypto-random-string": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
+          "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==",
+          "dev": true
+        },
+        "global-dirs": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-2.1.0.tgz",
+          "integrity": "sha512-MG6kdOUh/xBnyo9cJFeIKkLEc1AyFq42QTU4XiX51i2NEdxLxLWXIjEjmqKeSuKR7pAZjTqUVoT2b2huxVLgYQ==",
+          "dev": true,
+          "requires": {
+            "ini": "1.3.7"
+          }
+        },
+        "hosted-git-info": {
+          "version": "2.8.9",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+          "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+          "dev": true
+        },
+        "ini": {
+          "version": "1.3.7",
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.7.tgz",
+          "integrity": "sha512-iKpRpXP+CrP2jyrxvg1kMUpXDyRUFDWurxbnVT1vQPx+Wz9uCYsMIqYuSBLV+PAaZG/d7kRLKRFc9oDMsH+mFQ==",
+          "dev": true
+        },
+        "is-installed-globally": {
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.3.2.tgz",
+          "integrity": "sha512-wZ8x1js7Ia0kecP/CHM/3ABkAmujX7WPvQk6uu3Fly/Mk44pySulQpnHG46OMjHGXApINnV4QhY3SWnECO2z5g==",
+          "dev": true,
+          "requires": {
+            "global-dirs": "^2.0.1",
+            "is-path-inside": "^3.0.1"
+          }
+        },
+        "is-npm": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-4.0.0.tgz",
+          "integrity": "sha512-96ECIfh9xtDDlPylNPXhzjsykHsMJZ18ASpaWzQyBr4YRTcVjUvzaHayDAES2oU/3KpljhHUjtSRNiDwi0F0ig==",
+          "dev": true
+        },
+        "is-path-inside": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+          "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+          "dev": true
+        },
+        "meow": {
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/meow/-/meow-7.1.1.tgz",
+          "integrity": "sha512-GWHvA5QOcS412WCo8vwKDlTelGLsCGBVevQB5Kva961rmNfun0PCbv5+xta2kUMFJyR8/oWnn7ddeKdosbAPbA==",
+          "dev": true,
+          "requires": {
+            "@types/minimist": "^1.2.0",
+            "camelcase-keys": "^6.2.2",
+            "decamelize-keys": "^1.1.0",
+            "hard-rejection": "^2.1.0",
+            "minimist-options": "4.1.0",
+            "normalize-package-data": "^2.5.0",
+            "read-pkg-up": "^7.0.1",
+            "redent": "^3.0.0",
+            "trim-newlines": "^3.0.0",
+            "type-fest": "^0.13.1",
+            "yargs-parser": "^18.1.3"
           }
         },
         "normalize-package-data": {
@@ -14799,265 +14328,88 @@
             "validate-npm-package-license": "^3.0.1"
           }
         },
-        "p-limit": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+        "semver-diff": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-3.1.1.tgz",
+          "integrity": "sha512-GX0Ix/CJcHyB8c4ykpHGIAvLyOwOobtM/8d+TQkAd81/bEjgPHrfba41Vpesr7jX/t8Uh+R3EX9eAS5be+jQYg==",
           "dev": true,
           "requires": {
-            "p-try": "^1.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-          "dev": true,
-          "requires": {
-            "p-limit": "^1.1.0"
-          }
-        },
-        "p-try": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
-          "dev": true
-        },
-        "package-json": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
-          "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
-          "dev": true,
-          "requires": {
-            "got": "^6.7.1",
-            "registry-auth-token": "^3.0.1",
-            "registry-url": "^3.0.3",
-            "semver": "^5.1.0"
-          }
-        },
-        "parse-json": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-          "dev": true,
-          "requires": {
-            "error-ex": "^1.3.1",
-            "json-parse-better-errors": "^1.0.1"
-          }
-        },
-        "path-exists": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-          "dev": true
-        },
-        "path-type": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-          "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-          "dev": true,
-          "requires": {
-            "pify": "^3.0.0"
-          }
-        },
-        "prepend-http": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
-          "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
-          "dev": true
-        },
-        "quick-lru": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
-          "integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=",
-          "dev": true
-        },
-        "read-pkg": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
-          "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
-          "dev": true,
-          "requires": {
-            "load-json-file": "^4.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^3.0.0"
-          }
-        },
-        "read-pkg-up": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-4.0.0.tgz",
-          "integrity": "sha512-6etQSH7nJGsK0RbG/2TeDzZFa8shjQ1um+SwQQ5cwKy0dhSXdOncEhb1CPpvQG4h7FyOV6EB6YlV0yJvZQNAkA==",
-          "dev": true,
-          "requires": {
-            "find-up": "^3.0.0",
-            "read-pkg": "^3.0.0"
+            "semver": "^6.3.0"
           },
           "dependencies": {
-            "find-up": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-              "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-              "dev": true,
-              "requires": {
-                "locate-path": "^3.0.0"
-              }
-            },
-            "locate-path": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-              "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-              "dev": true,
-              "requires": {
-                "p-locate": "^3.0.0",
-                "path-exists": "^3.0.0"
-              }
-            },
-            "p-limit": {
-              "version": "2.3.0",
-              "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-              "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-              "dev": true,
-              "requires": {
-                "p-try": "^2.0.0"
-              }
-            },
-            "p-locate": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-              "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-              "dev": true,
-              "requires": {
-                "p-limit": "^2.0.0"
-              }
-            },
-            "p-try": {
-              "version": "2.2.0",
-              "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-              "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+            "semver": {
+              "version": "6.3.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
               "dev": true
             }
           }
         },
-        "redent": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
-          "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
-          "dev": true,
-          "requires": {
-            "indent-string": "^3.0.0",
-            "strip-indent": "^2.0.0"
-          }
-        },
-        "registry-auth-token": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.4.0.tgz",
-          "integrity": "sha512-4LM6Fw8eBQdwMYcES4yTnn2TqIasbXuwDx3um+QRs7S55aMKCBKBxvPXl2RiUjHwuJLTyYfxSpmfSAjQpcuP+A==",
-          "dev": true,
-          "requires": {
-            "rc": "^1.1.6",
-            "safe-buffer": "^5.0.1"
-          }
-        },
-        "registry-url": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
-          "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
-          "dev": true,
-          "requires": {
-            "rc": "^1.0.1"
-          }
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^3.0.0"
-          }
-        },
-        "strip-bom": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+        "term-size": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/term-size/-/term-size-2.2.1.tgz",
+          "integrity": "sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==",
           "dev": true
         },
-        "strip-indent": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
-          "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
+        "type-fest": {
+          "version": "0.13.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+          "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
           "dev": true
         },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+        "unique-string": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
+          "integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "crypto-random-string": "^2.0.0"
           }
-        },
-        "trim-newlines": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
-          "integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
-          "dev": true
         },
         "update-notifier": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.5.0.tgz",
-          "integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
+          "version": "4.1.3",
+          "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-4.1.3.tgz",
+          "integrity": "sha512-Yld6Z0RyCYGB6ckIjffGOSOmHXj1gMeE7aROz4MG+XMkmixBX4jUngrGXNYz7wPKBmtoD4MnBa2Anu7RSKht/A==",
           "dev": true,
           "requires": {
-            "boxen": "^1.2.1",
-            "chalk": "^2.0.1",
-            "configstore": "^3.0.0",
+            "boxen": "^4.2.0",
+            "chalk": "^3.0.0",
+            "configstore": "^5.0.1",
+            "has-yarn": "^2.1.0",
             "import-lazy": "^2.1.0",
-            "is-ci": "^1.0.10",
-            "is-installed-globally": "^0.1.0",
-            "is-npm": "^1.0.0",
-            "latest-version": "^3.0.0",
-            "semver-diff": "^2.0.0",
-            "xdg-basedir": "^3.0.0"
+            "is-ci": "^2.0.0",
+            "is-installed-globally": "^0.3.1",
+            "is-npm": "^4.0.0",
+            "is-yarn-global": "^0.3.0",
+            "latest-version": "^5.0.0",
+            "pupa": "^2.0.1",
+            "semver-diff": "^3.1.1",
+            "xdg-basedir": "^4.0.0"
           }
         },
-        "url-parse-lax": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
-          "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+        "widest-line": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
+          "integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
           "dev": true,
           "requires": {
-            "prepend-http": "^1.0.1"
+            "string-width": "^4.0.0"
           }
         },
-        "write-file-atomic": {
-          "version": "2.4.3",
-          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
-          "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.11",
-            "imurmurhash": "^0.1.4",
-            "signal-exit": "^3.0.2"
-          }
+        "xdg-basedir": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
+          "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==",
+          "dev": true
         },
         "yargs-parser": {
-          "version": "10.1.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
-          "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
+          "version": "18.1.3",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
           "dev": true,
           "requires": {
-            "camelcase": "^4.1.0"
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
           }
         }
       }
@@ -15258,12 +14610,6 @@
           "dev": true
         }
       }
-    },
-    "unzip-response": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
-      "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
-      "dev": true
     },
     "update-notifier": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "index.js",
     "LICENSE",
     "NOTICE",
-    "types/index.d.ts"
+    "types"
   ],
   "scripts": {
     "lint": "eslint --fix index.js \"lib/**/*.js\" \"__tests__/**/*.js\"",
@@ -146,7 +146,7 @@
     "node-sass": "^4.14.1",
     "standard-version": "^9.0.0",
     "stylus": "^0.54.8",
-    "tsd": "^0.11.0",
+    "tsd": "^0.15.1",
     "yaml": "^1.10.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "index.js",
     "LICENSE",
     "NOTICE",
-    "types/index.d.ts"
+    "types"
   ],
   "scripts": {
     "lint": "eslint --fix index.js \"lib/**/*.js\" \"__tests__/**/*.js\"",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "index.js",
     "LICENSE",
     "NOTICE",
-    "types"
+    "types/index.d.ts"
   ],
   "scripts": {
     "lint": "eslint --fix index.js \"lib/**/*.js\" \"__tests__/**/*.js\"",

--- a/types/Action.d.ts
+++ b/types/Action.d.ts
@@ -15,6 +15,9 @@ import { Dictionary } from './Dictionary';
 import { Platform } from './Platform';
 
 export interface Action {
+  /** The action in the form of a function. */
   do(dictionary: Dictionary, config: Platform): void;
+
+  /** A function that undoes the action. */
   undo?(dictionary: Dictionary, config: Platform): void;
 }

--- a/types/Action.d.ts
+++ b/types/Action.d.ts
@@ -11,16 +11,10 @@
  * and limitations under the License.
  */
 
-import Dictionary from './Dictionary';
-import Platform from './Platform';
+import { Dictionary } from './Dictionary';
+import { Platform } from './Platform';
 
-/**
- * @property {Function} do - The do function
- * @property {Function} undo - The undo function
- */
 export interface Action {
   do(dictionary: Dictionary, config: Platform): void;
   undo?(dictionary: Dictionary, config: Platform): void;
 }
-
-export default Action;

--- a/types/Action.d.ts
+++ b/types/Action.d.ts
@@ -14,7 +14,11 @@
 import Dictionary from './Dictionary';
 import Platform from './Platform';
 
-interface Action {
+/**
+ * @property {Function} do - The do function
+ * @property {Function} undo - The undo function
+ */
+export interface Action {
   do(dictionary: Dictionary, config: Platform): void;
   undo?(dictionary: Dictionary, config: Platform): void;
 }

--- a/types/Action.d.ts
+++ b/types/Action.d.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+import Dictionary from './Dictionary';
+import Platform from './Platform';
+
+interface Action {
+  do(dictionary: Dictionary, config: Platform): void;
+  undo?(dictionary: Dictionary, config: Platform): void;
+}
+
+export default Action;

--- a/types/Config.d.ts
+++ b/types/Config.d.ts
@@ -11,14 +11,14 @@
  * and limitations under the License.
  */
 
-import Parser from './Parser';
-import Transform from './Transform';
-import TransformGroup from './TransformGroup';
-import Filter from './Filter';
-import FileHeader from './FileHeader';
-import Format from './Format';
-import Action from './Action';
-import Platform from './Platform';
+import { Parser } from './Parser';
+import { Transform } from './Transform';
+import { TransformGroup } from './TransformGroup';
+import { Filter } from './Filter';
+import { FileHeader } from './FileHeader';
+import { Format } from './Format';
+import { Action } from './Action';
+import { Platform } from './Platform';
 import { DesignTokens } from './DesignToken';
 
 export interface Config {
@@ -35,5 +35,3 @@ export interface Config {
   properties?: DesignTokens;
   platforms: Record<string, Platform>;
 }
-
-export default Config;

--- a/types/Config.d.ts
+++ b/types/Config.d.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+import { Keyed } from './_helpers';
+
+import Parser from './Parser';
+import Transform from './Transform';
+import TransformGroup from './TransformGroup';
+import Filter from './Filter';
+import FileHeader from './FileHeader';
+import Format from './Format';
+import Action from './Action';
+import Platform from './Platform';
+import { DesignTokens } from './DesignToken';
+
+interface Config {
+  parsers?: Parser[];
+  transform?: Keyed<Transform>;
+  transformGroup?: Keyed<TransformGroup>;
+  format?: Keyed<Format>;
+  filter?: Keyed<Filter>;
+  fileHeader?: Keyed<FileHeader>;
+  action?: Keyed<Action>;
+  include?: string[];
+  source?: string[];
+  tokens?: DesignTokens;
+  properties?: DesignTokens;
+  platforms: Keyed<Platform>;
+}
+
+export default Config;

--- a/types/Config.d.ts
+++ b/types/Config.d.ts
@@ -11,8 +11,6 @@
  * and limitations under the License.
  */
 
-import { Keyed } from './_helpers';
-
 import Parser from './Parser';
 import Transform from './Transform';
 import TransformGroup from './TransformGroup';
@@ -23,19 +21,19 @@ import Action from './Action';
 import Platform from './Platform';
 import { DesignTokens } from './DesignToken';
 
-interface Config {
+export interface Config {
   parsers?: Parser[];
-  transform?: Keyed<Transform>;
-  transformGroup?: Keyed<TransformGroup>;
-  format?: Keyed<Format>;
-  filter?: Keyed<Filter>;
-  fileHeader?: Keyed<FileHeader>;
-  action?: Keyed<Action>;
+  transform?: Record<string, Transform>;
+  transformGroup?: Record<string, TransformGroup>;
+  format?: Record<string, Format>;
+  filter?: Record<string, Filter>;
+  fileHeader?: Record<string, FileHeader>;
+  action?: Record<string, Action>;
   include?: string[];
   source?: string[];
   tokens?: DesignTokens;
   properties?: DesignTokens;
-  platforms: Keyed<Platform>;
+  platforms: Record<string, Platform>;
 }
 
 export default Config;

--- a/types/DesignToken.d.ts
+++ b/types/DesignToken.d.ts
@@ -29,6 +29,7 @@ declare interface DesignToken {
 }
 //end
 
+export {DesignToken};
 export interface DesignTokens {
   [key: string]: DesignTokens | DesignToken;
 }

--- a/types/DesignToken.d.ts
+++ b/types/DesignToken.d.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+//start
+declare interface DesignToken {
+  value: any;
+  name?: string;
+  comment?: string;
+  themeable?: boolean;
+  attributes?: {
+    category?: string;
+    type?: string;
+    item?: string;
+    subitem?: string;
+    state?: string;
+    [key: string]: any;
+  };
+  [key: string]: any;
+}
+//end
+
+export interface DesignTokens {
+  [key: string]: DesignTokens | DesignToken;
+}
+
+export default DesignToken;

--- a/types/DesignToken.d.ts
+++ b/types/DesignToken.d.ts
@@ -11,8 +11,15 @@
  * and limitations under the License.
  */
 
+/**
+ * This type is also used in the `typescript/module-declarations` format,
+ * but we only want to include the lines of the DesignToken interface.
+ * The comments surrounding the definition are used to trim the lines of
+ * this file in that format.
+ */
+
 //start
-declare interface DesignToken {
+interface DesignToken {
   value: any;
   name?: string;
   comment?: string;
@@ -29,9 +36,7 @@ declare interface DesignToken {
 }
 //end
 
-export {DesignToken};
+export { DesignToken };
 export interface DesignTokens {
   [key: string]: DesignTokens | DesignToken;
 }
-
-export default DesignToken;

--- a/types/Dictionary.d.ts
+++ b/types/Dictionary.d.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+import TransformedToken, {TransformedTokens} from './TransformedToken';
+
+interface Dictionary {
+  allTokens: TransformedToken[];
+  tokens: TransformedTokens;
+  allProperties: TransformedToken[];
+  properties: TransformedTokens;
+  usesReference: (value: any) => boolean;
+  getReferences: (value: any) => TransformedToken[];
+}
+
+export default Dictionary;

--- a/types/Dictionary.d.ts
+++ b/types/Dictionary.d.ts
@@ -13,7 +13,7 @@
 
 import TransformedToken, {TransformedTokens} from './TransformedToken';
 
-interface Dictionary {
+export interface Dictionary {
   allTokens: TransformedToken[];
   tokens: TransformedTokens;
   allProperties: TransformedToken[];

--- a/types/Dictionary.d.ts
+++ b/types/Dictionary.d.ts
@@ -11,7 +11,7 @@
  * and limitations under the License.
  */
 
-import TransformedToken, {TransformedTokens} from './TransformedToken';
+import { TransformedToken, TransformedTokens } from './TransformedToken';
 
 export interface Dictionary {
   allTokens: TransformedToken[];
@@ -21,5 +21,3 @@ export interface Dictionary {
   usesReference: (value: any) => boolean;
   getReferences: (value: any) => TransformedToken[];
 }
-
-export default Dictionary;

--- a/types/File.d.ts
+++ b/types/File.d.ts
@@ -11,8 +11,8 @@
  * and limitations under the License.
  */
 
-import Options from './Options';
-import TransformedToken from './TransformedToken';
+import { Options } from './Options';
+import { TransformedToken } from './TransformedToken';
 
 export interface File {
   destination: string;
@@ -20,5 +20,3 @@ export interface File {
   filter?: string | Partial<TransformedToken> | ((token: TransformedToken) => boolean);
   options?: Options;
 }
-
-export default File;

--- a/types/File.d.ts
+++ b/types/File.d.ts
@@ -14,7 +14,7 @@
 import Options from './Options';
 import TransformedToken from './TransformedToken';
 
-interface File {
+export interface File {
   destination: string;
   format?: string;
   filter?: string | Partial<TransformedToken> | ((token: TransformedToken) => boolean);

--- a/types/File.d.ts
+++ b/types/File.d.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+import Options from './Options';
+import TransformedToken from './TransformedToken';
+
+interface File {
+  destination: string;
+  format?: string;
+  filter?: string | Partial<TransformedToken> | ((token: TransformedToken) => boolean);
+  options?: Options;
+}
+
+export default File;

--- a/types/FileHeader.d.ts
+++ b/types/FileHeader.d.ts
@@ -11,6 +11,6 @@
  * and limitations under the License.
  */
 
-type FileHeader = (defaultMessage: string) => string[];
+export type FileHeader = (defaultMessage: string) => string[];
 
 export default FileHeader;

--- a/types/FileHeader.d.ts
+++ b/types/FileHeader.d.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+type FileHeader = (defaultMessage: string) => string[];
+
+export default FileHeader;

--- a/types/FileHeader.d.ts
+++ b/types/FileHeader.d.ts
@@ -12,5 +12,3 @@
  */
 
 export type FileHeader = (defaultMessage: string) => string[];
-
-export default FileHeader;

--- a/types/Filter.d.ts
+++ b/types/Filter.d.ts
@@ -11,11 +11,9 @@
  * and limitations under the License.
  */
 
-import Matcher from './Matcher';
+import { Matcher } from './Matcher';
 
 export interface Filter {
   name: string;
   matcher: Matcher;
 }
-
-export default Filter;

--- a/types/Filter.d.ts
+++ b/types/Filter.d.ts
@@ -13,7 +13,7 @@
 
 import Matcher from './Matcher';
 
-interface Filter {
+export interface Filter {
   name: string;
   matcher: Matcher;
 }

--- a/types/Filter.d.ts
+++ b/types/Filter.d.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+import Matcher from './Matcher';
+
+interface Filter {
+  name: string;
+  matcher: Matcher;
+}
+
+export default Filter;

--- a/types/Format.d.ts
+++ b/types/Format.d.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+import Dictionary from './Dictionary';
+import File from './File';
+import Options from './Options';
+import Platform from './Platform';
+
+interface FormatterArguments {
+  dictionary: Dictionary;
+  file: File;
+  options: Options;
+  platform: Platform;
+}
+
+type Formatter = (this: File, arguments: FormatterArguments) => string;
+
+interface Format {
+  name: string;
+  formatter: Formatter;
+}
+
+export default Format;

--- a/types/Format.d.ts
+++ b/types/Format.d.ts
@@ -16,17 +16,32 @@ import File from './File';
 import Options from './Options';
 import Platform from './Platform';
 
-interface FormatterArguments {
+export interface FormatterArguments {
+  /**
+   * The transformed and resolved dictionary object
+   */
   dictionary: Dictionary;
+  /**
+   * The file configuration the format is called in
+   */
   file: File;
+  /**
+   * The options object,
+   */
   options: Options;
+  /**
+   * The platform configuration the format is called in
+   */
   platform: Platform;
 }
 
-type Formatter = (this: File, arguments: FormatterArguments) => string;
+/**
+ * The formatter function receives an overloaded object as its arguments and
+ * it should return a string, which will be written to a file.
+ */
+export type Formatter = (arguments: FormatterArguments) => string;
 
-interface Format {
-  name: string;
+export interface Format {
   formatter: Formatter;
 }
 

--- a/types/Format.d.ts
+++ b/types/Format.d.ts
@@ -11,10 +11,10 @@
  * and limitations under the License.
  */
 
-import Dictionary from './Dictionary';
-import File from './File';
-import Options from './Options';
-import Platform from './Platform';
+import { Dictionary } from './Dictionary';
+import { File } from './File';
+import { Options } from './Options';
+import { Platform } from './Platform';
 
 export interface FormatterArguments {
   /**
@@ -44,5 +44,3 @@ export type Formatter = (arguments: FormatterArguments) => string;
 export interface Format {
   formatter: Formatter;
 }
-
-export default Format;

--- a/types/FormatHelpers.d.ts
+++ b/types/FormatHelpers.d.ts
@@ -15,7 +15,7 @@ import Dictionary from './Dictionary';
 import TransformedToken from './TransformedToken';
 import File from './File';
 
-interface LineFormatting {
+export interface LineFormatting {
   prefix?: string;
   commentStyle?: "short" | "long" | "none";
   indentation?: string;
@@ -23,38 +23,36 @@ interface LineFormatting {
   suffix?: string;
 }
 
-type TokenFormatterArguments = {
+export type TokenFormatterArgs = {
   outputReferences?: boolean;
   dictionary: Dictionary;
   format?: "css" | "sass" | "less" | "stylus";
   formatting?: LineFormatting;
 }
 
-interface CommentFormatting {
+export interface CommentFormatting {
   prefix: string;
   lineSeparator: string;
   header: string;
   footer: string;
 }
 
-interface FileHeaderParameters {
+export interface FileHeaderArgs {
   file: File;
   commentStyle: string;
   formatting?: CommentFormatting;
 }
 
-interface FormattedVariablesOptions {
+export interface FormattedVariablesArgs {
   format: "css" | "sass";
   dictionary: Dictionary
   outputReferences?: boolean;
   formatting?: LineFormatting;
 }
 
-interface FormatHelpers {
-  createPropertyFormatter: (options: TokenFormatterArguments) =>
+export interface FormatHelpers {
+  createPropertyFormatter: (args: TokenFormatterArgs) =>
     (token: TransformedToken) => string;
-  fileHeader: (options: FileHeaderParameters) => string;
-  formattedVariables: (options: FormattedVariablesOptions) => string;
+  fileHeader: (args: FileHeaderArgs) => string;
+  formattedVariables: (args: FormattedVariablesArgs) => string;
 }
-
-export default FormatHelpers;

--- a/types/FormatHelpers.d.ts
+++ b/types/FormatHelpers.d.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+import Dictionary from './Dictionary';
+import TransformedToken from './TransformedToken';
+import File from './File';
+
+interface LineFormatting {
+  prefix?: string;
+  commentStyle?: "short" | "long" | "none";
+  indentation?: string;
+  separator?: string;
+  suffix?: string;
+}
+
+type TokenFormatterArguments = {
+  outputReferences?: boolean;
+  dictionary: Dictionary;
+  format?: "css" | "sass" | "less" | "stylus";
+  formatting?: LineFormatting;
+}
+
+interface CommentFormatting {
+  prefix: string;
+  lineSeparator: string;
+  header: string;
+  footer: string;
+}
+
+interface FileHeaderParameters {
+  file: File;
+  commentStyle: string;
+  formatting?: CommentFormatting;
+}
+
+interface FormattedVariablesOptions {
+  format: "css" | "sass";
+  dictionary: Dictionary
+  outputReferences?: boolean;
+  formatting?: LineFormatting;
+}
+
+interface FormatHelpers {
+  createPropertyFormatter: (options: TokenFormatterArguments) =>
+    (token: TransformedToken) => string;
+  fileHeader: (options: FileHeaderParameters) => string;
+  formattedVariables: (options: FormattedVariablesOptions) => string;
+}
+
+export default FormatHelpers;

--- a/types/FormatHelpers.d.ts
+++ b/types/FormatHelpers.d.ts
@@ -11,9 +11,9 @@
  * and limitations under the License.
  */
 
-import Dictionary from './Dictionary';
-import TransformedToken from './TransformedToken';
-import File from './File';
+import { Dictionary } from './Dictionary';
+import { TransformedToken } from './TransformedToken';
+import { File } from './File';
 
 export interface LineFormatting {
   prefix?: string;
@@ -51,8 +51,9 @@ export interface FormattedVariablesArgs {
 }
 
 export interface FormatHelpers {
-  createPropertyFormatter: (args: TokenFormatterArgs) =>
-    (token: TransformedToken) => string;
+  createPropertyFormatter: (
+    args: TokenFormatterArgs
+  ) => (token: TransformedToken) => string;
   fileHeader: (args: FileHeaderArgs) => string;
   formattedVariables: (args: FormattedVariablesArgs) => string;
 }

--- a/types/Matcher.d.ts
+++ b/types/Matcher.d.ts
@@ -11,8 +11,6 @@
  * and limitations under the License.
  */
 
-import TransformedToken from './TransformedToken';
+import { TransformedToken } from './TransformedToken';
 
 export type Matcher = (token: TransformedToken) => boolean;
-
-export default Matcher;

--- a/types/Matcher.d.ts
+++ b/types/Matcher.d.ts
@@ -13,6 +13,6 @@
 
 import TransformedToken from './TransformedToken';
 
-type Matcher = (token: TransformedToken) => boolean;
+export type Matcher = (token: TransformedToken) => boolean;
 
 export default Matcher;

--- a/types/Matcher.d.ts
+++ b/types/Matcher.d.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+import TransformedToken from './TransformedToken';
+
+type Matcher = (token: TransformedToken) => boolean;
+
+export default Matcher;

--- a/types/Options.d.ts
+++ b/types/Options.d.ts
@@ -13,7 +13,7 @@
 
 import FileHeader from './FileHeader';
 
-interface Options {
+export interface Options {
   showFileHeader?: boolean;
   fileHeader?: string | FileHeader;
   outputReferences?: boolean;

--- a/types/Options.d.ts
+++ b/types/Options.d.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+import FileHeader from './FileHeader';
+
+interface Options {
+  showFileHeader?: boolean;
+  fileHeader?: string | FileHeader;
+  outputReferences?: boolean;
+  [key: string]: any;
+}
+
+export default Options;

--- a/types/Options.d.ts
+++ b/types/Options.d.ts
@@ -11,7 +11,7 @@
  * and limitations under the License.
  */
 
-import FileHeader from './FileHeader';
+import { FileHeader } from './FileHeader';
 
 export interface Options {
   showFileHeader?: boolean;
@@ -19,5 +19,3 @@ export interface Options {
   outputReferences?: boolean;
   [key: string]: any;
 }
-
-export default Options;

--- a/types/Parser.d.ts
+++ b/types/Parser.d.ts
@@ -18,7 +18,7 @@ interface ParserOptions {
   filePath: string;
 }
 
-interface Parser {
+export interface Parser {
   pattern: RegExp;
   parse: (options: ParserOptions) => DesignTokens;
 }

--- a/types/Parser.d.ts
+++ b/types/Parser.d.ts
@@ -13,7 +13,7 @@
 
 import { DesignTokens } from './DesignToken';
 
-interface ParserOptions {
+export interface ParserOptions {
   contents: string;
   filePath: string;
 }
@@ -22,5 +22,3 @@ export interface Parser {
   pattern: RegExp;
   parse: (options: ParserOptions) => DesignTokens;
 }
-
-export default Parser;

--- a/types/Parser.d.ts
+++ b/types/Parser.d.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+import { DesignTokens } from './DesignToken';
+
+interface ParserOptions {
+  contents: string;
+  filePath: string;
+}
+
+interface Parser {
+  pattern: RegExp;
+  parse: (options: ParserOptions) => DesignTokens;
+}
+
+export default Parser;

--- a/types/Platform.d.ts
+++ b/types/Platform.d.ts
@@ -14,7 +14,7 @@
 import Options from './Options';
 import File from './File';
 
-interface Platform {
+export interface Platform {
   transformGroup?: string;
   transforms?: string[];
   prefix?: string;

--- a/types/Platform.d.ts
+++ b/types/Platform.d.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+import Options from './Options';
+import File from './File';
+
+interface Platform {
+  transformGroup?: string;
+  transforms?: string[];
+  prefix?: string;
+  buildPath?: string;
+  files?: File[];
+  actions?: string[];
+  options?: Options;
+}
+
+export default Platform;

--- a/types/Platform.d.ts
+++ b/types/Platform.d.ts
@@ -11,8 +11,8 @@
  * and limitations under the License.
  */
 
-import Options from './Options';
-import File from './File';
+import { Options } from './Options';
+import { File } from './File';
 
 export interface Platform {
   transformGroup?: string;
@@ -23,5 +23,3 @@ export interface Platform {
   actions?: string[];
   options?: Options;
 }
-
-export default Platform;

--- a/types/Transform.d.ts
+++ b/types/Transform.d.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+import Matcher from './Matcher';
+import TransformedToken from './TransformedToken';
+import Platform from './Platform';
+
+interface NameTransform {
+  type: "name";
+  matcher?: Matcher;
+  transformer: (token: TransformedToken, options?: Platform) => string;
+}
+
+interface ValueTransform {
+  type: "value";
+  transitive?: boolean;
+  matcher?: Matcher;
+  transformer: (token: TransformedToken, options?: Platform) => any;
+}
+
+interface AttributeTransform {
+  type: "attribute";
+  matcher?: Matcher;
+  transformer: (token: TransformedToken, options?: Platform) => { [key: string]: any };
+}
+
+type Transform = NameTransform | ValueTransform | AttributeTransform;
+
+export default Transform;

--- a/types/Transform.d.ts
+++ b/types/Transform.d.ts
@@ -11,29 +11,36 @@
  * and limitations under the License.
  */
 
-import Matcher from './Matcher';
-import TransformedToken from './TransformedToken';
-import Platform from './Platform';
+import { Matcher } from './Matcher';
+import { TransformedToken } from './TransformedToken';
+import { Platform } from './Platform';
 
 export interface NameTransform {
   type: "name";
   matcher?: Matcher;
-  transformer: (token: TransformedToken, options?: Platform) => string;
+  transformer: (
+    token: TransformedToken,
+    options?: Platform
+  ) => string;
 }
 
 export interface ValueTransform {
   type: "value";
   transitive?: boolean;
   matcher?: Matcher;
-  transformer: (token: TransformedToken, options?: Platform) => any;
+  transformer: (
+    token: TransformedToken,
+    options?: Platform
+  ) => any;
 }
 
 export interface AttributeTransform {
   type: "attribute";
   matcher?: Matcher;
-  transformer: (token: TransformedToken, options?: Platform) => { [key: string]: any };
+  transformer: (
+    token: TransformedToken,
+    options?: Platform
+  ) => { [key: string]: any };
 }
 
 export type Transform = NameTransform | ValueTransform | AttributeTransform;
-
-export default Transform;

--- a/types/Transform.d.ts
+++ b/types/Transform.d.ts
@@ -15,25 +15,25 @@ import Matcher from './Matcher';
 import TransformedToken from './TransformedToken';
 import Platform from './Platform';
 
-interface NameTransform {
+export interface NameTransform {
   type: "name";
   matcher?: Matcher;
   transformer: (token: TransformedToken, options?: Platform) => string;
 }
 
-interface ValueTransform {
+export interface ValueTransform {
   type: "value";
   transitive?: boolean;
   matcher?: Matcher;
   transformer: (token: TransformedToken, options?: Platform) => any;
 }
 
-interface AttributeTransform {
+export interface AttributeTransform {
   type: "attribute";
   matcher?: Matcher;
   transformer: (token: TransformedToken, options?: Platform) => { [key: string]: any };
 }
 
-type Transform = NameTransform | ValueTransform | AttributeTransform;
+export type Transform = NameTransform | ValueTransform | AttributeTransform;
 
 export default Transform;

--- a/types/TransformGroup.d.ts
+++ b/types/TransformGroup.d.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+interface TransformGroup {
+  name: string;
+  transforms: string[];
+}
+
+export default TransformGroup;

--- a/types/TransformGroup.d.ts
+++ b/types/TransformGroup.d.ts
@@ -11,7 +11,7 @@
  * and limitations under the License.
  */
 
-interface TransformGroup {
+export interface TransformGroup {
   name: string;
   transforms: string[];
 }

--- a/types/TransformGroup.d.ts
+++ b/types/TransformGroup.d.ts
@@ -15,5 +15,3 @@ export interface TransformGroup {
   name: string;
   transforms: string[];
 }
-
-export default TransformGroup;

--- a/types/TransformedToken.d.ts
+++ b/types/TransformedToken.d.ts
@@ -11,7 +11,7 @@
  * and limitations under the License.
  */
 
-import DesignToken from './DesignToken';
+import { DesignToken } from './DesignToken';
 
 export type TransformedToken = DesignToken & {
   name: string;
@@ -41,5 +41,3 @@ export type TransformedToken = DesignToken & {
 export interface TransformedTokens {
   [key: string]: TransformedTokens | TransformedToken;
 }
-
-export default TransformedToken;

--- a/types/TransformedToken.d.ts
+++ b/types/TransformedToken.d.ts
@@ -13,7 +13,7 @@
 
 import DesignToken from './DesignToken';
 
-type TransformedToken = DesignToken & {
+export type TransformedToken = DesignToken & {
   name: string;
   /** The object path of the property.
    *

--- a/types/TransformedToken.d.ts
+++ b/types/TransformedToken.d.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+import DesignToken from './DesignToken';
+
+type TransformedToken = DesignToken & {
+  name: string;
+  /** The object path of the property.
+   *
+   * `color: { background: { primary: { value: "#fff" } } }` will have a path of `['color', 'background', 'primary']`.
+   */
+  path: string[];
+  /**
+   * A pristine copy of the original property object.
+   *
+   * This is to make sure transforms and formats always have the unmodified version of  the original property.
+   */
+  original: DesignToken;
+  /**
+   * The file path of the file the token is defined in.
+   *
+   * This file path is derived from the source or include file path arrays defined in the configuration.
+   */
+  filePath: string;
+  /**
+   * If the token is from a file defined in the source array as opposed to include in the [configuration](https://amzn.github.io/style-dictionary/#/config).
+   */
+  isSource: boolean;
+}
+
+export interface TransformedTokens {
+  [key: string]: TransformedTokens | TransformedToken;
+}
+
+export default TransformedToken;

--- a/types/_helpers.ts
+++ b/types/_helpers.ts
@@ -12,6 +12,5 @@
  */
 
 type Named<T> = T & { name: string; };
-type Keyed<T> = { [name: string]: T };
 
-export { Named, Keyed }
+export { Named }

--- a/types/_helpers.ts
+++ b/types/_helpers.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+type Named<T> = T & { name: string; };
+type Keyed<T> = { [name: string]: T };
+
+export { Named, Keyed }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -13,85 +13,294 @@
 
 // Minimum TypeScript Version: 3.0
 
-import _DesignToken, {DesignTokens as _DesignTokens} from './DesignToken';
-import _File from './File';
-import _Options from './Options';
-import _FileHeader from './FileHeader';
-import _TransformedToken, {TransformedTokens as _TransformedTokens} from './TransformedToken';
-import _Platform from './Platform';
-import _Transform from './Transform';
-import _Filter from './Filter';
-import _Format from './Format';
-import _Dictionary from './Dictionary';
-import _TransformGroup from './TransformGroup';
-import _Action from './Action';
-import _Parser from './Parser';
-import _Config from './Config';
-import FormatHelpers from './FormatHelpers';
+import {Action} from './Action';
+import {Config} from './Config';
+import {DesignToken, DesignTokens} from './DesignToken';
+import {Dictionary} from './Dictionary';
+import {File} from './File';
+import {FileHeader} from './FileHeader';
+import {Filter} from './Filter';
+import {Format} from './Format';
+import {FormatHelpers} from './FormatHelpers';
+import {Options} from './Options';
+import {Parser} from './Parser';
+import {Platform} from './Platform';
+import {Transform} from './Transform';
+import {TransformedToken, TransformedTokens} from './TransformedToken';
+import {TransformGroup} from './TransformGroup';
+import { Named } from './_helpers';
 
-import { Named, Keyed } from './_helpers';
 
-declare namespace StyleDictionary {
+declare interface StyleDictionary {
+  VERSION: string;
+  tokens: DesignTokens | TransformedTokens;
+  allTokens: TransformedTokens[];
+  properties: DesignTokens | TransformedTokens;
+  allProperties: TransformedTokens[];
+  options: Config;
 
-  type DesignToken = _DesignToken;
-  type DesignTokens = _DesignTokens;
-  type File = _File;
-  type Options = _Options;
-  type FileHeader = _FileHeader;
-  type TransformedToken = _TransformedToken;
-  type TransformedTokens = _TransformedTokens;
-  type Platform = _Platform;
-  type Transform = _Transform;
-  type Filter = _Filter;
-  type Format = _Format;
-  type Dictionary = _Dictionary;
-  type TransformGroup = _TransformGroup;
-  type Action = _Action;
-  type Parser = _Parser;
-  type Config = _Config;
+  transform: Record<string, Transform>;
+  transformGroup: Record<string, TransformGroup>;
+  format: Record<string, Format>;
+  action: Record<string, Action>;
+  filter: Record<string, Filter>;
+  fileHeader: Record<string, FileHeader>;
+  parsers: Parser[];
 
-  // aliased for backwards compatibility
-  type Property = DesignToken;
-  type Properties = DesignTokens;
-  type Prop = TransformedToken;
+  formatHelpers: FormatHelpers;
 
-  interface Core {
-    VERSION: string;
-    tokens: DesignTokens | TransformedTokens;
-    allTokens: TransformedTokens[];
-    properties: Properties;
-    allProperties: Prop[];
-    options: Config;
+  /**
+   * Add a custom transform to the Style Dictionary
+   * Transforms can manipulate a token's name, value, or attributes
+   *
+   * @param {String} transform.type - Type of transform, can be: name, attribute, or value
+   * @param {String} transform.name - Name of the transformer (used by transformGroup to call a list of transforms).
+   * @param {Boolean} transform.transitive - If the value transform should be applied transitively, i.e. should be applied to referenced values as well as absolute values.
+   * @param {Function} [transform.matcher] - Matcher function, return boolean if transform should be applied. If you omit the matcher function, it will match all tokens.
+   * @param {Function} transform.transformer Modifies a design token object. The transformer function will receive the token and the platform configuration as its arguments. The transformer function should return a string for name transforms, an object for attribute transforms, and same type of value for a value transform.
+   * @example
+   * ```js
+   * StyleDictionary.registerTransform({
+   *   name: 'time/seconds',
+   *   type: 'value',
+   *   matcher: function(token) {
+   *     return token.attributes.category === 'time';
+   *   },
+   *   transformer: function(token) {
+   *     return (parseInt(token.original.value) / 1000).toString() + 's';
+   *   }
+   * });
+   * ```
+   */
+  registerTransform(transform: Named<Transform>): this;
 
-    transform: Keyed<Transform>;
-    transformGroup: Keyed<TransformGroup>;
-    format: Keyed<Format>;
-    action: Keyed<Action>;
-    filter: Keyed<Filter>;
-    fileHeader: Keyed<FileHeader>;
-    parsers: Parser[];
+  /**
+   * Add a custom transformGroup to the Style Dictionary, which is a
+   * group of transforms.
+   * @param {String} transformGroup.name - Name of the transform group that will be referenced in config.json
+   * @param {String[]} transformGroup.transforms - Array of strings that reference the name of transforms to be applied in order. Transforms must be defined and match the name or there will be an error at build time.
+   * @example
+   * ```js
+   * StyleDictionary.registerTransformGroup({
+   *   name: 'Swift',
+   *   transforms: [
+   *     'attribute/cti',
+   *     'size/pt',
+   *     'name/cti'
+   *   ]
+   * });
+   * ```
+   */
+  registerTransformGroup(transformGroup: Named<TransformGroup>): this;
 
-    formatHelpers: FormatHelpers;
+  /**
+   * Add a custom format to Style Dictionary
+   * @param {String} format.name The name of the format to be added
+   * @param {Formatter} format.formatter The formatter function
+   * @example
+   * ```js
+   * StyleDictionary.registerFormat({
+   *   name: 'json',
+   *   formatter: function({dictionary, platform, options, file}) {
+   *     return JSON.stringify(dictionary.tokens, null, 2);
+   *   }
+   * })
+   * ```
+   */
+  registerFormat(format: Named<Format>): this;
 
-    registerTransform(this: Core, transform: Named<Transform>): this;
-    registerTransformGroup(this: Core, transformGroup: Named<TransformGroup>): this;
-    registerFormat(this: Core, format: Named<Format>): this;
-    registerTemplate(this: Core, template: Named<{ template: string }>): this;
-    registerAction(this: Core, action: Named<Action>): this;
-    registerFilter(this: Core, filter: Named<Filter>): this;
-    registerParser(this: Core, parser: Parser): this;
+  /**
+   * Add a custom template to Style Dictionary
+   * @deprecated registerTemplate will be removed in the future, please use registerFormat
+   * @param {String} template.name - The name of your template. You will refer to this in your config.json file.
+   * @param {String} template.template - Path to your lodash template
+   * @example
+   * ```js
+   * StyleDictionary.registerTemplate({
+   *   name: 'Swift/colors',
+   *   template: __dirname + '/templates/swift/colors.template'
+   * });
+   * ```
+   */
+  registerTemplate(template: Named<{ template: string }>): this;
 
-    exportPlatform(this: Core, platform: string): TransformedTokens;
-    buildPlatform(this: Core, platform: string): this;
-    buildAllPlatforms(this: Core): this;
+  /**
+   * Add a custom filter to Style Dictionary. Filters are used to hide tokens from
+   * generated files.
+   * @param {String} filter.name - Name of the filter to be referenced in your config.json
+   * @param {Function} filter.matcher - Matcher function, return boolean if the token should be included.
+   * @example
+   * ```js
+   * StyleDictionary.registerFilter({
+   *   name: 'isColor',
+   *   matcher: function(token) {
+    *     return token.attributes.category === 'color';
+    *   }
+  * })
+  * ```
+  */
+  registerFilter(filter: Named<Filter>): this;
 
-    cleanPlatform(this: Core, platform: string): this;
-    cleanAllPlatforms(this: Core): this;
+  /**
+   * Adds a custom parser to parse style dictionary files. This allows you to modify
+   * the design token data before it gets to Style Dictionary or write your
+   * token files in a language other than JSON, JSON5, or CommonJS modules.
+   *
+   * @param {Regex} parser.pattern - A file path regular expression to match which files this parser should be be used on. This is similar to how webpack loaders work. `/\.json$/` will match any file ending in '.json', for example.
+   * @param {Function} parser.parse - Function to parse the file contents. Takes 1 argument, which is an object with 2 attributes: contents which is the string of the file contents and filePath. The function should return a plain Javascript object.
+   * @example
+   * ```js
+   * StyleDictionary.registerParser({
+   *   pattern: /\.json$/,
+   *   parse: ({contents, filePath}) => {
+   *     return JSON.parse(contents);
+   *   }
+   * })
+   * ```
+   */
+  registerParser(parser: Parser): this;
 
-    extend(this: Core, options: string | Config): this;
-  }
+  /**
+   * Adds a custom action to Style Dictionary. Actions
+   * are functions that can do whatever you need, such as: copying files,
+   * base64'ing files, running other build scripts, etc.
+   * After you register a custom action, you then use that
+   * action in a platform your configuration
+   *
+   * You can perform operations on files generated by the style dictionary
+   * as actions run after these files are generated.
+   * Actions are run sequentially, if you write synchronous code then
+   * it will block other actions, or if you use asynchronous code like Promises
+   * it will not block.
+   *
+   * @param {String} action.name - The name of the action
+   * @param {Function} action.do - The action in the form of a function.
+   * @param {Function} [action.undo] - A function that undoes the action.
+   * @example
+   * ```js
+   * StyleDictionary.registerAction({
+   *   name: 'copy_assets',
+   *   do: function(dictionary, config) {
+   *     console.log('Copying assets directory');
+   *     fs.copySync('assets', config.buildPath + 'assets');
+   *   },
+   *   undo: function(dictionary, config) {
+   *     console.log('Cleaning assets directory');
+   *     fs.removeSync(config.buildPath + 'assets');
+   *   }
+   * });
+   * ```
+   */
+  registerAction(action: Named<Action>): this;
+
+  /**
+   * Exports a tokens object with applied
+   * platform transforms.
+   *
+   * This is useful if you want to use a style
+   * dictionary in JS build tools like webpack.
+   *
+   * @param {String} platform - Name of the platform to be exported. This platform name must exist on the Style Dictionary configuration.
+   */
+  exportPlatform(platform: string): TransformedTokens;
+
+  /**
+   * Takes a platform and performs all transforms to
+   * the tokens object (non-mutative) then
+   * builds all the files and performs any actions. This is useful if you only want to
+   * build the artifacts of one platform to speed up the build process.
+   *
+   * This method is also used internally in `.buildAllPlatforms` to
+   * build each platform defined in the config.
+   *
+   * @param {String} platform - Name of the platform you want to build. This platform name must exist on the Style Dictionary configuration.
+   * @example
+   * ```js
+   * StyleDictionary.buildPlatform('web');
+   * ```
+   * ```bash
+   * $ style-dictionary build --platform web
+   * ```
+   */
+  buildPlatform(platform: string): this;
+
+  /**
+   * Will build all the platforms defined in the configuration.
+   *
+   * @example
+   * ```js
+   * const StyleDictionary = require('style-dictionary').extend('config.json');
+   * StyleDictionary.buildAllPlatforms();
+   * ```
+  */
+  buildAllPlatforms(): this;
+
+  /**
+   * Takes a platform and performs all transforms to
+   * the tokens object (non-mutative) then
+   * cleans all the files and performs the undo method of any actions.
+   *
+   * @param {String} platform
+   */
+  cleanPlatform(platform: string): this;
+
+  /**
+   * Does the reverse of `.buildAllPlatforms` by
+   * performing a clean on each platform. This removes all the files
+   * defined in the platform and calls the undo method on any actions.
+   *
+   * @example
+   * ```js
+   * StyleDictionary.cleanAllPlatforms();
+   * ```
+   */
+  cleanAllPlatforms(this: StyleDictionary): this;
+
+  /**
+   * Creates a Style Dictionary
+   * @param {String | Config} config - The configuration for Style Dictionary, can either be a path to a JSON or CommonJS file or a configuration object.
+   * @example
+   * ```js
+   * const StyleDictionary = require('style-dictionary').extend('config.json');
+   *
+   * const StyleDictionary = require('style-dictionary').extend({
+   *   source: ['tokens/*.json'],
+   *   platforms: {
+   *     scss: {
+   *       transformGroup: 'scss',
+   *       buildPath: 'build/',
+   *       files: [{
+   *         destination: 'variables.scss',
+   *         format: 'scss/variables'
+   *       }]
+   *     }
+   *     // ...
+   *   }
+   * });
+   * ```
+   */
+  extend(config: string | Config): StyleDictionary;
 }
 
-declare var StyleDictionary: StyleDictionary.Core;
-export = StyleDictionary;
-export as namespace StyleDictionary;
+export {
+  Action,
+  Config,
+  DesignToken,
+  DesignTokens,
+  Dictionary,
+  File,
+  Filter,
+  Format,
+  FormatHelpers,
+  Options,
+  Parser,
+  Platform,
+  StyleDictionary,
+  Transform,
+  TransformedToken,
+  TransformedTokens,
+  TransformGroup,
+}
+
+declare var StyleDictionary: StyleDictionary;
+export default StyleDictionary;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -304,6 +304,5 @@ declare namespace StyleDictionary {
   }
 }
 
-
 declare var StyleDictionary: StyleDictionary.Core;
 export = StyleDictionary;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -13,182 +13,75 @@
 
 // Minimum TypeScript Version: 3.0
 
+import _DesignToken, {DesignTokens as _DesignTokens} from './DesignToken';
+import _File from './File';
+import _Options from './Options';
+import _FileHeader from './FileHeader';
+import _TransformedToken, {TransformedTokens as _TransformedTokens} from './TransformedToken';
+import _Platform from './Platform';
+import _Transform from './Transform';
+import _Filter from './Filter';
+import _Format from './Format';
+import _Dictionary from './Dictionary';
+import _TransformGroup from './TransformGroup';
+import _Action from './Action';
+import _Parser from './Parser';
+import _Config from './Config';
+import FormatHelpers from './FormatHelpers';
+
+import { Named, Keyed } from './_helpers';
+
 declare namespace StyleDictionary {
-  interface Property {
-    value: string;
-    comment?: string;
-    [key: string]: any;
-  }
 
-  interface Properties {
-    [key: string]: Properties | Property;
-  }
+  type DesignToken = _DesignToken;
+  type DesignTokens = _DesignTokens;
+  type File = _File;
+  type Options = _Options;
+  type FileHeader = _FileHeader;
+  type TransformedToken = _TransformedToken;
+  type TransformedTokens = _TransformedTokens;
+  type Platform = _Platform;
+  type Transform = _Transform;
+  type Filter = _Filter;
+  type Format = _Format;
+  type Dictionary = _Dictionary;
+  type TransformGroup = _TransformGroup;
+  type Action = _Action;
+  type Parser = _Parser;
+  type Config = _Config;
 
-  interface Options {
-    showFileHeader: boolean;
-  }
-
-  interface File {
-    destination?: string;
-    format?: string;
-    filter?: string | Partial<Prop> | ((property: Prop) => boolean);
-    options?: Options;
-  }
-
-  interface Platform {
-    transformGroup?: string;
-    transforms?: string[];
-    prefix?: string;
-    buildPath?: string;
-    files?: File[];
-    actions?: string[];
-  }
-
-  interface Config {
-    parsers?: Parser[];
-    transform?: Transforms;
-    include?: string[];
-    source: string[];
-    platforms: { [platform: string]: Platform };
-  }
-
-  interface Attributes {
-    category: string;
-    type: string;
-    item?: string;
-    subitem?: string;
-    state?: string;
-  }
-
-  interface Prop {
-    /** A default name of the property that is set to the key of the property. */
-    name: string;
-    value: string;
-    /** The object path of the property.
-     *
-     * `color: { background: { primary: { value: "#fff" } } }` will have a path of `['color', 'background', 'primary']`.
-     */
-    path: string[];
-    /**
-     * A pristine copy of the original property object.
-     *
-     * This is to make sure transforms and formats always have the unmodified version of the original property.
-     */
-    original: Property;
-    /**
-     * The file path of the file the token is defined in.
-     *
-     * This file path is derived from the source or include file path arrays defined in the configuration.
-     */
-    filePath: string;
-    /**
-     * If the token is from a file defined in the source array as opposed to include in the [configuration](https://amzn.github.io/style-dictionary/#/config).
-     */
-    isSource: boolean;
-    attributes: Attributes;
-    [key: string]: any;
-  }
-
-  interface NameTransform {
-    type: "name";
-    matcher?: (prop: Prop) => boolean;
-    transformer: (prop: Prop, options?: Platform) => string;
-  }
-
-  interface ValueTransform {
-    type: "value";
-    transitive?: boolean;
-    matcher?: (prop: Prop) => boolean;
-    transformer: (prop: Prop, options?: Platform) => string;
-  }
-
-  interface AttributeTransform {
-    type: "attribute";
-    matcher?: (prop: Prop) => boolean;
-    transformer: (prop: Prop, options?: Platform) => { [key: string]: any };
-  }
-
-  type Transform = NameTransform | ValueTransform | AttributeTransform;
-
-  interface Transforms {
-    [name: string]: Transform;
-  }
-
-  interface TransformGroup {
-    name: string;
-    transforms: string[];
-  }
-
-  interface TransformGroups {
-    [name: string]: string[];
-  }
-
-  type Formatter = (this: File, dictionary: Core, config: Platform) => string;
-
-  interface Format {
-    name: string;
-    formatter: Formatter;
-  }
-
-  interface Formats {
-    [name: string]: Formatter;
-  }
-
-  interface Action {
-    do(dictionary: Core, config: Platform): void;
-    undo?(dictionary: Core, config: Platform): void;
-  }
-
-  interface Actions {
-    [name: string]: Action;
-  }
-
-  type Matcher = (prop: Prop) => boolean;
-
-  interface Filter {
-    name: string;
-    matcher: Matcher;
-  }
-
-  interface Filters {
-    [name: string]: Matcher;
-  }
-
-  interface ParserOptions {
-    contents: string;
-    filePath: string;
-  }
-
-  interface Parser {
-    pattern: RegExp;
-    parse: (props: ParserOptions) => Properties;
-  }
-
-  type Named<T> = T & {
-    name: string;
-  };
+  // aliased for backwards compatibility
+  type Property = DesignToken;
+  type Properties = DesignTokens;
+  type Prop = TransformedToken;
 
   interface Core {
     VERSION: string;
+    tokens: DesignTokens | TransformedTokens;
+    allTokens: TransformedTokens[];
     properties: Properties;
     allProperties: Prop[];
     options: Config;
 
-    transform: Transforms;
-    transformGroup: TransformGroups;
-    format: Formats;
-    action: Actions;
-    filter: Filters;
+    transform: Keyed<Transform>;
+    transformGroup: Keyed<TransformGroup>;
+    format: Keyed<Format>;
+    action: Keyed<Action>;
+    filter: Keyed<Filter>;
+    fileHeader: Keyed<FileHeader>;
+    parsers: Parser[];
 
-    registerTransform(this: Core, options: Named<Transform>): this;
-    registerTransformGroup(this: Core, options: TransformGroup): this;
-    registerFormat(this: Core, format: Format): this;
+    formatHelpers: FormatHelpers;
+
+    registerTransform(this: Core, transform: Named<Transform>): this;
+    registerTransformGroup(this: Core, transformGroup: Named<TransformGroup>): this;
+    registerFormat(this: Core, format: Named<Format>): this;
     registerTemplate(this: Core, template: Named<{ template: string }>): this;
     registerAction(this: Core, action: Named<Action>): this;
-    registerFilter(this: Core, filter: Filter): this;
+    registerFilter(this: Core, filter: Named<Filter>): this;
     registerParser(this: Core, parser: Parser): this;
 
-    exportPlatform(this: Core, platform: string): Properties;
+    exportPlatform(this: Core, platform: string): TransformedTokens;
     buildPlatform(this: Core, platform: string): this;
     buildAllPlatforms(this: Core): this;
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -13,294 +13,297 @@
 
 // Minimum TypeScript Version: 3.0
 
-import {Action} from './Action';
-import {Config} from './Config';
-import {DesignToken, DesignTokens} from './DesignToken';
-import {Dictionary} from './Dictionary';
-import {File} from './File';
-import {FileHeader} from './FileHeader';
-import {Filter} from './Filter';
-import {Format} from './Format';
-import {FormatHelpers} from './FormatHelpers';
-import {Options} from './Options';
-import {Parser} from './Parser';
-import {Platform} from './Platform';
-import {Transform} from './Transform';
-import {TransformedToken, TransformedTokens} from './TransformedToken';
-import {TransformGroup} from './TransformGroup';
-import { Named } from './_helpers';
+import {Action as _Action} from './Action';
+import {Config as _Config} from './Config';
+import {DesignToken as _DesignToken, DesignTokens as _DesignTokens} from './DesignToken';
+import {Dictionary as _Dictionary} from './Dictionary';
+import {File as _File} from './File';
+import {FileHeader as _FileHeader} from './FileHeader';
+import {Filter as _Filter} from './Filter';
+import {Format as _Format} from './Format';
+import {FormatHelpers as _FormatHelpers} from './FormatHelpers';
+import {Options as _Options} from './Options';
+import {Parser as _Parser} from './Parser';
+import {Platform as _Platform} from './Platform';
+import {Transform as _Transform} from './Transform';
+import {TransformedToken as _TransformedToken, TransformedTokens as _TransformedTokens} from './TransformedToken';
+import {TransformGroup as _TransformGroup} from './TransformGroup';
+import {Named} from './_helpers';
 
+// Because this library is used in Node and needs to be accessible
+// as a CommonJS module, we are declaring it as a namespace so that
+// autocomplete works for CommonJS files.
+declare namespace StyleDictionary {
+  type Action = _Action;
+  type Config = _Config;
+  type DesignToken = _DesignToken;
+  type DesignTokens = _DesignTokens;
+  type Dictionary = _Dictionary;
+  type File = _File;
+  type FileHeader = _FileHeader;
+  type Filter = _Filter;
+  type Format = _Format;
+  type FormatHelpers = _FormatHelpers;
+  type Options = _Options;
+  type Parser = _Parser;
+  type Platform = _Platform;
+  type Transform = _Transform;
+  type TransformedToken = _TransformedToken;
+  type TransformedTokens = _TransformedTokens;
+  type TransformGroup = _TransformGroup;
 
-declare interface StyleDictionary {
-  VERSION: string;
-  tokens: DesignTokens | TransformedTokens;
-  allTokens: TransformedTokens[];
-  properties: DesignTokens | TransformedTokens;
-  allProperties: TransformedTokens[];
-  options: Config;
+  interface Core {
+    VERSION: string;
+    tokens: DesignTokens | TransformedTokens;
+    allTokens: TransformedTokens[];
+    properties: DesignTokens | TransformedTokens;
+    allProperties: TransformedTokens[];
+    options: Config;
 
-  transform: Record<string, Transform>;
-  transformGroup: Record<string, TransformGroup>;
-  format: Record<string, Format>;
-  action: Record<string, Action>;
-  filter: Record<string, Filter>;
-  fileHeader: Record<string, FileHeader>;
-  parsers: Parser[];
+    transform: Record<string, Transform>;
+    transformGroup: Record<string, TransformGroup>;
+    format: Record<string, Format>;
+    action: Record<string, Action>;
+    filter: Record<string, Filter>;
+    fileHeader: Record<string, FileHeader>;
+    parsers: Parser[];
 
-  formatHelpers: FormatHelpers;
+    formatHelpers: FormatHelpers;
 
-  /**
-   * Add a custom transform to the Style Dictionary
-   * Transforms can manipulate a token's name, value, or attributes
-   *
-   * @param {String} transform.type - Type of transform, can be: name, attribute, or value
-   * @param {String} transform.name - Name of the transformer (used by transformGroup to call a list of transforms).
-   * @param {Boolean} transform.transitive - If the value transform should be applied transitively, i.e. should be applied to referenced values as well as absolute values.
-   * @param {Function} [transform.matcher] - Matcher function, return boolean if transform should be applied. If you omit the matcher function, it will match all tokens.
-   * @param {Function} transform.transformer Modifies a design token object. The transformer function will receive the token and the platform configuration as its arguments. The transformer function should return a string for name transforms, an object for attribute transforms, and same type of value for a value transform.
-   * @example
-   * ```js
-   * StyleDictionary.registerTransform({
-   *   name: 'time/seconds',
-   *   type: 'value',
-   *   matcher: function(token) {
-   *     return token.attributes.category === 'time';
-   *   },
-   *   transformer: function(token) {
-   *     return (parseInt(token.original.value) / 1000).toString() + 's';
-   *   }
-   * });
-   * ```
-   */
-  registerTransform(transform: Named<Transform>): this;
+    /**
+     * Add a custom transform to the Style Dictionary
+     * Transforms can manipulate a token's name, value, or attributes
+     *
+     * @param {String} transform.type - Type of transform, can be: name, attribute, or value
+     * @param {String} transform.name - Name of the transformer (used by transformGroup to call a list of transforms).
+     * @param {Boolean} transform.transitive - If the value transform should be applied transitively, i.e. should be applied to referenced values as well as absolute values.
+     * @param {Function} [transform.matcher] - Matcher function, return boolean if transform should be applied. If you omit the matcher function, it will match all tokens.
+     * @param {Function} transform.transformer Modifies a design token object. The transformer function will receive the token and the platform configuration as its arguments. The transformer function should return a string for name transforms, an object for attribute transforms, and same type of value for a value transform.
+     * @example
+     * ```js
+     * StyleDictionary.registerTransform({
+     *   name: 'time/seconds',
+     *   type: 'value',
+     *   matcher: function(token) {
+     *     return token.attributes.category === 'time';
+     *   },
+     *   transformer: function(token) {
+     *     return (parseInt(token.original.value) / 1000).toString() + 's';
+     *   }
+     * });
+     * ```
+     */
+    registerTransform(transform: Named<Transform>): this;
 
-  /**
-   * Add a custom transformGroup to the Style Dictionary, which is a
-   * group of transforms.
-   * @param {String} transformGroup.name - Name of the transform group that will be referenced in config.json
-   * @param {String[]} transformGroup.transforms - Array of strings that reference the name of transforms to be applied in order. Transforms must be defined and match the name or there will be an error at build time.
-   * @example
-   * ```js
-   * StyleDictionary.registerTransformGroup({
-   *   name: 'Swift',
-   *   transforms: [
-   *     'attribute/cti',
-   *     'size/pt',
-   *     'name/cti'
-   *   ]
-   * });
-   * ```
-   */
-  registerTransformGroup(transformGroup: Named<TransformGroup>): this;
+    /**
+     * Add a custom transformGroup to the Style Dictionary, which is a
+     * group of transforms.
+     * @param {String} transformGroup.name - Name of the transform group that will be referenced in config.json
+     * @param {String[]} transformGroup.transforms - Array of strings that reference the name of transforms to be applied in order. Transforms must be defined and match the name or there will be an error at build time.
+     * @example
+     * ```js
+     * StyleDictionary.registerTransformGroup({
+     *   name: 'Swift',
+     *   transforms: [
+     *     'attribute/cti',
+     *     'size/pt',
+     *     'name/cti'
+     *   ]
+     * });
+     * ```
+     */
+    registerTransformGroup(transformGroup: Named<TransformGroup>): this;
 
-  /**
-   * Add a custom format to Style Dictionary
-   * @param {String} format.name The name of the format to be added
-   * @param {Formatter} format.formatter The formatter function
-   * @example
-   * ```js
-   * StyleDictionary.registerFormat({
-   *   name: 'json',
-   *   formatter: function({dictionary, platform, options, file}) {
-   *     return JSON.stringify(dictionary.tokens, null, 2);
-   *   }
-   * })
-   * ```
-   */
-  registerFormat(format: Named<Format>): this;
+    /**
+     * Add a custom format to Style Dictionary
+     * @param {String} format.name The name of the format to be added
+     * @param {Formatter} format.formatter The formatter function
+     * @example
+     * ```js
+     * StyleDictionary.registerFormat({
+     *   name: 'json',
+     *   formatter: function({dictionary, platform, options, file}) {
+     *     return JSON.stringify(dictionary.tokens, null, 2);
+     *   }
+     * })
+     * ```
+     */
+    registerFormat(format: Named<Format>): this;
 
-  /**
-   * Add a custom template to Style Dictionary
-   * @deprecated registerTemplate will be removed in the future, please use registerFormat
-   * @param {String} template.name - The name of your template. You will refer to this in your config.json file.
-   * @param {String} template.template - Path to your lodash template
-   * @example
-   * ```js
-   * StyleDictionary.registerTemplate({
-   *   name: 'Swift/colors',
-   *   template: __dirname + '/templates/swift/colors.template'
-   * });
-   * ```
-   */
-  registerTemplate(template: Named<{ template: string }>): this;
+    /**
+     * Add a custom template to Style Dictionary
+     * @deprecated registerTemplate will be removed in the future, please use registerFormat
+     * @param {String} template.name - The name of your template. You will refer to this in your config.json file.
+     * @param {String} template.template - Path to your lodash template
+     * @example
+     * ```js
+     * StyleDictionary.registerTemplate({
+     *   name: 'Swift/colors',
+     *   template: __dirname + '/templates/swift/colors.template'
+     * });
+     * ```
+     */
+    registerTemplate(template: Named<{ template: string }>): this;
 
-  /**
-   * Add a custom filter to Style Dictionary. Filters are used to hide tokens from
-   * generated files.
-   * @param {String} filter.name - Name of the filter to be referenced in your config.json
-   * @param {Function} filter.matcher - Matcher function, return boolean if the token should be included.
-   * @example
-   * ```js
-   * StyleDictionary.registerFilter({
-   *   name: 'isColor',
-   *   matcher: function(token) {
-    *     return token.attributes.category === 'color';
-    *   }
-  * })
-  * ```
-  */
-  registerFilter(filter: Named<Filter>): this;
+    /**
+     * Add a custom filter to Style Dictionary. Filters are used to hide tokens from
+     * generated files.
+     * @param {String} filter.name - Name of the filter to be referenced in your config.json
+     * @param {Function} filter.matcher - Matcher function, return boolean if the token should be included.
+     * @example
+     * ```js
+     * StyleDictionary.registerFilter({
+     *   name: 'isColor',
+     *   matcher: function(token) {
+      *     return token.attributes.category === 'color';
+      *   }
+    * })
+    * ```
+    */
+    registerFilter(filter: Named<Filter>): this;
 
-  /**
-   * Adds a custom parser to parse style dictionary files. This allows you to modify
-   * the design token data before it gets to Style Dictionary or write your
-   * token files in a language other than JSON, JSON5, or CommonJS modules.
-   *
-   * @param {Regex} parser.pattern - A file path regular expression to match which files this parser should be be used on. This is similar to how webpack loaders work. `/\.json$/` will match any file ending in '.json', for example.
-   * @param {Function} parser.parse - Function to parse the file contents. Takes 1 argument, which is an object with 2 attributes: contents which is the string of the file contents and filePath. The function should return a plain Javascript object.
-   * @example
-   * ```js
-   * StyleDictionary.registerParser({
-   *   pattern: /\.json$/,
-   *   parse: ({contents, filePath}) => {
-   *     return JSON.parse(contents);
-   *   }
-   * })
-   * ```
-   */
-  registerParser(parser: Parser): this;
+    /**
+     * Adds a custom parser to parse style dictionary files. This allows you to modify
+     * the design token data before it gets to Style Dictionary or write your
+     * token files in a language other than JSON, JSON5, or CommonJS modules.
+     *
+     * @param {Regex} parser.pattern - A file path regular expression to match which files this parser should be be used on. This is similar to how webpack loaders work. `/\.json$/` will match any file ending in '.json', for example.
+     * @param {Function} parser.parse - Function to parse the file contents. Takes 1 argument, which is an object with 2 attributes: contents which is the string of the file contents and filePath. The function should return a plain Javascript object.
+     * @example
+     * ```js
+     * StyleDictionary.registerParser({
+     *   pattern: /\.json$/,
+     *   parse: ({contents, filePath}) => {
+     *     return JSON.parse(contents);
+     *   }
+     * })
+     * ```
+     */
+    registerParser(parser: Parser): this;
 
-  /**
-   * Adds a custom action to Style Dictionary. Actions
-   * are functions that can do whatever you need, such as: copying files,
-   * base64'ing files, running other build scripts, etc.
-   * After you register a custom action, you then use that
-   * action in a platform your configuration
-   *
-   * You can perform operations on files generated by the style dictionary
-   * as actions run after these files are generated.
-   * Actions are run sequentially, if you write synchronous code then
-   * it will block other actions, or if you use asynchronous code like Promises
-   * it will not block.
-   *
-   * @param {String} action.name - The name of the action
-   * @param {Function} action.do - The action in the form of a function.
-   * @param {Function} [action.undo] - A function that undoes the action.
-   * @example
-   * ```js
-   * StyleDictionary.registerAction({
-   *   name: 'copy_assets',
-   *   do: function(dictionary, config) {
-   *     console.log('Copying assets directory');
-   *     fs.copySync('assets', config.buildPath + 'assets');
-   *   },
-   *   undo: function(dictionary, config) {
-   *     console.log('Cleaning assets directory');
-   *     fs.removeSync(config.buildPath + 'assets');
-   *   }
-   * });
-   * ```
-   */
-  registerAction(action: Named<Action>): this;
+    /**
+     * Adds a custom action to Style Dictionary. Actions
+     * are functions that can do whatever you need, such as: copying files,
+     * base64'ing files, running other build scripts, etc.
+     * After you register a custom action, you then use that
+     * action in a platform your configuration
+     *
+     * You can perform operations on files generated by the style dictionary
+     * as actions run after these files are generated.
+     * Actions are run sequentially, if you write synchronous code then
+     * it will block other actions, or if you use asynchronous code like Promises
+     * it will not block.
+     *
+     * @param {String} action.name - The name of the action
+     * @param {Function} action.do - The action in the form of a function.
+     * @param {Function} [action.undo] - A function that undoes the action.
+     * @example
+     * ```js
+     * StyleDictionary.registerAction({
+     *   name: 'copy_assets',
+     *   do: function(dictionary, config) {
+     *     console.log('Copying assets directory');
+     *     fs.copySync('assets', config.buildPath + 'assets');
+     *   },
+     *   undo: function(dictionary, config) {
+     *     console.log('Cleaning assets directory');
+     *     fs.removeSync(config.buildPath + 'assets');
+     *   }
+     * });
+     * ```
+     */
+    registerAction(action: Named<Action>): this;
 
-  /**
-   * Exports a tokens object with applied
-   * platform transforms.
-   *
-   * This is useful if you want to use a style
-   * dictionary in JS build tools like webpack.
-   *
-   * @param {String} platform - Name of the platform to be exported. This platform name must exist on the Style Dictionary configuration.
-   */
-  exportPlatform(platform: string): TransformedTokens;
+    /**
+     * Exports a tokens object with applied
+     * platform transforms.
+     *
+     * This is useful if you want to use a style
+     * dictionary in JS build tools like webpack.
+     *
+     * @param {String} platform - Name of the platform to be exported. This platform name must exist on the Style Dictionary configuration.
+     */
+    exportPlatform(platform: string): TransformedTokens;
 
-  /**
-   * Takes a platform and performs all transforms to
-   * the tokens object (non-mutative) then
-   * builds all the files and performs any actions. This is useful if you only want to
-   * build the artifacts of one platform to speed up the build process.
-   *
-   * This method is also used internally in `.buildAllPlatforms` to
-   * build each platform defined in the config.
-   *
-   * @param {String} platform - Name of the platform you want to build. This platform name must exist on the Style Dictionary configuration.
-   * @example
-   * ```js
-   * StyleDictionary.buildPlatform('web');
-   * ```
-   * ```bash
-   * $ style-dictionary build --platform web
-   * ```
-   */
-  buildPlatform(platform: string): this;
+    /**
+     * Takes a platform and performs all transforms to
+     * the tokens object (non-mutative) then
+     * builds all the files and performs any actions. This is useful if you only want to
+     * build the artifacts of one platform to speed up the build process.
+     *
+     * This method is also used internally in `.buildAllPlatforms` to
+     * build each platform defined in the config.
+     *
+     * @param {String} platform - Name of the platform you want to build. This platform name must exist on the Style Dictionary configuration.
+     * @example
+     * ```js
+     * StyleDictionary.buildPlatform('web');
+     * ```
+     * ```bash
+     * $ style-dictionary build --platform web
+     * ```
+     */
+    buildPlatform(platform: string): this;
 
-  /**
-   * Will build all the platforms defined in the configuration.
-   *
-   * @example
-   * ```js
-   * const StyleDictionary = require('style-dictionary').extend('config.json');
-   * StyleDictionary.buildAllPlatforms();
-   * ```
-  */
-  buildAllPlatforms(): this;
+    /**
+     * Will build all the platforms defined in the configuration.
+     *
+     * @example
+     * ```js
+     * const StyleDictionary = require('style-dictionary').extend('config.json');
+     * StyleDictionary.buildAllPlatforms();
+     * ```
+    */
+    buildAllPlatforms(): this;
 
-  /**
-   * Takes a platform and performs all transforms to
-   * the tokens object (non-mutative) then
-   * cleans all the files and performs the undo method of any actions.
-   *
-   * @param {String} platform
-   */
-  cleanPlatform(platform: string): this;
+    /**
+     * Takes a platform and performs all transforms to
+     * the tokens object (non-mutative) then
+     * cleans all the files and performs the undo method of any actions.
+     *
+     * @param {String} platform
+     */
+    cleanPlatform(platform: string): this;
 
-  /**
-   * Does the reverse of `.buildAllPlatforms` by
-   * performing a clean on each platform. This removes all the files
-   * defined in the platform and calls the undo method on any actions.
-   *
-   * @example
-   * ```js
-   * StyleDictionary.cleanAllPlatforms();
-   * ```
-   */
-  cleanAllPlatforms(this: StyleDictionary): this;
+    /**
+     * Does the reverse of `.buildAllPlatforms` by
+     * performing a clean on each platform. This removes all the files
+     * defined in the platform and calls the undo method on any actions.
+     *
+     * @example
+     * ```js
+     * StyleDictionary.cleanAllPlatforms();
+     * ```
+     */
+    cleanAllPlatforms(): this;
 
-  /**
-   * Creates a Style Dictionary
-   * @param {String | Config} config - The configuration for Style Dictionary, can either be a path to a JSON or CommonJS file or a configuration object.
-   * @example
-   * ```js
-   * const StyleDictionary = require('style-dictionary').extend('config.json');
-   *
-   * const StyleDictionary = require('style-dictionary').extend({
-   *   source: ['tokens/*.json'],
-   *   platforms: {
-   *     scss: {
-   *       transformGroup: 'scss',
-   *       buildPath: 'build/',
-   *       files: [{
-   *         destination: 'variables.scss',
-   *         format: 'scss/variables'
-   *       }]
-   *     }
-   *     // ...
-   *   }
-   * });
-   * ```
-   */
-  extend(config: string | Config): StyleDictionary;
+    /**
+     * Creates a Style Dictionary
+     * @param {String | Config} config - The configuration for Style Dictionary, can either be a path to a JSON or CommonJS file or a configuration object.
+     * @example
+     * ```js
+     * const StyleDictionary = require('style-dictionary').extend('config.json');
+     *
+     * const StyleDictionary = require('style-dictionary').extend({
+     *   source: ['tokens/*.json'],
+     *   platforms: {
+     *     scss: {
+     *       transformGroup: 'scss',
+     *       buildPath: 'build/',
+     *       files: [{
+     *         destination: 'variables.scss',
+     *         format: 'scss/variables'
+     *       }]
+     *     }
+     *     // ...
+     *   }
+     * });
+     * ```
+     */
+    extend(config: string | Config): Core;
+  }
 }
 
-export {
-  Action,
-  Config,
-  DesignToken,
-  DesignTokens,
-  Dictionary,
-  File,
-  Filter,
-  Format,
-  FormatHelpers,
-  Options,
-  Parser,
-  Platform,
-  StyleDictionary,
-  Transform,
-  TransformedToken,
-  TransformedTokens,
-  TransformGroup,
-}
 
-declare var StyleDictionary: StyleDictionary;
-export default StyleDictionary;
+declare var StyleDictionary: StyleDictionary.Core;
+export = StyleDictionary;

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -12,26 +12,19 @@
  */
 
 import { expectType, expectError, expectAssignable } from "tsd";
-import StyleDictionary, {
-  TransformedTokens,
-  TransformedToken,
-  Dictionary,
-  File,
-  Options,
-  Platform
-} from ".";
+import StyleDictionary = require(".");
 
-expectType<StyleDictionary>(StyleDictionary.buildAllPlatforms());
-expectType<StyleDictionary>(StyleDictionary.buildPlatform("web"));
+expectType<StyleDictionary.Core>(StyleDictionary.buildAllPlatforms());
+expectType<StyleDictionary.Core>(StyleDictionary.buildPlatform("web"));
 
-expectType<StyleDictionary>(StyleDictionary.cleanAllPlatforms());
+expectType<StyleDictionary.Core>(StyleDictionary.cleanAllPlatforms());
 
-expectType<StyleDictionary>(StyleDictionary.cleanPlatform("web"));
-expectType<TransformedTokens>(StyleDictionary.exportPlatform("web"));
+expectType<StyleDictionary.Core>(StyleDictionary.cleanPlatform("web"));
+expectType<StyleDictionary.TransformedTokens>(StyleDictionary.exportPlatform("web"));
 
-expectType<StyleDictionary>(StyleDictionary.extend("config.json"));
+expectType<StyleDictionary.Core>(StyleDictionary.extend("config.json"));
 
-expectType<StyleDictionary>(
+expectType<StyleDictionary.Core>(
   StyleDictionary.extend({
     source: ["tokens/**/*.json"],
     platforms: {
@@ -49,7 +42,7 @@ expectType<StyleDictionary>(
   })
 );
 
-expectType<StyleDictionary>(
+expectType<StyleDictionary.Core>(
   StyleDictionary.registerAction({
     name: "copy_assets",
     do: function (dictionary, config) {
@@ -65,7 +58,7 @@ expectType<StyleDictionary>(
   })
 );
 
-expectType<StyleDictionary>(
+expectType<StyleDictionary.Core>(
   StyleDictionary.registerFilter({
     name: "isColor",
     matcher: function (token) {
@@ -74,27 +67,27 @@ expectType<StyleDictionary>(
   })
 );
 
-expectType<StyleDictionary>(
+expectType<StyleDictionary.Core>(
   StyleDictionary.registerFormat({
     name: "json",
     formatter: function ({dictionary, file, options, platform}) {
-      expectType<Dictionary>(dictionary);
-      expectType<File>(file);
-      expectType<Options>(options);
-      expectType<Platform>(platform);
+      expectType<StyleDictionary.Dictionary>(dictionary);
+      expectType<StyleDictionary.File>(file);
+      expectType<StyleDictionary.Options>(options);
+      expectType<StyleDictionary.Platform>(platform);
       return JSON.stringify(dictionary.tokens, null, 2);
     },
   })
 );
 
-expectType<StyleDictionary>(
+expectType<StyleDictionary.Core>(
   StyleDictionary.registerTemplate({
     name: "Swift/colors",
     template: __dirname + "/templates/swift/colors.template",
   })
 );
 
-expectType<StyleDictionary>(
+expectType<StyleDictionary.Core>(
   StyleDictionary.registerTransform({
     name: "time/seconds",
     type: "value",
@@ -102,20 +95,20 @@ expectType<StyleDictionary>(
       return token.attributes?.category === "time";
     },
     transformer: function (token) {
-      expectType<TransformedToken>(token);
+      expectType<StyleDictionary.TransformedToken>(token);
       return (parseInt(token.original.value) / 1000).toString() + "s";
     },
   })
 );
 
-expectType<StyleDictionary>(
+expectType<StyleDictionary.Core>(
   StyleDictionary.registerTransformGroup({
     name: "Swift",
     transforms: ["attribute/cti", "size/pt", "name/cti"],
   })
 );
 
-expectType<StyleDictionary>(
+expectType<StyleDictionary.Core>(
   StyleDictionary.registerParser({
     pattern: /\.json$/,
     parse: ({ contents, filePath }) => {
@@ -124,11 +117,11 @@ expectType<StyleDictionary>(
   })
 );
 
-const file: File = {
+const file: StyleDictionary.File = {
   destination: `somePath.json`,
   format: `css/variables`,
   filter: (token) => {
-    expectType<TransformedToken>(token);
+    expectType<StyleDictionary.TransformedToken>(token);
     return false;
   },
   options: {
@@ -136,39 +129,39 @@ const file: File = {
   }
 }
 
-expectType<Options | undefined>(file.options);
+expectType<StyleDictionary.Options | undefined>(file.options);
 
 // Files need a destination
-expectError<File>({
+expectError<StyleDictionary.File>({
   format: `css/variables`,
 });
 
-expectAssignable<File>({
+expectAssignable<StyleDictionary.File>({
   format: `css/variables`,
   destination: `variables.css`
 });
 
 
-expectAssignable<Platform>({
+expectAssignable<StyleDictionary.Platform>({
   transformGroup: `css`,
 });
 
-expectAssignable<Platform>({
+expectAssignable<StyleDictionary.Platform>({
   transforms: [`attribute/cti`],
 });
 
-expectAssignable<Platform>({
+expectAssignable<StyleDictionary.Platform>({
   transforms: [`attribute/cti`],
   files: [{
     destination: `destination`
   }]
 });
 
-expectError<Platform>({
+expectError<StyleDictionary.Platform>({
   transforms: `css`,
 });
 
-expectError<Platform>({
+expectError<StyleDictionary.Platform>({
   transformGroup: [`attribute/cti`],
 });
 
@@ -178,8 +171,8 @@ expectError<Platform>({
  * fileHeader needs to be a string or a function that returns a string[]
  * showFileHeader must be a boolean
  */
-expectError<Options>({ fileHeader: false });
-expectAssignable<Options>({ fileHeader: 'fileHeader' });
-expectError<Options>({ fileHeader: () => 42 });
-expectAssignable<Options>({ fileHeader: () => [`hello`] });
-expectError<Options>({ showFileHeader: 'false' });
+expectError<StyleDictionary.Options>({ fileHeader: false });
+expectAssignable<StyleDictionary.Options>({ fileHeader: 'fileHeader' });
+expectError<StyleDictionary.Options>({ fileHeader: () => 42 });
+expectAssignable<StyleDictionary.Options>({ fileHeader: () => [`hello`] });
+expectError<StyleDictionary.Options>({ showFileHeader: 'false' });

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -11,20 +11,29 @@
  * and limitations under the License.
  */
 
-import { expectType, expectError } from "tsd";
-import StyleDictionary = require(".");
+import { expectType, expectError, expectAssignable } from "tsd";
+import StyleDictionary, {
+  TransformedTokens,
+  TransformedToken,
+  Dictionary,
+  File,
+  Options,
+  Platform
+} from ".";
 
-expectType<StyleDictionary.Core>(StyleDictionary.buildAllPlatforms());
-expectType<StyleDictionary.Core>(StyleDictionary.buildPlatform("web"));
+// declare var styleDictionary: StyleDictionary;
 
-expectType<StyleDictionary.Core>(StyleDictionary.cleanAllPlatforms());
+expectType<StyleDictionary>(StyleDictionary.buildAllPlatforms());
+expectType<StyleDictionary>(StyleDictionary.buildPlatform("web"));
 
-expectType<StyleDictionary.Core>(StyleDictionary.cleanPlatform("web"));
-expectType<StyleDictionary.TransformedTokens>(StyleDictionary.exportPlatform("web"));
+expectType<StyleDictionary>(StyleDictionary.cleanAllPlatforms());
 
-expectType<StyleDictionary.Core>(StyleDictionary.extend("config.json"));
+expectType<StyleDictionary>(StyleDictionary.cleanPlatform("web"));
+expectType<TransformedTokens>(StyleDictionary.exportPlatform("web"));
 
-expectType<StyleDictionary.Core>(
+expectType<StyleDictionary>(StyleDictionary.extend("config.json"));
+
+expectType<StyleDictionary>(
   StyleDictionary.extend({
     source: ["tokens/**/*.json"],
     platforms: {
@@ -42,7 +51,7 @@ expectType<StyleDictionary.Core>(
   })
 );
 
-expectType<StyleDictionary.Core>(
+expectType<StyleDictionary>(
   StyleDictionary.registerAction({
     name: "copy_assets",
     do: function (dictionary, config) {
@@ -58,7 +67,7 @@ expectType<StyleDictionary.Core>(
   })
 );
 
-expectType<StyleDictionary.Core>(
+expectType<StyleDictionary>(
   StyleDictionary.registerFilter({
     name: "isColor",
     matcher: function (token) {
@@ -67,27 +76,27 @@ expectType<StyleDictionary.Core>(
   })
 );
 
-expectType<StyleDictionary.Core>(
+expectType<StyleDictionary>(
   StyleDictionary.registerFormat({
     name: "json",
     formatter: function ({dictionary, file, options, platform}) {
-      expectType<StyleDictionary.Dictionary>(dictionary);
-      expectType<StyleDictionary.File>(file);
-      expectType<StyleDictionary.Options>(options);
-      expectType<StyleDictionary.Platform>(platform);
+      expectType<Dictionary>(dictionary);
+      expectType<File>(file);
+      expectType<Options>(options);
+      expectType<Platform>(platform);
       return JSON.stringify(dictionary.tokens, null, 2);
     },
   })
 );
 
-expectType<StyleDictionary.Core>(
+expectType<StyleDictionary>(
   StyleDictionary.registerTemplate({
     name: "Swift/colors",
     template: __dirname + "/templates/swift/colors.template",
   })
 );
 
-expectType<StyleDictionary.Core>(
+expectType<StyleDictionary>(
   StyleDictionary.registerTransform({
     name: "time/seconds",
     type: "value",
@@ -95,20 +104,20 @@ expectType<StyleDictionary.Core>(
       return token.attributes?.category === "time";
     },
     transformer: function (token) {
-      expectType<StyleDictionary.TransformedToken>(token);
+      expectType<TransformedToken>(token);
       return (parseInt(token.original.value) / 1000).toString() + "s";
     },
   })
 );
 
-expectType<StyleDictionary.Core>(
+expectType<StyleDictionary>(
   StyleDictionary.registerTransformGroup({
     name: "Swift",
     transforms: ["attribute/cti", "size/pt", "name/cti"],
   })
 );
 
-expectType<StyleDictionary.Core>(
+expectType<StyleDictionary>(
   StyleDictionary.registerParser({
     pattern: /\.json$/,
     parse: ({ contents, filePath }) => {
@@ -117,11 +126,11 @@ expectType<StyleDictionary.Core>(
   })
 );
 
-const file: StyleDictionary.File = {
+const file: File = {
   destination: `somePath.json`,
   format: `css/variables`,
   filter: (token) => {
-    expectType<StyleDictionary.TransformedToken>(token);
+    expectType<TransformedToken>(token);
     return false;
   },
   options: {
@@ -129,39 +138,39 @@ const file: StyleDictionary.File = {
   }
 }
 
-expectType<StyleDictionary.Options | undefined>(file.options);
+expectType<Options | undefined>(file.options);
 
 // Files need a destination
-expectError<StyleDictionary.File>({
+expectError<File>({
   format: `css/variables`,
 });
 
-expectType<StyleDictionary.File>({
+expectAssignable<File>({
   format: `css/variables`,
   destination: `variables.css`
-} as StyleDictionary.File);
+});
 
 
-expectType<StyleDictionary.Platform>({
+expectAssignable<Platform>({
   transformGroup: `css`,
-} as StyleDictionary.Platform);
+});
 
-expectType<StyleDictionary.Platform>({
+expectAssignable<Platform>({
   transforms: [`attribute/cti`],
-} as StyleDictionary.Platform);
+});
 
-expectType<StyleDictionary.Platform>({
+expectAssignable<Platform>({
   transforms: [`attribute/cti`],
   files: [{
-
+    destination: `destination`
   }]
-} as StyleDictionary.Platform);
+});
 
-expectError<StyleDictionary.Platform>({
+expectError<Platform>({
   transforms: `css`,
 });
 
-expectError<StyleDictionary.Platform>({
+expectError<Platform>({
   transformGroup: [`attribute/cti`],
 });
 
@@ -171,8 +180,8 @@ expectError<StyleDictionary.Platform>({
  * fileHeader needs to be a string or a function that returns a string[]
  * showFileHeader must be a boolean
  */
-expectError<StyleDictionary.Options>({ fileHeader: false });
-expectType<StyleDictionary.Options>({ fileHeader: 'fileHeader' } as StyleDictionary.Options);
-expectError<StyleDictionary.Options>({ fileHeader: () => 42 });
-expectType<StyleDictionary.Options>({ fileHeader: () => [`hello`] } as StyleDictionary.Options);
-expectError<StyleDictionary.Options>({ showFileHeader: 'false' });
+expectError<Options>({ fileHeader: false });
+expectAssignable<Options>({ fileHeader: 'fileHeader' });
+expectError<Options>({ fileHeader: () => 42 });
+expectAssignable<Options>({ fileHeader: () => [`hello`] });
+expectError<Options>({ showFileHeader: 'false' });

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -21,8 +21,6 @@ import StyleDictionary, {
   Platform
 } from ".";
 
-// declare var styleDictionary: StyleDictionary;
-
 expectType<StyleDictionary>(StyleDictionary.buildAllPlatforms());
 expectType<StyleDictionary>(StyleDictionary.buildPlatform("web"));
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* 
* Updating the typescript formats to use the updated format arguments
* Using a shared `DesignToken` type for `typescript/module-definitions` format as well as in our types
* Fixed a lot of missing things and incorrect things in our type definitions
* Separated types out into their own files for readability

I'm not a Typescript person so would love some expert 👀 on this.

**update**
Here is what I am thinking for this pull request: is this code *good enough* for now? Good enough meaning: is it a *better* developer experience for Javascript and Typescript developers than what currently exists in the live version of Style Dictionary (2.10)? If so, and there are no obvious errors with the types, then I think we can merge in and get 3.0 out, and then plan on cleaning up in a minor release afterwards.

Some things that are not great, but acceptable for now to not push the 3.0 launch out even further to migrate the whole codebase to Typescript.
* Duplication of JSDoc documentation. I think this is an acceptable interim solution for now. The alternative would either be to not have JSDoc comments in the typescript declarations, but that would be a worse developer experience than 2.10 because the Intellisense popups would show less information. 

Other avenues I tried:
* Using the `tsc` with the existing source JS files to auto-generate types. This worked somewhat, but it had some downsides. It did not work well trying to share types across different parts of the codebase, like a Transform or DesignToken for example. It also did not export all types in the main entry point to the library. To get this to work well, it would require a lot more tweaking and editing of the source code, which at that point we might as well migrate to typescript.  

In maybe a new minor version (3.1) we could migrate the codebase to Typescript and clean this up a bit. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
