### PR TITLE
fix(format): 'typescript/es6-declarations' return type

### DIFF
--- a/__tests__/common/formatHelpers/getTypeScriptType.test.js
+++ b/__tests__/common/formatHelpers/getTypeScriptType.test.js
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+const getTypeScriptType = require('../../../lib/common/formatHelpers/getTypeScriptType');
+
+describe('common', () => {
+  describe('formatHelpers', () => {
+    describe('getTypeScriptType', () => {
+      it('should recognize basic types', () => {
+        expect(getTypeScriptType('a string')).toEqual('string');
+        expect(getTypeScriptType(3.14159)).toEqual('number');
+        expect(getTypeScriptType(true)).toEqual('boolean');
+      });
+
+      it('should recognize arrays of basic types', () => {
+        expect(getTypeScriptType(['an', 'array', 'of', 'strings'])).toEqual('string[]');
+        expect(getTypeScriptType([3.14159])).toEqual('number[]');
+        expect(getTypeScriptType([true, false, true, true])).toEqual('boolean[]');
+      });
+
+      it('should default to any, if no type is determined', () => {
+        expect(getTypeScriptType({})).toEqual('any');
+        expect(getTypeScriptType([{}])).toEqual('any[]');
+        expect(getTypeScriptType(['string', 3.14, false])).toEqual('any[]');
+      });
+
+      it('should support nested arrays', () => {
+        expect(getTypeScriptType([[100, 200], [300, 400]])).toEqual('number[][]');
+      })
+    });
+  });
+});

--- a/lib/common/formatHelpers/getTypeScriptType.js
+++ b/lib/common/formatHelpers/getTypeScriptType.js
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+/**
+ * Given some value, returns a basic valid TypeScript type for that value.
+ * Supports numbers, strings, booleans, and arrays of any of those types.
+ * 
+ * @memberof module:formatHelpers
+ * @example
+ * ```javascript
+ * StyleDictionary.registerFormat({
+ *   name: 'myCustomFormat',
+ *   formatter: function({ dictionary, options }) {
+ *    return dictionary.allProperties.map(function(prop) {
+ *      var to_ret_prop = 'export const ' + prop.name + ' : ' + getTypeScriptType(prop.value) + ';';
+ *      if (prop.comment)
+ *        to_ret_prop = to_ret_prop.concat(' // ' + prop.comment);
+ *      return to_ret_prop;
+ *    }).join('\n');
+ *   }
+ * });
+ * 
+ * @param {*} value A value to check the type of.
+ * @return {String} A valid name for a TypeScript type.
+ * ```
+ */
+ function getTypeScriptType(value) {
+    if (Array.isArray(value)) {
+      if (value.length > 0) {
+        const firstValueType = getTypeScriptType(value[0]);
+        if (value.every((v) => getTypeScriptType(v) === firstValueType)) {
+          return firstValueType + '[]';
+        }
+      }
+      return 'any[]';
+    }
+  
+    const type = typeof value;
+    if (['string', 'number', 'boolean'].includes(type)) return type;
+    return 'any';
+  }
+  
+  module.exports = getTypeScriptType;

--- a/lib/common/formatHelpers/index.js
+++ b/lib/common/formatHelpers/index.js
@@ -15,10 +15,11 @@
  *
  * @module formatHelpers
  */
-module.exports = {
+ module.exports = {
   createPropertyFormatter: require('./createPropertyFormatter'),
   fileHeader: require('./fileHeader'),
   formattedVariables: require('./formattedVariables'),
+  getTypeScriptType: require('./getTypeScriptType'),
   iconsWithPrefix: require('./iconsWithPrefix'),
   sortByReference: require('./sortByReference'),
   sortByName: require('./sortByName'),

--- a/lib/common/formats.js
+++ b/lib/common/formats.js
@@ -15,7 +15,7 @@ const fs = require('fs');
 const path = require('path');
 const _template = require('lodash/template');
 const GroupMessages = require('../utils/groupMessages');
-const { fileHeader, formattedVariables, iconsWithPrefix, minifyDictionary, sortByReference, createPropertyFormatter, sortByName } = require('./formatHelpers');
+const { fileHeader, formattedVariables, getTypeScriptType, iconsWithPrefix, minifyDictionary, sortByReference, createPropertyFormatter, sortByName } = require('./formatHelpers');
 
 const SASS_MAP_FORMAT_DEPRECATION_WARNINGS = GroupMessages.GROUP.SassMapFormatDeprecationWarnings;
 
@@ -393,7 +393,7 @@ module.exports = {
   'typescript/es6-declarations': function({dictionary, file}) {
     return fileHeader({file}) +
       dictionary.allProperties.map(function(prop) {
-        var to_ret_prop = 'export const ' + prop.name + ' : string;';
+        var to_ret_prop = 'export const ' + prop.name + ' : ' + getTypeScriptType(prop.value) + ';';
         if (prop.comment)
           to_ret_prop = to_ret_prop.concat(' // ' + prop.comment);
         return to_ret_prop;


### PR DESCRIPTION
This change fixes an issue where all variables exported from 'typescript/es6-declarations' are assumed to be of type `string`.

Before this, if you had an input type like:
```json
{
  "color": {
    "blue": { "value": "#0000ff" },
  },
  "size": {
    "padding": { "value": 2 }
  }
}
```

Your output ES6 module would be:
```js
export const ColorBlue = "#0000ff";
export const SizePadding = 2;
```

But your output TypeScript module would be:
```ts
export const ColorBlue : string;
export const SizePadding : string;
```

This adds some *basic* type checking for a few known values, and will fall back to `any` if the type can't be easily determined. It will look for:

- strings
- numbers
- booleans
- or arrays of any of those things

If it can't determine the type, it will fall back to `any` (or `any[]` if we know it's an array).


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
