### PR TITLE
Enable usage with --isolatedModules

### DIFF
--- a/types/_helpers.ts
+++ b/types/_helpers.ts
@@ -13,4 +13,4 @@
 
 type Named<T> = T & { name: string; };
 
-export { Named }
+export type { Named }


### PR DESCRIPTION
When compiling code using style dictionary with the [isolatedModules](https://www.typescriptlang.org/tsconfig/#isolatedModules) flag enabled, we get a type error:
```
error TS1205: Re-exporting a type when the '--isolatedModules' flag is provided requires using 'export type'.

16 export { Named }
            ~~~~~


Found 1 error.
```

This PR adresses the issue. It should not have any other implications.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
