### PR TITLE
chore(docs): add selector option for css/variables format

### DIFF
--- a/docs/formats.md
+++ b/docs/formats.md
@@ -729,6 +729,9 @@ Creates a CSS file with variable definitions based on the style dictionary
     </tr><tr>
     <td>[options.outputReferences]</td><td><code>Boolean</code></td><td><code>false</code></td><td><p>Whether or not to keep <a href="/#/formats?id=references-in-output-files">references</a> (a -&gt; b -&gt; c) in the output.</p>
 </td>
+    </tr><tr>
+    <td>[options.selector]</td><td><code>string</code></td><td></td><td><p>Override the root css selector</p>
+</td>
     </tr>  </tbody>
 </table>
 

--- a/lib/common/formats.js
+++ b/lib/common/formats.js
@@ -32,6 +32,7 @@ module.exports = {
    * @param {Object} options
    * @param {Boolean} [options.showFileHeader=true] - Whether or not to include a comment that has the build date
    * @param {Boolean} [options.outputReferences=false] - Whether or not to keep [references](/#/formats?id=references-in-output-files) (a -> b -> c) in the output.
+   * @param {string} [options.selector] - Override the root css selector
    * @example
    * ```css
    * :root {


### PR DESCRIPTION
*Description of changes:*

Documents the selector option on the css/variables format. 

*Context:*

I was trying to figure out how to split .light-theme/.dark-theme files and came across this nifty feature. I didn't see it documented anywhere. Is this correct?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
