### PR TITLE
feat(ios-swift): add transformer for Color class from SwiftUI

### DIFF
--- a/__tests__/common/transforms.test.js
+++ b/__tests__/common/transforms.test.js
@@ -416,6 +416,29 @@ describe('common', () => {
       });
     });
 
+    describe('color/ColorSwiftUI', () => {
+      it('should handle normal colors', () => {
+        var value = transforms["color/ColorSwiftUI"].transformer({
+          value: "#aaaaaa"
+        });
+        expect(value).toBe("Color(red: 0.667, green: 0.667, blue: 0.667, opacity: 1)");
+      });
+
+      it('should retain enough precision when converting to decimal', () => {
+        var value = transforms["color/ColorSwiftUI"].transformer({
+          value: "#1d1d1d"
+        });
+        expect(value).toBe("Color(red: 0.114, green: 0.114, blue: 0.114, opacity: 1)");
+      });
+
+      it('should handle colors with transparency', () => {
+        var value = transforms["color/ColorSwiftUI"].transformer({
+          value: "#aaaaaa99"
+        });
+        expect(value).toBe("Color(red: 0.667, green: 0.667, blue: 0.667, opacity: 0.6)");
+      });
+    });
+
     describe('color/hex8flutter', () => {
       it('should handle colors without alpha', () => {
         var value = transforms["color/hex8flutter"].transformer({

--- a/docs/tokens.md
+++ b/docs/tokens.md
@@ -37,7 +37,7 @@ For any design tokens you wish to output, the "value" attribute is required. Thi
 | comment | String (optional) | The comment attribute will show up in a code comment in output files if the format supports it.
 | themeable | Boolean (optional) | This is used in formats that support override-able or themable values like the `!default` flag in Sass.
 | name | String (optional) | Usually the name for a design token is generated with a [name transform](transforms.md#transform-types), but you can write your own if you choose. By default Style Dictionary will add a default name which is the key of the design token object.
-| attributes | Object (optional) | Extra information about the design token you want to include. [Attribute transforms](transforms.md#transform-types) will modify this object so be careful 
+| attributes | Object (optional) | Extra information about the design token you want to include. [Attribute transforms](transforms.md#transform-types) will modify this object so be careful
 
 You can add any attributes or data you want in a design token and Style Dictionary will pass it along to transforms and formats. For example, you could add a `deprecated` flag like in [this example](https://github.com/amzn/style-dictionary/tree/main/examples/advanced/tokens-deprecation). Other things you can do is add documentation information about each design token or information about color contrast.
 
@@ -360,12 +360,13 @@ Everything under this category is a color. You can further organize by backgroun
 * [`color/hex8android`](transforms.md#colorhex8android)
 * [`color/UIColor`](transforms.md#coloruicolor)
 * [`color/UIColorSwift`](transforms.md#coloruicolorswift)
+* [`color/ColorSwiftUI`](transforms.md#colorcolorswiftui)
 * [`color/css`](transforms.md#colorcss)
 * [`color/sketch`](transforms.md#colorsketch)
 * [`color/hex8flutter`](transforms.md#colorhex8flutter)
 
 #### Category: size
-Most platforms any type of size is treated the same. On Android it is common to use SP for font sizes and DP for paddings and dimensions. 
+Most platforms any type of size is treated the same. On Android it is common to use SP for font sizes and DP for paddings and dimensions.
 * [`size/sp`](transforms.md#sizesp)
 * [`size/dp`](transforms.md#sizedp)
 * [`size/object`](transforms.md#sizeobject)

--- a/docs/transform_groups.md
+++ b/docs/transform_groups.md
@@ -25,7 +25,7 @@ You use transformGroups in your config file under platforms > [platform] > trans
 
 [lib/common/transformGroups.js](https://github.com/amzn/style-dictionary/blob/main/lib/common/transformGroups.js)
 
-### web 
+### web
 
 
 Transforms:
@@ -38,7 +38,7 @@ Transforms:
 
 * * *
 
-### js 
+### js
 
 
 Transforms:
@@ -51,7 +51,7 @@ Transforms:
 
 * * *
 
-### scss 
+### scss
 
 
 Transforms:
@@ -66,7 +66,7 @@ Transforms:
 
 * * *
 
-### css 
+### css
 
 
 Transforms:
@@ -81,7 +81,7 @@ Transforms:
 
 * * *
 
-### less 
+### less
 
 
 Transforms:
@@ -96,7 +96,7 @@ Transforms:
 
 * * *
 
-### html 
+### html
 
 
 Transforms:
@@ -108,7 +108,7 @@ Transforms:
 
 * * *
 
-### android 
+### android
 
 
 Transforms:
@@ -122,7 +122,7 @@ Transforms:
 
 * * *
 
-### compose 
+### compose
 
 
 Transforms:
@@ -137,7 +137,7 @@ Transforms:
 
 * * *
 
-### ios 
+### ios
 
 
 Transforms:
@@ -153,7 +153,7 @@ Transforms:
 
 * * *
 
-### ios-swift 
+### ios-swift
 
 
 Transforms:
@@ -161,6 +161,7 @@ Transforms:
 [attribute/cti](transforms.md#attributecti)
 [name/cti/camel](transforms.md#namecticamel)
 [color/UIColorSwift](transforms.md#coloruicolorswift)
+[`color/ColorSwiftUI`](transforms.md#colorcolorswiftui)
 [content/swift/literal](transforms.md#contentswiftliteral)
 [asset/swift/literal](transforms.md#assetswiftliteral)
 [size/swift/remToCGFloat](transforms.md#sizeswiftremtocgfloat)
@@ -169,7 +170,7 @@ Transforms:
 
 * * *
 
-### ios-swift-separate 
+### ios-swift-separate
 
 
 Transforms:
@@ -177,6 +178,7 @@ Transforms:
 [attribute/cti](transforms.md#attributecti)
 [name/ti/camel](transforms.md#nameticamel)
 [color/UIColorSwift](transforms.md#coloruicolorswift)
+[color/ColorSwiftUI](transforms.md#colorcolorswiftui)
 [content/swift/literal](transforms.md#contentswiftliteral)
 [asset/swift/literal](transforms.md#assetswiftliteral)
 [size/swift/remToCGFloat](transforms.md#sizeswiftremtocgfloat)
@@ -187,7 +189,7 @@ This is to be used if you want to have separate files per category and you don't
 
 * * *
 
-### assets 
+### assets
 
 
 Transforms:
@@ -197,7 +199,7 @@ Transforms:
 
 * * *
 
-### flutter 
+### flutter
 
 
 Transforms:
@@ -213,7 +215,7 @@ Transforms:
 
 * * *
 
-### flutter-separate 
+### flutter-separate
 
 
 Transforms:
@@ -231,7 +233,7 @@ This is to be used if you want to have separate files per category and you don't
 
 * * *
 
-### react-native 
+### react-native
 
 
 Transforms:

--- a/docs/transforms.md
+++ b/docs/transforms.md
@@ -88,7 +88,7 @@ If you want to learn more about transitive transforms, take a look at the [trans
 
 > All the pre-defined transforms included use the [CTI structure](tokens.md?id=category-type-item) for matching tokens. If you structure your design tokens differently you will need to write [custom transforms](transforms.md?id=defining-custom-transforms) or make sure the proper CTIs are on the attributes of your design tokens.
 
-### attribute/cti 
+### attribute/cti
 
 
 Adds: category, type, item, subitem, and state on the attributes object based on the location in the style dictionary.
@@ -108,7 +108,7 @@ Adds: category, type, item, subitem, and state on the attributes object based on
 
 * * *
 
-### attribute/color 
+### attribute/color
 
 
 Adds: hex, hsl, hsv, rgb, red, blue, green.
@@ -127,7 +127,7 @@ Adds: hex, hsl, hsv, rgb, red, blue, green.
 
 * * *
 
-### name/human 
+### name/human
 
 
 Creates a human-friendly name
@@ -141,7 +141,7 @@ Creates a human-friendly name
 
 * * *
 
-### name/cti/camel 
+### name/cti/camel
 
 
 Creates a camel case name. If you define a prefix on the platform in your config, it will prepend with your prefix
@@ -156,7 +156,7 @@ Creates a camel case name. If you define a prefix on the platform in your config
 
 * * *
 
-### name/ti/camel 
+### name/ti/camel
 
 
 Creates a camel case name without the category at the front.  This is most useful when there is a class, struct, enum, etc.
@@ -173,7 +173,7 @@ If you define a prefix on the platform in your config, it will prepend with your
 
 * * *
 
-### name/cti/kebab 
+### name/cti/kebab
 
 
 Creates a kebab case name. If you define a prefix on the platform in your config, it will prepend with your prefix
@@ -188,7 +188,7 @@ Creates a kebab case name. If you define a prefix on the platform in your config
 
 * * *
 
-### name/cti/snake 
+### name/cti/snake
 
 
 Creates a snake case name. If you define a prefix on the platform in your config, it will prepend with your prefix
@@ -203,7 +203,7 @@ Creates a snake case name. If you define a prefix on the platform in your config
 
 * * *
 
-### name/cti/constant 
+### name/cti/constant
 
 
 Creates a constant-style name based on the full CTI of the token. If you define a prefix on the platform in your config, it will prepend with your prefix
@@ -218,7 +218,7 @@ Creates a constant-style name based on the full CTI of the token. If you define 
 
 * * *
 
-### name/ti/constant 
+### name/ti/constant
 
 
 Creates a constant-style name on the type and item of the token. This is useful if you want to create different static classes/files for categories like `Color.BACKGROUND_BASE`. If you define a prefix on the platform in your config, it will prepend with your prefix.
@@ -233,7 +233,7 @@ Creates a constant-style name on the type and item of the token. This is useful 
 
 * * *
 
-### name/cti/pascal 
+### name/cti/pascal
 
 
 Creates a Pascal case name. If you define a prefix on the platform in your config, it will prepend with your prefix
@@ -248,7 +248,7 @@ Creates a Pascal case name. If you define a prefix on the platform in your confi
 
 * * *
 
-### color/rgb 
+### color/rgb
 
 
 Transforms the value into an RGB string
@@ -262,7 +262,7 @@ Transforms the value into an RGB string
 
 * * *
 
-### color/hsl 
+### color/hsl
 
 
 Transforms the value into an HSL string or HSLA if alpha is present. Better browser support than color/hsl-4
@@ -277,7 +277,7 @@ Transforms the value into an HSL string or HSLA if alpha is present. Better brow
 
 * * *
 
-### color/hsl-4 
+### color/hsl-4
 
 
 Transforms the value into an HSL string, using fourth argument if alpha is present.
@@ -292,7 +292,7 @@ Transforms the value into an HSL string, using fourth argument if alpha is prese
 
 * * *
 
-### color/hex 
+### color/hex
 
 
 Transforms the value into an 6-digit hex string
@@ -306,7 +306,7 @@ Transforms the value into an 6-digit hex string
 
 * * *
 
-### color/hex8 
+### color/hex8
 
 
 Transforms the value into an 8-digit hex string
@@ -320,7 +320,7 @@ Transforms the value into an 8-digit hex string
 
 * * *
 
-### color/hex8android 
+### color/hex8android
 
 
 Transforms the value into an 8-digit hex string for Android because they put the alpha channel first
@@ -334,7 +334,7 @@ Transforms the value into an 8-digit hex string for Android because they put the
 
 * * *
 
-### color/composeColor 
+### color/composeColor
 
 
 Transforms the value into a Color class for Compose
@@ -348,7 +348,7 @@ Color(0xFF009688)
 
 * * *
 
-### color/UIColor 
+### color/UIColor
 
 
 Transforms the value into an UIColor class for iOS
@@ -362,7 +362,7 @@ Transforms the value into an UIColor class for iOS
 
 * * *
 
-### color/UIColorSwift 
+### color/UIColorSwift
 
 
 Transforms the value into an UIColor swift class for iOS
@@ -373,10 +373,23 @@ Transforms the value into an UIColor swift class for iOS
 UIColor(red: 0.667, green: 0.667, blue: 0.667, alpha: 0.6)
 ```
 
+* * *
+
+### color/ColorSwiftUI
+
+
+Transforms the value into an Color from SwiftUI for iOS
+
+```swift
+// Matches: token.attributes.category === 'color'
+// Returns:
+Color(red: 0.667, green: 0.667, blue: 0.667, opacity: 0.6)
+```
+
 
 * * *
 
-### color/css 
+### color/css
 
 
 Transforms the value into a hex or rgb string depending on if it has transparency
@@ -391,7 +404,7 @@ rgba(0,0,0,0.5)
 
 * * *
 
-### color/sketch 
+### color/sketch
 
 
 Transforms a color into an object with red, green, blue, and alpha
@@ -412,7 +425,7 @@ colors.
 
 * * *
 
-### size/sp 
+### size/sp
 
 
 Transforms the value into a scale-independent pixel (sp) value for font sizes on Android. It will not scale the number.
@@ -426,7 +439,7 @@ Transforms the value into a scale-independent pixel (sp) value for font sizes on
 
 * * *
 
-### size/dp 
+### size/dp
 
 
 Transforms the value into a density-independent pixel (dp) value for non-font sizes on Android. It will not scale the number.
@@ -440,7 +453,7 @@ Transforms the value into a density-independent pixel (dp) value for non-font si
 
 * * *
 
-### size/object 
+### size/object
 
 
 Transforms the value into a usefull object ( for React Native support )
@@ -459,7 +472,7 @@ Transforms the value into a usefull object ( for React Native support )
 
 * * *
 
-### size/remToSp 
+### size/remToSp
 
 
 Transforms the value from a REM size on web into a scale-independent pixel (sp) value for font sizes on Android. It WILL scale the number by a factor of 16 (common base font size on web).
@@ -473,7 +486,7 @@ Transforms the value from a REM size on web into a scale-independent pixel (sp) 
 
 * * *
 
-### size/remToDp 
+### size/remToDp
 
 
 Transforms the value from a REM size on web into a density-independent pixel (dp) value for font sizes on Android. It WILL scale the number by a factor of 16 (or the value of 'basePxFontSize' on the platform in your config).
@@ -487,7 +500,7 @@ Transforms the value from a REM size on web into a density-independent pixel (dp
 
 * * *
 
-### size/px 
+### size/px
 
 
 Adds 'px' to the end of the number. Does not scale the number
@@ -501,7 +514,7 @@ Adds 'px' to the end of the number. Does not scale the number
 
 * * *
 
-### size/rem 
+### size/rem
 
 
 Adds 'rem' to the end of the number. Does not scale the number
@@ -515,7 +528,7 @@ Adds 'rem' to the end of the number. Does not scale the number
 
 * * *
 
-### size/remToPt 
+### size/remToPt
 
 
 Scales the number by 16 (or the value of 'basePxFontSize' on the platform in your config) and adds 'pt' to the end.
@@ -529,7 +542,7 @@ Scales the number by 16 (or the value of 'basePxFontSize' on the platform in you
 
 * * *
 
-### size/compose/remToSp 
+### size/compose/remToSp
 
 
 Transforms the value from a REM size on web into a scale-independent pixel (sp) value for font sizes in Compose. It WILL scale the number by a factor of 16 (common base font size on web).
@@ -543,7 +556,7 @@ Transforms the value from a REM size on web into a scale-independent pixel (sp) 
 
 * * *
 
-### size/compose/remToDp 
+### size/compose/remToDp
 
 
 Transforms the value from a REM size on web into a density-independent pixel (dp) value for font sizes in Compose. It WILL scale the number by a factor of 16 (or the value of 'basePxFontSize' on the platform in your config).
@@ -557,7 +570,7 @@ Transforms the value from a REM size on web into a density-independent pixel (dp
 
 * * *
 
-### size/compose/em 
+### size/compose/em
 
 
 Adds the .em Compose extension to the end of a number. Does not scale the value
@@ -571,7 +584,7 @@ Adds the .em Compose extension to the end of a number. Does not scale the value
 
 * * *
 
-### size/swift/remToCGFloat 
+### size/swift/remToCGFloat
 
 
 Scales the number by 16 (or the value of 'basePxFontSize' on the platform in your config) to get to points for Swift and initializes a CGFloat
@@ -584,7 +597,7 @@ Scales the number by 16 (or the value of 'basePxFontSize' on the platform in you
 
 * * *
 
-### size/remToPx 
+### size/remToPx
 
 
 Scales the number by 16 (or the value of 'basePxFontSize' on the platform in your config) and adds 'px' to the end.
@@ -598,7 +611,7 @@ Scales the number by 16 (or the value of 'basePxFontSize' on the platform in you
 
 * * *
 
-### content/icon 
+### content/icon
 
 
 Takes a unicode point and transforms it into a form CSS can use.
@@ -612,7 +625,7 @@ Takes a unicode point and transforms it into a form CSS can use.
 
 * * *
 
-### content/quote 
+### content/quote
 
 
 Wraps the value in a single quoted string
@@ -626,7 +639,7 @@ Wraps the value in a single quoted string
 
 * * *
 
-### content/objC/literal 
+### content/objC/literal
 
 
 Wraps the value in a double-quoted string and prepends an '@' to make a string literal.
@@ -635,11 +648,11 @@ Wraps the value in a double-quoted string and prepends an '@' to make a string l
 // Matches: token.attributes.category === 'content'
 // Returns:
 
-**&quot;string&quot;**: ```  
+**&quot;string&quot;**: ```
 
 * * *
 
-### content/swift/literal 
+### content/swift/literal
 
 
 Wraps the value in a double-quoted string to make a string literal.
@@ -653,7 +666,7 @@ Wraps the value in a double-quoted string to make a string literal.
 
 * * *
 
-### font/objC/literal 
+### font/objC/literal
 
 
 Wraps the value in a double-quoted string and prepends an '@' to make a string literal.
@@ -666,7 +679,7 @@ Wraps the value in a double-quoted string and prepends an '@' to make a string l
 
 * * *
 
-### font/swift/literal 
+### font/swift/literal
 
 
 Wraps the value in a double-quoted string to make a string literal.
@@ -679,7 +692,7 @@ Wraps the value in a double-quoted string to make a string literal.
 
 * * *
 
-### time/seconds 
+### time/seconds
 
 
 Assumes a time in miliseconds and transforms it into a decimal
@@ -693,7 +706,7 @@ Assumes a time in miliseconds and transforms it into a decimal
 
 * * *
 
-### asset/base64 
+### asset/base64
 
 
 Wraps the value in a double-quoted string and prepends an '@' to make a string literal.
@@ -707,7 +720,7 @@ Wraps the value in a double-quoted string and prepends an '@' to make a string l
 
 * * *
 
-### asset/path 
+### asset/path
 
 
 Prepends the local file path
@@ -721,7 +734,7 @@ Prepends the local file path
 
 * * *
 
-### asset/objC/literal 
+### asset/objC/literal
 
 
 Wraps the value in a double-quoted string and prepends an '@' to make a string literal.
@@ -734,7 +747,7 @@ Wraps the value in a double-quoted string and prepends an '@' to make a string l
 
 * * *
 
-### asset/swift/literal 
+### asset/swift/literal
 
 
 Wraps the value in a double-quoted string to make a string literal.
@@ -747,7 +760,7 @@ Wraps the value in a double-quoted string to make a string literal.
 
 * * *
 
-### color/hex8flutter 
+### color/hex8flutter
 
 
 Transforms the value into a Flutter Color object using 8-digit hex with the alpha chanel on start
@@ -760,7 +773,7 @@ Transforms the value into a Flutter Color object using 8-digit hex with the alph
 
 * * *
 
-### content/flutter/literal 
+### content/flutter/literal
 
 
 Wraps the value in a double-quoted string to make a string literal.
@@ -773,7 +786,7 @@ Wraps the value in a double-quoted string to make a string literal.
 
 * * *
 
-### asset/flutter/literal 
+### asset/flutter/literal
 
 
 Wraps the value in a double-quoted string to make a string literal.
@@ -786,7 +799,7 @@ Wraps the value in a double-quoted string to make a string literal.
 
 * * *
 
-### font/flutter/literal 
+### font/flutter/literal
 
 
 Wraps the value in a double-quoted string to make a string literal.
@@ -799,7 +812,7 @@ Wraps the value in a double-quoted string to make a string literal.
 
 * * *
 
-### size/flutter/remToDouble 
+### size/flutter/remToDouble
 
 
 Scales the number by 16 (or the value of 'basePxFontSize' on the platform in your config) to get to points for Flutter

--- a/lib/common/transforms.js
+++ b/lib/common/transforms.js
@@ -474,6 +474,29 @@ module.exports = {
     }
   },
 
+    /**
+   * Transforms the value into an UIColor swift class for iOS
+   *
+   * ```swift
+   * // Matches: token.attributes.category === 'color'
+   * // Returns:
+   * Color(red: 0.667, green: 0.667, blue: 0.667, opacity: 0.6)
+   * ```
+   *
+   * @memberof Transforms
+   */
+  'color/ColorSwiftUI': {
+    type: 'value',
+    matcher: isColor,
+    transformer: function (token) {
+      const { r, g, b, a } = Color(token.value).toRgb();
+      const rFixed = (r / 255.0).toFixed(3);
+      const gFixed = (g / 255.0).toFixed(3);
+      const bFixed = (b / 255.0).toFixed(3);
+      return `Color(red: ${rFixed}, green: ${gFixed}, blue: ${bFixed}, opacity: ${a})`;
+    }
+  },
+
   /**
    * Transforms the value into a hex or rgb string depending on if it has transparency
    *


### PR DESCRIPTION
*Issue #719*

*Description of changes:*

I have added a new color formatter to correctly render `Color` from SwiftUI. See the [documentation](https://developer.apple.com/documentation/swiftui/color).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

It would be used like this:

~~~json
  "ios-swift-separate-enums": {
    "transforms": [
      "attribute/cti",
      "name/ti/camel",
      "color/ColorSwiftUI",
      "content/swift/literal",
      "asset/swift/literal",
      "size/swift/remToCGFloat",
      "font/swift/literal"
    ],
    "buildPath": "build/ios-swift/",
    "files": [
      {
        "destination": "StyleDictionaryColor.swift",
        "format": "ios-swift/extension.swift",
        "className": "Color",
        "filter": {
          "attributes": {
            "category": "color"
          }
        }
      },
      {
        "destination": "StyleDictionarySize.swift",
        "format": "ios-swift/extension.swift",
        "className": "CGFloat",
        "filter": {
          "attributes": {
            "category": "size"
          }
        }
      }
    ]
  },
~~~

We need to specify the tranformers using `transforms` because there is not a transform group defined using this new transformer.