### PR TITLE
[TS] Fix FileHeader input type

### DIFF
--- a/types/FileHeader.d.ts
+++ b/types/FileHeader.d.ts
@@ -11,4 +11,4 @@
  * and limitations under the License.
  */
 
-export type FileHeader = (defaultMessage: string) => string[];
+export type FileHeader = (defaultMessage: string[]) => string[];


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Change the `FileHeader`'s `defaultMessage` input type `string[]` instead of just `string`.

*Reason:*

File Header's defaultMessage is [defined as an array in code](https://github.com/amzn/style-dictionary/blob/main/lib/common/formatHelpers/fileHeader.js#L64-L67).

File Header in [Examples](https://amzn.github.io/style-dictionary/#/formats?id=file-headers) shows expanding the `defaultMessage`. E.g. `return [...defaultMessage, 'hello world']`. TypeScript won't allow this currently due to the `string` data type.

Altho the current data type works, it implicitly converts the array into a string which results in a malformed header.

```javascript
// Do not edit directly,Generated on Sat, 02 Oct 2021 12:57:05 GMT
// hello, world!
```

vs (fixed)

```javascript
// Do not edit directly
// Generated on Sat, 02 Oct 2021 12:45:13 GMT
// hello, world!
```

---

P.S. Is there a way to change the header for every file without the need to specify the custom header formater in every file/platform? Currently, I do following:
```ts
Object.keys(config.platforms).forEach((key) => {
    config.platforms[key].options = {fileHeader: 'myHeader', ...config.platforms[key].options}
})

```
---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
