### PR TITLE
fix(types): make FileHeaderArgs.commentStyle optional

### DIFF
--- a/lib/common/formatHelpers/fileHeader.js
+++ b/lib/common/formatHelpers/fileHeader.js
@@ -38,7 +38,7 @@ const defaultFormatting = {
  * StyleDictionary.registerFormat({
  *   name: 'myCustomFormat',
  *   formatter: function({ dictionary, file }) {
- *     return fileHeader({file, 'short') +
+ *     return fileHeader({file, commentStyle: 'short'}) +
  *       dictionary.allTokens.map(token => `${token.name} = ${token.value}`)
  *         .join('\n');
  *   }

--- a/types/FormatHelpers.d.ts
+++ b/types/FormatHelpers.d.ts
@@ -39,7 +39,7 @@ export interface CommentFormatting {
 
 export interface FileHeaderArgs {
   file: File;
-  commentStyle: string;
+  commentStyle?: string;
   formatting?: CommentFormatting;
 }
 


### PR DESCRIPTION
Issue #742 

*Description of changes:*

* types update: make FileHeaderArgs.commentStyle optional
* jsDoc update: fix 'fileHeader' example syntax error

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
