### PR TITLE
fix(types): format config expects formatter function

### DIFF
--- a/types/Config.d.ts
+++ b/types/Config.d.ts
@@ -16,7 +16,7 @@ import { Transform } from './Transform';
 import { TransformGroup } from './TransformGroup';
 import { Filter } from './Filter';
 import { FileHeader } from './FileHeader';
-import { Format } from './Format';
+import { Formatter } from './Format';
 import { Action } from './Action';
 import { Platform } from './Platform';
 import { DesignTokens } from './DesignToken';
@@ -25,7 +25,7 @@ export interface Config {
   parsers?: Parser[];
   transform?: Record<string, Transform>;
   transformGroup?: Record<string, TransformGroup>;
-  format?: Record<string, Format>;
+  format?: Record<string, Formatter>;
   filter?: Record<string, Filter>;
   fileHeader?: Record<string, FileHeader>;
   action?: Record<string, Action>;


### PR DESCRIPTION
As per the [docs](https://amzn.github.io/style-dictionary/#/config?id=configuration-file-formats#/config?id=configuration-file-formats#/config?id=configuration-file-formats), config expects an object of Formatter functions, not the Format object.

*Description of changes:*
Change type from Format to Formatter

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
