### PR TITLE
fix(types): added `name` to format, and export `Named`

### DIFF
--- a/types/Format.d.ts
+++ b/types/Format.d.ts
@@ -42,5 +42,6 @@ export interface FormatterArguments {
 export type Formatter = (arguments: FormatterArguments) => string;
 
 export interface Format {
+  name: string;
   formatter: Formatter;
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -28,7 +28,7 @@ import {Platform as _Platform} from './Platform';
 import {Transform as _Transform} from './Transform';
 import {TransformedToken as _TransformedToken, TransformedTokens as _TransformedTokens} from './TransformedToken';
 import {TransformGroup as _TransformGroup} from './TransformGroup';
-import {Named} from './_helpers';
+import {Named as _Named} from './_helpers';
 
 // Because this library is used in Node and needs to be accessible
 // as a CommonJS module, we are declaring it as a namespace so that
@@ -51,6 +51,7 @@ declare namespace StyleDictionary {
   type TransformedToken = _TransformedToken;
   type TransformedTokens = _TransformedTokens;
   type TransformGroup = _TransformGroup;
+  type Named<T> = _Named<T>
 
   interface Core {
     VERSION: string;


### PR DESCRIPTION
*Issue #, if available:* 
Sorry, haven't raised an issue

*Description of changes:*
1. Added `name` to `Format`. On our project we use `registerFormat` which takes an object (`Format`) with a `formatter` and a `name`. However, on switching to the latest version of SD, an error is thrown as the types weren't allowing `name`.
2. Export `Named`. `registerTransform` takes `Named<Transform>` as an input, yet was not exported from SD as a type, so we weren't able to type these transforms independently. Exporting `Named` allows us to do this.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
