### PR TITLE
RFC: adding .toString() on tokens so you can leave off '.value' in references

### DIFF
--- a/__integration__/__snapshots__/objectValues.test.js.snap
+++ b/__integration__/__snapshots__/objectValues.test.js.snap
@@ -8,6 +8,7 @@ exports[`integration object values css/variables border should match snapshot 1`
 
 :root {
   --border-primary: 0.125rem solid #ff0000;
+  --border-secondary: 0.125rem solid #ff0000;
 }
 "
 `;
@@ -19,6 +20,7 @@ exports[`integration object values css/variables border with references should m
  */
 
 :root {
+  --border-secondary: var(--size-border) solid var(--color-red);
   --border-primary: var(--size-border) solid var(--color-red);
 }
 "
@@ -32,7 +34,9 @@ exports[`integration object values css/variables hex syntax should match snapsho
 
 :root {
   --color-red: #ff0000;
+  --color-redder: #ff0000;
   --color-green: #40bf40;
+  --color-greener: #40bf40;
 }
 "
 `;
@@ -46,6 +50,8 @@ exports[`integration object values css/variables hex syntax with references shou
 :root {
   --color-red: #ff0000;
   --color-green: #40bf40;
+  --color-redder: var(--color-red);
+  --color-greener: var(--color-green);
 }
 "
 `;
@@ -58,7 +64,9 @@ exports[`integration object values css/variables hsl syntax should match snapsho
 
 :root {
   --color-red: #ff0000;
+  --color-redder: #ff0000;
   --color-green: hsl(120, 50%, 50%);
+  --color-greener: hsl(120, 50%, 50%);
 }
 "
 `;
@@ -72,6 +80,8 @@ exports[`integration object values css/variables hsl syntax with references shou
 :root {
   --color-red: #ff0000;
   --color-green: hsl(120, 50%, 50%);
+  --color-redder: var(--color-red);
+  --color-greener: var(--color-green);
 }
 "
 `;
@@ -81,7 +91,8 @@ exports[`integration object values scss/variables should match snapshot 1`] = `
 // Do not edit directly
 // Generated on Sat, 01 Jan 2000 00:00:00 GMT
 
-$border-primary: 0.125rem solid #ff0000;"
+$border-primary: 0.125rem solid #ff0000;
+$border-secondary: 0.125rem solid #ff0000;"
 `;
 
 exports[`integration object values scss/variables with references should match snapshot 1`] = `
@@ -89,5 +100,6 @@ exports[`integration object values scss/variables with references should match s
 // Do not edit directly
 // Generated on Sat, 01 Jan 2000 00:00:00 GMT
 
+$border-secondary: $size-border solid $color-red;
 $border-primary: $size-border solid $color-red;"
 `;

--- a/__integration__/objectValues.test.js
+++ b/__integration__/objectValues.test.js
@@ -29,13 +29,15 @@ describe('integration', () => {
         lightness: `50%`,
         color: {
           red: { value: "#f00" },
+          redder: { value: "{color.red.value}" },
           green: {
             value: {
               h: "{hue}",
               s: "{saturation}",
               l: "{lightness}"
             }
-          }
+          },
+          greener: { value: "{color.green.value}" }
         },
         size: {
           border: { value: 0.125 }
@@ -49,6 +51,13 @@ describe('integration', () => {
               style: "solid"
             }
           },
+          secondary: {
+            value: {
+              color: "{color.red}",
+              width: "{size.border}",
+              style: "solid"
+            }
+          }
         }
       },
       transform: {

--- a/__tests__/transform/object.test.js
+++ b/__tests__/transform/object.test.js
@@ -92,7 +92,7 @@ describe('transform', () => {
       };
 
       const actual = transformObject(objectToTransform, options);
-      expect(actual).toEqual(expected);
+      expect(actual).toMatchObject(expected);
     });
 
     it('fills the transformationContext with transformed and deferred transforms', () => {

--- a/__tests__/transform/propertySetup.test.js
+++ b/__tests__/transform/propertySetup.test.js
@@ -96,7 +96,14 @@ describe('transform', () => {
       }, 'red', ['color','red']);
       expect(test).toHaveProperty('value.h', 20);
       expect(test).toHaveProperty('original.value.h', 20);
-    })
+    });
 
+    it('should set .toString', () => {
+      const test = propertySetup({
+        value: '#ff0000'
+      }, 'red', ['color','red']);
+
+      expect(`${test}`).toEqual('#ff0000');
+    });
   });
 });

--- a/lib/transform/propertySetup.js
+++ b/lib/transform/propertySetup.js
@@ -53,6 +53,9 @@ function propertySetup(property, name, path) {
     // An array of the path down the object tree; we will use it to build readable names
     // like color_font_base
     to_ret.path = _.clone(path);
+    to_ret.toString = function() {
+      return this.value;
+    }
   }
 
   return to_ret;

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "style-dictionary",
       "version": "3.0.2",
       "license": "Apache-2.0",
       "dependencies": {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
