### PR TITLE
fix(lib): Fix `createFormatArgs` positional args

### DIFF
--- a/__integration__/__snapshots__/customFormats.test.js.snap
+++ b/__integration__/__snapshots__/customFormats.test.js.snap
@@ -566,6 +566,166 @@ exports[`integration custom formats inline custom with new args should match sna
       }
     }
   },
+  \\"allTokens\\": [
+    {
+      \\"value\\": \\"0.5rem\\",
+      \\"filePath\\": \\"__integration__/tokens/size/padding.json\\",
+      \\"isSource\\": true,
+      \\"original\\": {
+        \\"value\\": 0.5
+      },
+      \\"name\\": \\"SizePaddingSmall\\",
+      \\"attributes\\": {
+        \\"category\\": \\"size\\",
+        \\"type\\": \\"padding\\",
+        \\"item\\": \\"small\\"
+      },
+      \\"path\\": [
+        \\"size\\",
+        \\"padding\\",
+        \\"small\\"
+      ]
+    },
+    {
+      \\"value\\": \\"1rem\\",
+      \\"filePath\\": \\"__integration__/tokens/size/padding.json\\",
+      \\"isSource\\": true,
+      \\"original\\": {
+        \\"value\\": 1
+      },
+      \\"name\\": \\"SizePaddingMedium\\",
+      \\"attributes\\": {
+        \\"category\\": \\"size\\",
+        \\"type\\": \\"padding\\",
+        \\"item\\": \\"medium\\"
+      },
+      \\"path\\": [
+        \\"size\\",
+        \\"padding\\",
+        \\"medium\\"
+      ]
+    },
+    {
+      \\"value\\": \\"1rem\\",
+      \\"filePath\\": \\"__integration__/tokens/size/padding.json\\",
+      \\"isSource\\": true,
+      \\"original\\": {
+        \\"value\\": 1
+      },
+      \\"name\\": \\"SizePaddingLarge\\",
+      \\"attributes\\": {
+        \\"category\\": \\"size\\",
+        \\"type\\": \\"padding\\",
+        \\"item\\": \\"large\\"
+      },
+      \\"path\\": [
+        \\"size\\",
+        \\"padding\\",
+        \\"large\\"
+      ]
+    },
+    {
+      \\"value\\": \\"1rem\\",
+      \\"filePath\\": \\"__integration__/tokens/size/padding.json\\",
+      \\"isSource\\": true,
+      \\"original\\": {
+        \\"value\\": 1
+      },
+      \\"name\\": \\"SizePaddingXl\\",
+      \\"attributes\\": {
+        \\"category\\": \\"size\\",
+        \\"type\\": \\"padding\\",
+        \\"item\\": \\"xl\\"
+      },
+      \\"path\\": [
+        \\"size\\",
+        \\"padding\\",
+        \\"xl\\"
+      ]
+    }
+  ],
+  \\"tokens\\": {
+    \\"size\\": {
+      \\"padding\\": {
+        \\"small\\": {
+          \\"value\\": \\"0.5rem\\",
+          \\"filePath\\": \\"__integration__/tokens/size/padding.json\\",
+          \\"isSource\\": true,
+          \\"original\\": {
+            \\"value\\": 0.5
+          },
+          \\"name\\": \\"SizePaddingSmall\\",
+          \\"attributes\\": {
+            \\"category\\": \\"size\\",
+            \\"type\\": \\"padding\\",
+            \\"item\\": \\"small\\"
+          },
+          \\"path\\": [
+            \\"size\\",
+            \\"padding\\",
+            \\"small\\"
+          ]
+        },
+        \\"medium\\": {
+          \\"value\\": \\"1rem\\",
+          \\"filePath\\": \\"__integration__/tokens/size/padding.json\\",
+          \\"isSource\\": true,
+          \\"original\\": {
+            \\"value\\": 1
+          },
+          \\"name\\": \\"SizePaddingMedium\\",
+          \\"attributes\\": {
+            \\"category\\": \\"size\\",
+            \\"type\\": \\"padding\\",
+            \\"item\\": \\"medium\\"
+          },
+          \\"path\\": [
+            \\"size\\",
+            \\"padding\\",
+            \\"medium\\"
+          ]
+        },
+        \\"large\\": {
+          \\"value\\": \\"1rem\\",
+          \\"filePath\\": \\"__integration__/tokens/size/padding.json\\",
+          \\"isSource\\": true,
+          \\"original\\": {
+            \\"value\\": 1
+          },
+          \\"name\\": \\"SizePaddingLarge\\",
+          \\"attributes\\": {
+            \\"category\\": \\"size\\",
+            \\"type\\": \\"padding\\",
+            \\"item\\": \\"large\\"
+          },
+          \\"path\\": [
+            \\"size\\",
+            \\"padding\\",
+            \\"large\\"
+          ]
+        },
+        \\"xl\\": {
+          \\"value\\": \\"1rem\\",
+          \\"filePath\\": \\"__integration__/tokens/size/padding.json\\",
+          \\"isSource\\": true,
+          \\"original\\": {
+            \\"value\\": 1
+          },
+          \\"name\\": \\"SizePaddingXl\\",
+          \\"attributes\\": {
+            \\"category\\": \\"size\\",
+            \\"type\\": \\"padding\\",
+            \\"item\\": \\"xl\\"
+          },
+          \\"path\\": [
+            \\"size\\",
+            \\"padding\\",
+            \\"xl\\"
+          ]
+        }
+      }
+    }
+  },
   \\"platform\\": {
     \\"transformGroup\\": \\"js\\",
     \\"buildPath\\": \\"__integration__/build/\\",
@@ -1104,6 +1264,166 @@ exports[`integration custom formats inline custom with old args should match sna
       }
     ],
     \\"properties\\": {
+      \\"size\\": {
+        \\"padding\\": {
+          \\"small\\": {
+            \\"value\\": \\"0.5rem\\",
+            \\"filePath\\": \\"__integration__/tokens/size/padding.json\\",
+            \\"isSource\\": true,
+            \\"original\\": {
+              \\"value\\": 0.5
+            },
+            \\"name\\": \\"SizePaddingSmall\\",
+            \\"attributes\\": {
+              \\"category\\": \\"size\\",
+              \\"type\\": \\"padding\\",
+              \\"item\\": \\"small\\"
+            },
+            \\"path\\": [
+              \\"size\\",
+              \\"padding\\",
+              \\"small\\"
+            ]
+          },
+          \\"medium\\": {
+            \\"value\\": \\"1rem\\",
+            \\"filePath\\": \\"__integration__/tokens/size/padding.json\\",
+            \\"isSource\\": true,
+            \\"original\\": {
+              \\"value\\": 1
+            },
+            \\"name\\": \\"SizePaddingMedium\\",
+            \\"attributes\\": {
+              \\"category\\": \\"size\\",
+              \\"type\\": \\"padding\\",
+              \\"item\\": \\"medium\\"
+            },
+            \\"path\\": [
+              \\"size\\",
+              \\"padding\\",
+              \\"medium\\"
+            ]
+          },
+          \\"large\\": {
+            \\"value\\": \\"1rem\\",
+            \\"filePath\\": \\"__integration__/tokens/size/padding.json\\",
+            \\"isSource\\": true,
+            \\"original\\": {
+              \\"value\\": 1
+            },
+            \\"name\\": \\"SizePaddingLarge\\",
+            \\"attributes\\": {
+              \\"category\\": \\"size\\",
+              \\"type\\": \\"padding\\",
+              \\"item\\": \\"large\\"
+            },
+            \\"path\\": [
+              \\"size\\",
+              \\"padding\\",
+              \\"large\\"
+            ]
+          },
+          \\"xl\\": {
+            \\"value\\": \\"1rem\\",
+            \\"filePath\\": \\"__integration__/tokens/size/padding.json\\",
+            \\"isSource\\": true,
+            \\"original\\": {
+              \\"value\\": 1
+            },
+            \\"name\\": \\"SizePaddingXl\\",
+            \\"attributes\\": {
+              \\"category\\": \\"size\\",
+              \\"type\\": \\"padding\\",
+              \\"item\\": \\"xl\\"
+            },
+            \\"path\\": [
+              \\"size\\",
+              \\"padding\\",
+              \\"xl\\"
+            ]
+          }
+        }
+      }
+    },
+    \\"allTokens\\": [
+      {
+        \\"value\\": \\"0.5rem\\",
+        \\"filePath\\": \\"__integration__/tokens/size/padding.json\\",
+        \\"isSource\\": true,
+        \\"original\\": {
+          \\"value\\": 0.5
+        },
+        \\"name\\": \\"SizePaddingSmall\\",
+        \\"attributes\\": {
+          \\"category\\": \\"size\\",
+          \\"type\\": \\"padding\\",
+          \\"item\\": \\"small\\"
+        },
+        \\"path\\": [
+          \\"size\\",
+          \\"padding\\",
+          \\"small\\"
+        ]
+      },
+      {
+        \\"value\\": \\"1rem\\",
+        \\"filePath\\": \\"__integration__/tokens/size/padding.json\\",
+        \\"isSource\\": true,
+        \\"original\\": {
+          \\"value\\": 1
+        },
+        \\"name\\": \\"SizePaddingMedium\\",
+        \\"attributes\\": {
+          \\"category\\": \\"size\\",
+          \\"type\\": \\"padding\\",
+          \\"item\\": \\"medium\\"
+        },
+        \\"path\\": [
+          \\"size\\",
+          \\"padding\\",
+          \\"medium\\"
+        ]
+      },
+      {
+        \\"value\\": \\"1rem\\",
+        \\"filePath\\": \\"__integration__/tokens/size/padding.json\\",
+        \\"isSource\\": true,
+        \\"original\\": {
+          \\"value\\": 1
+        },
+        \\"name\\": \\"SizePaddingLarge\\",
+        \\"attributes\\": {
+          \\"category\\": \\"size\\",
+          \\"type\\": \\"padding\\",
+          \\"item\\": \\"large\\"
+        },
+        \\"path\\": [
+          \\"size\\",
+          \\"padding\\",
+          \\"large\\"
+        ]
+      },
+      {
+        \\"value\\": \\"1rem\\",
+        \\"filePath\\": \\"__integration__/tokens/size/padding.json\\",
+        \\"isSource\\": true,
+        \\"original\\": {
+          \\"value\\": 1
+        },
+        \\"name\\": \\"SizePaddingXl\\",
+        \\"attributes\\": {
+          \\"category\\": \\"size\\",
+          \\"type\\": \\"padding\\",
+          \\"item\\": \\"xl\\"
+        },
+        \\"path\\": [
+          \\"size\\",
+          \\"padding\\",
+          \\"xl\\"
+        ]
+      }
+    ],
+    \\"tokens\\": {
       \\"size\\": {
         \\"padding\\": {
           \\"small\\": {
@@ -1849,6 +2169,166 @@ exports[`integration custom formats register custom format with new args should 
       }
     }
   },
+  \\"allTokens\\": [
+    {
+      \\"value\\": \\"0.5rem\\",
+      \\"filePath\\": \\"__integration__/tokens/size/padding.json\\",
+      \\"isSource\\": true,
+      \\"original\\": {
+        \\"value\\": 0.5
+      },
+      \\"name\\": \\"SizePaddingSmall\\",
+      \\"attributes\\": {
+        \\"category\\": \\"size\\",
+        \\"type\\": \\"padding\\",
+        \\"item\\": \\"small\\"
+      },
+      \\"path\\": [
+        \\"size\\",
+        \\"padding\\",
+        \\"small\\"
+      ]
+    },
+    {
+      \\"value\\": \\"1rem\\",
+      \\"filePath\\": \\"__integration__/tokens/size/padding.json\\",
+      \\"isSource\\": true,
+      \\"original\\": {
+        \\"value\\": 1
+      },
+      \\"name\\": \\"SizePaddingMedium\\",
+      \\"attributes\\": {
+        \\"category\\": \\"size\\",
+        \\"type\\": \\"padding\\",
+        \\"item\\": \\"medium\\"
+      },
+      \\"path\\": [
+        \\"size\\",
+        \\"padding\\",
+        \\"medium\\"
+      ]
+    },
+    {
+      \\"value\\": \\"1rem\\",
+      \\"filePath\\": \\"__integration__/tokens/size/padding.json\\",
+      \\"isSource\\": true,
+      \\"original\\": {
+        \\"value\\": 1
+      },
+      \\"name\\": \\"SizePaddingLarge\\",
+      \\"attributes\\": {
+        \\"category\\": \\"size\\",
+        \\"type\\": \\"padding\\",
+        \\"item\\": \\"large\\"
+      },
+      \\"path\\": [
+        \\"size\\",
+        \\"padding\\",
+        \\"large\\"
+      ]
+    },
+    {
+      \\"value\\": \\"1rem\\",
+      \\"filePath\\": \\"__integration__/tokens/size/padding.json\\",
+      \\"isSource\\": true,
+      \\"original\\": {
+        \\"value\\": 1
+      },
+      \\"name\\": \\"SizePaddingXl\\",
+      \\"attributes\\": {
+        \\"category\\": \\"size\\",
+        \\"type\\": \\"padding\\",
+        \\"item\\": \\"xl\\"
+      },
+      \\"path\\": [
+        \\"size\\",
+        \\"padding\\",
+        \\"xl\\"
+      ]
+    }
+  ],
+  \\"tokens\\": {
+    \\"size\\": {
+      \\"padding\\": {
+        \\"small\\": {
+          \\"value\\": \\"0.5rem\\",
+          \\"filePath\\": \\"__integration__/tokens/size/padding.json\\",
+          \\"isSource\\": true,
+          \\"original\\": {
+            \\"value\\": 0.5
+          },
+          \\"name\\": \\"SizePaddingSmall\\",
+          \\"attributes\\": {
+            \\"category\\": \\"size\\",
+            \\"type\\": \\"padding\\",
+            \\"item\\": \\"small\\"
+          },
+          \\"path\\": [
+            \\"size\\",
+            \\"padding\\",
+            \\"small\\"
+          ]
+        },
+        \\"medium\\": {
+          \\"value\\": \\"1rem\\",
+          \\"filePath\\": \\"__integration__/tokens/size/padding.json\\",
+          \\"isSource\\": true,
+          \\"original\\": {
+            \\"value\\": 1
+          },
+          \\"name\\": \\"SizePaddingMedium\\",
+          \\"attributes\\": {
+            \\"category\\": \\"size\\",
+            \\"type\\": \\"padding\\",
+            \\"item\\": \\"medium\\"
+          },
+          \\"path\\": [
+            \\"size\\",
+            \\"padding\\",
+            \\"medium\\"
+          ]
+        },
+        \\"large\\": {
+          \\"value\\": \\"1rem\\",
+          \\"filePath\\": \\"__integration__/tokens/size/padding.json\\",
+          \\"isSource\\": true,
+          \\"original\\": {
+            \\"value\\": 1
+          },
+          \\"name\\": \\"SizePaddingLarge\\",
+          \\"attributes\\": {
+            \\"category\\": \\"size\\",
+            \\"type\\": \\"padding\\",
+            \\"item\\": \\"large\\"
+          },
+          \\"path\\": [
+            \\"size\\",
+            \\"padding\\",
+            \\"large\\"
+          ]
+        },
+        \\"xl\\": {
+          \\"value\\": \\"1rem\\",
+          \\"filePath\\": \\"__integration__/tokens/size/padding.json\\",
+          \\"isSource\\": true,
+          \\"original\\": {
+            \\"value\\": 1
+          },
+          \\"name\\": \\"SizePaddingXl\\",
+          \\"attributes\\": {
+            \\"category\\": \\"size\\",
+            \\"type\\": \\"padding\\",
+            \\"item\\": \\"xl\\"
+          },
+          \\"path\\": [
+            \\"size\\",
+            \\"padding\\",
+            \\"xl\\"
+          ]
+        }
+      }
+    }
+  },
   \\"platform\\": {
     \\"transformGroup\\": \\"js\\",
     \\"buildPath\\": \\"__integration__/build/\\",
@@ -2387,6 +2867,166 @@ exports[`integration custom formats register custom format with old args should 
       }
     ],
     \\"properties\\": {
+      \\"size\\": {
+        \\"padding\\": {
+          \\"small\\": {
+            \\"value\\": \\"0.5rem\\",
+            \\"filePath\\": \\"__integration__/tokens/size/padding.json\\",
+            \\"isSource\\": true,
+            \\"original\\": {
+              \\"value\\": 0.5
+            },
+            \\"name\\": \\"SizePaddingSmall\\",
+            \\"attributes\\": {
+              \\"category\\": \\"size\\",
+              \\"type\\": \\"padding\\",
+              \\"item\\": \\"small\\"
+            },
+            \\"path\\": [
+              \\"size\\",
+              \\"padding\\",
+              \\"small\\"
+            ]
+          },
+          \\"medium\\": {
+            \\"value\\": \\"1rem\\",
+            \\"filePath\\": \\"__integration__/tokens/size/padding.json\\",
+            \\"isSource\\": true,
+            \\"original\\": {
+              \\"value\\": 1
+            },
+            \\"name\\": \\"SizePaddingMedium\\",
+            \\"attributes\\": {
+              \\"category\\": \\"size\\",
+              \\"type\\": \\"padding\\",
+              \\"item\\": \\"medium\\"
+            },
+            \\"path\\": [
+              \\"size\\",
+              \\"padding\\",
+              \\"medium\\"
+            ]
+          },
+          \\"large\\": {
+            \\"value\\": \\"1rem\\",
+            \\"filePath\\": \\"__integration__/tokens/size/padding.json\\",
+            \\"isSource\\": true,
+            \\"original\\": {
+              \\"value\\": 1
+            },
+            \\"name\\": \\"SizePaddingLarge\\",
+            \\"attributes\\": {
+              \\"category\\": \\"size\\",
+              \\"type\\": \\"padding\\",
+              \\"item\\": \\"large\\"
+            },
+            \\"path\\": [
+              \\"size\\",
+              \\"padding\\",
+              \\"large\\"
+            ]
+          },
+          \\"xl\\": {
+            \\"value\\": \\"1rem\\",
+            \\"filePath\\": \\"__integration__/tokens/size/padding.json\\",
+            \\"isSource\\": true,
+            \\"original\\": {
+              \\"value\\": 1
+            },
+            \\"name\\": \\"SizePaddingXl\\",
+            \\"attributes\\": {
+              \\"category\\": \\"size\\",
+              \\"type\\": \\"padding\\",
+              \\"item\\": \\"xl\\"
+            },
+            \\"path\\": [
+              \\"size\\",
+              \\"padding\\",
+              \\"xl\\"
+            ]
+          }
+        }
+      }
+    },
+    \\"allTokens\\": [
+      {
+        \\"value\\": \\"0.5rem\\",
+        \\"filePath\\": \\"__integration__/tokens/size/padding.json\\",
+        \\"isSource\\": true,
+        \\"original\\": {
+          \\"value\\": 0.5
+        },
+        \\"name\\": \\"SizePaddingSmall\\",
+        \\"attributes\\": {
+          \\"category\\": \\"size\\",
+          \\"type\\": \\"padding\\",
+          \\"item\\": \\"small\\"
+        },
+        \\"path\\": [
+          \\"size\\",
+          \\"padding\\",
+          \\"small\\"
+        ]
+      },
+      {
+        \\"value\\": \\"1rem\\",
+        \\"filePath\\": \\"__integration__/tokens/size/padding.json\\",
+        \\"isSource\\": true,
+        \\"original\\": {
+          \\"value\\": 1
+        },
+        \\"name\\": \\"SizePaddingMedium\\",
+        \\"attributes\\": {
+          \\"category\\": \\"size\\",
+          \\"type\\": \\"padding\\",
+          \\"item\\": \\"medium\\"
+        },
+        \\"path\\": [
+          \\"size\\",
+          \\"padding\\",
+          \\"medium\\"
+        ]
+      },
+      {
+        \\"value\\": \\"1rem\\",
+        \\"filePath\\": \\"__integration__/tokens/size/padding.json\\",
+        \\"isSource\\": true,
+        \\"original\\": {
+          \\"value\\": 1
+        },
+        \\"name\\": \\"SizePaddingLarge\\",
+        \\"attributes\\": {
+          \\"category\\": \\"size\\",
+          \\"type\\": \\"padding\\",
+          \\"item\\": \\"large\\"
+        },
+        \\"path\\": [
+          \\"size\\",
+          \\"padding\\",
+          \\"large\\"
+        ]
+      },
+      {
+        \\"value\\": \\"1rem\\",
+        \\"filePath\\": \\"__integration__/tokens/size/padding.json\\",
+        \\"isSource\\": true,
+        \\"original\\": {
+          \\"value\\": 1
+        },
+        \\"name\\": \\"SizePaddingXl\\",
+        \\"attributes\\": {
+          \\"category\\": \\"size\\",
+          \\"type\\": \\"padding\\",
+          \\"item\\": \\"xl\\"
+        },
+        \\"path\\": [
+          \\"size\\",
+          \\"padding\\",
+          \\"xl\\"
+        ]
+      }
+    ],
+    \\"tokens\\": {
       \\"size\\": {
         \\"padding\\": {
           \\"small\\": {

--- a/lib/utils/createFormatArgs.js
+++ b/lib/utils/createFormatArgs.js
@@ -14,7 +14,7 @@
 const deepExtend = require('./deepExtend');
 
 function createFormatArgs({ dictionary, platform, file = {} }) {
-  const {allProperties, properties, usesReference, getReferences} = dictionary;
+  const {allProperties, properties, allTokens, tokens, usesReference, getReferences} = dictionary;
   // This will merge platform and file-level configuration
   // where the file configuration takes precedence
   const {options} = platform;
@@ -26,6 +26,10 @@ function createFormatArgs({ dictionary, platform, file = {} }) {
     getReferences,
     allProperties,
     properties,
+    // adding tokens and allTokens as the new way starting in v3,
+    // keeping properties and allProperties around for backwards-compatibility
+    allTokens,
+    tokens,
     platform,
     file,
     options: file.options || {}


### PR DESCRIPTION
*Issue #, if available:* #652

*Description of changes:*

- Update `createFormatArgs` to return `allTokens` and `tokens` properties along with `properties` and `allProperties`
- Update snapshots
    - It's hard to confirm in the diff, but I manually confirmed that the newly-added values for `allTokens` are the same as `allProperties`, and `tokens` are the same as `properties`

*Note:*

Correcting the types will be done in a future PR.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
