### PR TITLE
#684: Add `className` optional parameter

### DIFF
--- a/types/File.d.ts
+++ b/types/File.d.ts
@@ -15,6 +15,7 @@ import { Options } from './Options';
 import { TransformedToken } from './TransformedToken';
 
 export interface File {
+  className?: string;
   destination: string;
   format?: string;
   filter?: string | Partial<TransformedToken> | ((token: TransformedToken) => boolean);


### PR DESCRIPTION
*Issue #, if available:* 
#684 

*Description of changes:*
Adds `className` to the `File` object, as it should be supported looking at the [config](https://github.com/amzn/style-dictionary/blob/main/examples/basic/config.json#L100) available. Currently, the `ios-swift` format produces a class without any name when using a TypeScript configuration, meaning it can't be used.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
