### PR TITLE
fix(types): Add overloaded formatter fn definiton

### DIFF
--- a/types/Format.d.ts
+++ b/types/Format.d.ts
@@ -36,10 +36,17 @@ export interface FormatterArguments {
 }
 
 /**
- * The formatter function receives an overloaded object as its arguments and
+ * The formatter function receives positional arguments and it should return a
+ * string, which will be written to a file.
+ */
+declare function formatter(dictionary: Dictionary, platform: Platform, file: File): string;
+/**
+ * The formatter function receives an overloaded object as its argument and
  * it should return a string, which will be written to a file.
  */
-export type Formatter = (arguments: FormatterArguments) => string;
+declare function formatter(arguments: FormatterArguments): string;
+
+export type Formatter = typeof formatter;
 
 export interface Format {
   formatter: Formatter;


### PR DESCRIPTION
*Issue #, if available:* #652

*Description of changes:*

- `formatter` type now accepts either positional arguments or a single object argument

*Note:*

I didn't see an easy way to typecheck usages of `formatter` within the project, but I did make these changes in my local `node_modules` of another project and confirmed that the types seemed to be correct there.

I'm not familiar with `tsd`, so I'm unsure why the type tests are failing or how to fix them.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
