### PR TITLE
docs(examples): fix source reference and properties function

### DIFF
--- a/examples/advanced/custom-transforms/config.json
+++ b/examples/advanced/custom-transforms/config.json
@@ -1,5 +1,5 @@
 {
-  "source": ["properties/**/*.json"],
+  "source": ["tokens/**/*.json"],
   "platforms": {
     "web": {
       "transformGroup": "custom/web",


### PR DESCRIPTION
Found a few small typos prevent the custom transforms examples from working.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
