### PR TITLE
docs: Update formatter functions to use single arg

### DIFF
--- a/docs/formats.md
+++ b/docs/formats.md
@@ -1044,7 +1044,7 @@ Thankfully you can extend style-dictionary very easily:
 const JsonToTS = require('json-to-ts');
 StyleDictionaryPackage.registerFormat({
   name: 'typescript/accurate-module-declarations',
-  formatter: function(dictionary) {
+  formatter: function({ dictionary }) {
     return 'declare const root: RootObject\n' +
     'export default root\n' +
     JsonToTS(dictionary.properties).join('\n');

--- a/docs/version_3.md
+++ b/docs/version_3.md
@@ -156,7 +156,7 @@ If you have custom formats you can make use of this feature too! The `dictionary
 StyleDictionary.registerFormat({
   name: `myCustomFormat`,
   formatter: function({ dictionary }) {
-    return dictionary.allProperties.map(token => {
+    return dictionary.allTokens.map(token => {
       let value = JSON.stringify(token.value);
       // the `dictionary` object now has `usesReference()` and
       // `getReference()` methods. `usesReference()` will return true if

--- a/docs/version_3.md
+++ b/docs/version_3.md
@@ -155,7 +155,7 @@ If you have custom formats you can make use of this feature too! The `dictionary
 ```javascript
 StyleDictionary.registerFormat({
   name: `myCustomFormat`,
-  formatter: function(dictionary) {
+  formatter: function({ dictionary }) {
     return dictionary.allProperties.map(token => {
       let value = JSON.stringify(token.value);
       // the `dictionary` object now has `usesReference()` and

--- a/examples/advanced/custom-transforms/build.js
+++ b/examples/advanced/custom-transforms/build.js
@@ -95,7 +95,7 @@ StyleDictionary.registerTransformGroup({
 
 StyleDictionary.registerFormat({
   name: 'custom/android/xml',
-  formatter: function(dictionary) {
+  formatter: function({ dictionary }) {
     return dictionary.allTokens.map(function(token) {
       return `<item name="${token.name}">${token.value}</item>`;
     }).join('\n');

--- a/examples/advanced/format-helpers/sd.config.js
+++ b/examples/advanced/format-helpers/sd.config.js
@@ -30,7 +30,7 @@ module.exports = {
       // proper style. If the file has a custom file header defined, or
       // showFileHeader option, it will honor those.
       return fileHeader({file, commentStyle: 'short'}) +
-        dictionary.allProperties
+        dictionary.allTokens
           // sortByReference returns a function that can be used as to sort
           // an array. This will sort the array so that references always
           // come after their instantiation so that there are no errors

--- a/examples/advanced/matching-build-files/config.js
+++ b/examples/advanced/matching-build-files/config.js
@@ -81,7 +81,7 @@ module.exports = {
 
 StyleDictionary.registerFormat({
   name: "custom/cjsmodule",
-  formatter: function (dictionary) {
+  formatter: function({ dictionary }) {
     return `module.exports = {${dictionary.allTokens.map(
       (token) => `\n\t${token.name}: "${token.value}"`
     )}\n};`;

--- a/examples/advanced/node-modules-as-config-and-properties/config.js
+++ b/examples/advanced/node-modules-as-config-and-properties/config.js
@@ -18,7 +18,7 @@ StyleDictionary.registerTransform({
 
 StyleDictionary.registerFormat({
   name: 'myRegisteredFormat',
-  formatter: (dictionary) => {
+  formatter: ({ dictionary }) => {
     return dictionary.allTokens.map((token) => token.value).join('\n');
   }
 })

--- a/examples/advanced/variables-in-outputs/README.md
+++ b/examples/advanced/variables-in-outputs/README.md
@@ -24,7 +24,7 @@ The `sd.config.js` file has everything you need to see. The tokens included in t
 Here is an example that shows how to get an alias's name within a custom format:
 ```javascript
 //...
-function(dictionary) {
+function({ dictionary }) {
   return dictionary.allTokens.map(token => {
     let value = JSON.stringify(token.value);
     // the `dictionary` object now has `usesReference()` and

--- a/lib/common/formats.js
+++ b/lib/common/formats.js
@@ -445,7 +445,7 @@ module.exports = {
    * const JsonToTS = require('json-to-ts');
    * StyleDictionaryPackage.registerFormat({
    *   name: 'typescript/accurate-module-declarations',
-   *   formatter: function(dictionary) {
+   *   formatter: function({ dictionary }) {
    *     return 'declare const root: RootObject\n' +
    *     'export default root\n' +
    *     JsonToTS(dictionary.properties).join('\n');


### PR DESCRIPTION
*Issue #, if available:* #652

*Description of changes:*

- Update all usages of formatter functions to use the single, object arg instead of positional arguments, to match recommended v3 usage

*Note:*

I also changed the usages within actual example code, and confirmed that those examples all still built.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
