### PR TITLE
docs: Fix "getReferences" typos

### DIFF
--- a/docs/version_3.md
+++ b/docs/version_3.md
@@ -164,8 +164,12 @@ StyleDictionary.registerFormat({
       // an array of references to the whole tokens so that you can access
       // their names or any other attributes.
       if (dictionary.usesReference(token.original.value)) {
-        const references = dictionary.getReferences(token.original.value);
-        value = references[0].name;
+        const refs = dictionary.getReferences(token.original.value);
+        refs.forEach(ref => {
+          value = value.replace(ref.value, function() {
+            return `${ref.name}`;
+          });
+        });
       }
       return `export const ${token.name} = ${value};`
     }).join(`\n`)

--- a/docs/version_3.md
+++ b/docs/version_3.md
@@ -150,7 +150,7 @@ Not all formats use the `outputReferences` option because that file format might
 * ios-swift/enum.swift
 * flutter/class.dart
 
-If you have custom formats you can make use of this feature too! The `dictionary` object that is passed as an argument to the formatter function has 2 new methods on it: `usesReference()` and `getReference()` which you can use to get the reference name. Here is an example of that:
+If you have custom formats you can make use of this feature too! The `dictionary` object that is passed as an argument to the formatter function has 2 new methods on it: `usesReference()` and `getReferences()` which you can use to get the reference name. Here is an example of that:
 
 ```javascript
 StyleDictionary.registerFormat({
@@ -159,13 +159,13 @@ StyleDictionary.registerFormat({
     return dictionary.allProperties.map(token => {
       let value = JSON.stringify(token.value);
       // the `dictionary` object now has `usesReference()` and
-      // `getReference()` methods. `usesReference()` will return true if
-      // the value has a reference in it. `getReference()` will return
-      // the reference to the whole token so that you can access its
-      // name or any other attributes.
+      // `getReferences()` methods. `usesReference()` will return true if
+      // the value has a reference in it. `getReferences()` will return
+      // an array of references to the whole tokens so that you can access
+      // their names or any other attributes.
       if (dictionary.usesReference(token.original.value)) {
-        const reference = dictionary.getReference(token.original.value);
-        value = reference.name;
+        const references = dictionary.getReferences(token.original.value);
+        value = references[0].name;
       }
       return `export const ${token.name} = ${value};`
     }).join(`\n`)

--- a/examples/advanced/variables-in-outputs/README.md
+++ b/examples/advanced/variables-in-outputs/README.md
@@ -30,11 +30,11 @@ function(dictionary) {
     // the `dictionary` object now has `usesReference()` and
     // `getReferences()` methods. `usesReference()` will return true if
     // the value has a reference in it. `getReferences()` will return 
-    // an array of references to the whole tokens so that you can access its 
-    // name or any other attributes.
+    // an array of references to the whole tokens so that you can access their
+    // names or any other attributes.
     if (dictionary.usesReference(token.original.value)) {
-      const reference = dictionary.getReferences(token.original.value);
-      value = reference.name;
+      const references = dictionary.getReferences(token.original.value);
+      value = references[0].name;
     }
     return `export const ${token.name} = ${value};`
   }).join(`\n`)

--- a/examples/advanced/variables-in-outputs/README.md
+++ b/examples/advanced/variables-in-outputs/README.md
@@ -33,8 +33,12 @@ function(dictionary) {
     // an array of references to the whole tokens so that you can access their
     // names or any other attributes.
     if (dictionary.usesReference(token.original.value)) {
-      const references = dictionary.getReferences(token.original.value);
-      value = references[0].name;
+      const refs = dictionary.getReferences(token.original.value);
+      refs.forEach(ref => {
+        value = value.replace(ref.value, function() {
+          return `${ref.name}`;
+        });
+      });
     }
     return `export const ${token.name} = ${value};`
   }).join(`\n`)

--- a/examples/advanced/variables-in-outputs/sd.config.js
+++ b/examples/advanced/variables-in-outputs/sd.config.js
@@ -9,11 +9,11 @@ module.exports = {
           // the `dictionary` object now has `usesReference()` and
           // `getReferences()` methods. `usesReference()` will return true if
           // the value has a reference in it. `getReferences()` will return
-          // an array of references to the whole tokens so that you can access its
-          // name or any other attributes.
+          // an array of references to the whole tokens so that you can access
+          // their names or any other attributes.
           if (dictionary.usesReference(token.original.value)) {
-            const reference = dictionary.getReferences(token.original.value);
-            value = reference.name;
+            const references = dictionary.getReferences(token.original.value);
+            value = references[0].name;
           }
         }
 

--- a/examples/advanced/variables-in-outputs/sd.config.js
+++ b/examples/advanced/variables-in-outputs/sd.config.js
@@ -12,8 +12,12 @@ module.exports = {
           // an array of references to the whole tokens so that you can access
           // their names or any other attributes.
           if (dictionary.usesReference(token.original.value)) {
-            const references = dictionary.getReferences(token.original.value);
-            value = references[0].name;
+            const refs = dictionary.getReferences(token.original.value);
+            refs.forEach(ref => {
+              value = value.replace(ref.value, function() {
+                return `${ref.name}`;
+              });
+            });
           }
         }
 

--- a/scripts/handlebars/templates/formats.hbs
+++ b/scripts/handlebars/templates/formats.hbs
@@ -260,8 +260,12 @@ StyleDictionary.registerFormat({
       if (dictionary.usesReference(token.original.value)) {
         // Note: make sure to use `token.original.value` because
         // `token.value` is already resolved at this point.
-        const references = dictionary.getReferences(token.original.value);
-        value = references[0].name;
+        const refs = dictionary.getReferences(token.original.value);
+        refs.forEach(ref => {
+          value = value.replace(ref.value, function() {
+            return `${ref.name}`;
+          });
+        });
       }
       return `export const ${token.name} = ${value};`
     }).join(`\n`)

--- a/scripts/handlebars/templates/formats.hbs
+++ b/scripts/handlebars/templates/formats.hbs
@@ -255,13 +255,13 @@ StyleDictionary.registerFormat({
       // the `dictionary` object now has `usesReference()` and
       // `getReferences()` methods. `usesReference()` will return true if
       // the value has a reference in it. `getReferences()` will return
-      // an array of references to the whole tokens so that you can access its
-      // name or any other attributes.
+      // an array of references to the whole tokens so that you can access their
+      // names or any other attributes.
       if (dictionary.usesReference(token.original.value)) {
         // Note: make sure to use `token.original.value` because
         // `token.value` is already resolved at this point.
-        const reference = dictionary.getReferences(token.original.value);
-        value = reference.name;
+        const references = dictionary.getReferences(token.original.value);
+        value = references[0].name;
       }
       return `export const ${token.name} = ${value};`
     }).join(`\n`)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Change "getReference" to "getReferences"
- Update documented return value to array of original tokens
- Update code snippets to access array of tokens instead of single token

The [way `refs` are iterated over here](https://github.com/kylegach/style-dictionary/blob/b12c4b1c6a94c62c757cd1675d216d9638f8d6e0/lib/common/formatHelpers/createPropertyFormatter.js#L95-L116), implies that simply accessing the first token in the array may not be a good strategy. All tests & builds pass, though (including those in the "variables-in-outputs" example, where I changed actual code, not just docs).


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
