### PR TITLE
chore(docs): adddocs reference to playground

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ For detailed usage head to https://amzn.github.io/style-dictionary
 ## Watch the Demo on Youtube
 [![Watch the video](/docs/assets/fake_player.png)](http://youtu.be/1HREvonfqhY)
 
+## Experiment in the playground
+Try the browser-based Style Dictionary playground: [https://www.style-dictionary-play.dev/](https://www.style-dictionary-play.dev/), built by the folks at [\<div\>RIOTS](https://divriots.com/).
+
 ## Contents
 * [Installation](#installation)
 * [Usage](#usage)

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,9 @@ When you are managing user experiences, it can be quite challenging to keep styl
 ## Watch the Demo on Youtube
 [![Watch the video](assets/fake_player.png)](http://youtu.be/1HREvonfqhY)
 
+## Experiment in the playground
+Try the browser-based Style Dictionary playground: [https://www.style-dictionary-play.dev/](https://www.style-dictionary-play.dev/), built by the folks at [\<div\>RIOTS](https://divriots.com/).
+
 ## Examples
 [See examples of Style Dictionary here](examples.md)
 


### PR DESCRIPTION
As discussed with @dbanksdesign  I would open a PR to add a reference to the playground in the docs.

I took the liberty to add a CTA button for it on the coverpage, let me know if that's okay with you guys, I'm obviously a bit biased to saying it's important enough to be there ;)
