### PR TITLE
fix(references): check if object value is a string before replacement

### DIFF
--- a/__tests__/utils/reference/getReferences.test.js
+++ b/__tests__/utils/reference/getReferences.test.js
@@ -30,9 +30,17 @@ const properties = {
         color: "{color.red.value}",
         width: "{size.border.value}",
         style: "solid"
-      }
+      },
     },
     secondary: {
+      // and objects that have a non-string
+      value: {
+        color: "{color.red.value}",
+        width: 2,
+        style: "solid"
+      }
+    },
+    tertiary: {
       // getReferences should work on interpolated values like this:
       value: "{size.border.value} solid {color.red.value}"
     }
@@ -65,8 +73,16 @@ describe('utils', () => {
         );
       });
 
-      it(`should work with interpolated values`, () => {
+      it(`should work with objects that have numbers`, () => {
         expect(dictionary.getReferences(properties.border.secondary.value)).toEqual(
+          expect.arrayContaining([
+            {value: "#f00"}
+          ])
+        );
+      });
+
+      it(`should work with interpolated values`, () => {
+        expect(dictionary.getReferences(properties.border.tertiary.value)).toEqual(
           expect.arrayContaining([
             {value: "2px"},
             {value: "#f00"}

--- a/lib/utils/references/getReferences.js
+++ b/lib/utils/references/getReferences.js
@@ -67,7 +67,7 @@ function getReferences(value) {
   // function which iterates over the object to see if there is a reference
   if (typeof value === 'object') {
     for (const key in value) {
-      if (value.hasOwnProperty(key)) {
+      if (value.hasOwnProperty(key) && typeof value[key] === 'string') {
         value[key].replace(regex, findReference);
       }
     }


### PR DESCRIPTION
*Issue #, if available:* #678

*Description of changes:* In the `getReferences` function first check if the values within an object are strings before trying to run `.replace` on them. It is valid to have a non-string value within an object, just like it is valid to have a non-string as a regular value (like a number for a dimension).


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
