### PR TITLE
fix: fixes type error when building with isolate modules

### DIFF
--- a/types/_helpers.ts
+++ b/types/_helpers.ts
@@ -13,4 +13,4 @@
 
 type Named<T> = T & { name: string; };
 
-export { Named }
+export type { Named }


### PR DESCRIPTION
*Description of changes:*

This fixes a TypeScript error when building with isolate modules:

```
$ NODE_OPTIONS=--max-old-space-size=8192 tsc --project ./tsconfig.typecheck.json
node_modules/style-dictionary/types/_helpers.ts(16,10): error TS1205: Re-exporting a type when the '--isolatedModules' flag is provided requires using 'export type'.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
