### PR TITLE
Fix: Directly export `Named` type to avoid ambiguity with TS `--isolatedModules` option

### DIFF
--- a/types/_helpers.ts
+++ b/types/_helpers.ts
@@ -11,6 +11,4 @@
  * and limitations under the License.
  */
 
-type Named<T> = T & { name: string; };
-
-export { Named }
+export type Named<T> = T & { name: string; };


### PR DESCRIPTION
*Description of changes:*

We've recently attempted to update from `3.0.0-rc9` to `3.0.0` and encountered the following issue when using style-dictionary within our project that uses `--isolatedModules` via config (Next.js project, Next.js uses Babel to compile):

```
./node_modules/style-dictionary/types/_helpers.ts:16:10
Type error: Re-exporting a type when the '--isolatedModules' flag is provided requires using 'export type'.

  14 | type Named<T> = T & { name: string; };
  15 |
> 16 | export { Named }
```

This PR makes the change of exporting the type directly inline to avoid this issue, as you are already using that syntax within `styled-dictionary`.

I believe the alternative means of fixing this are:
- Having this file be a `.d.ts` file - Didn't want to mess with file names
- Using `export type { Named }` - TS 3.8+

If necessary, [context around `--isolatedModules` by the TS authors](https://github.com/microsoft/TypeScript/issues/28481#issuecomment-479965467) around this specific issue.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
