### PR TITLE
setting Named export to export type

### DIFF
--- a/types/_helpers.ts
+++ b/types/_helpers.ts
@@ -11,6 +11,4 @@
  * and limitations under the License.
  */
 
-type Named<T> = T & { name: string; };
-
-export { Named }
+export type Named<T> = T & { name: string; };


### PR DESCRIPTION
*Description of changes:*

When importing from this project and compiling my own project using a combo of Babel and Typescript (for creation of `.d.ts` files) I get an error that this PR fixed. When Babel sees `export { Named }` it doesn’t know if it’s a JS value or Type value. Using `export type` resolves this. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
