### PR TITLE
Asynchronous parsers

### DIFF
--- a/lib/extend.js
+++ b/lib/extend.js
@@ -83,7 +83,7 @@ var PROPERTY_VALUE_COLLISIONS = GroupMessages.GROUP.PropertyValueCollisions;
  * });
  * ```
  */
-function extend(opts) {
+async function extend(opts) {
   let options, to_ret;
   let inlineTokens = {};
   let includeTokens = {};
@@ -111,7 +111,7 @@ function extend(opts) {
     if (!_.isArray(options.include))
       throw new Error('include must be an array');
 
-    includeTokens = combineJSON(options.include, true, null, false, to_ret.parsers);
+    includeTokens = await combineJSON(options.include, true, null, false, to_ret.parsers);
 
     to_ret.include = null; // We don't want to carry over include references
   }
@@ -122,7 +122,7 @@ function extend(opts) {
     if (!_.isArray(options.source))
       throw new Error('source must be an array');
 
-    sourceTokens = combineJSON(options.source, true, function Collision(prop) {
+    sourceTokens = await combineJSON(options.source, true, function Collision(prop) {
       GroupMessages.add(
         PROPERTY_VALUE_COLLISIONS,
         `Collision detected at: ${prop.path.join('.')}! Original value: ${prop.target[prop.key]}, New value: ${prop.copy[prop.key]}`

--- a/lib/utils/combineJSON.js
+++ b/lib/utils/combineJSON.js
@@ -37,9 +37,9 @@ function traverseObj(obj, fn) {
  * @param {Function} collision - A function to be called when a name collision happens that isn't a normal deep merge of objects
  * @param {Boolean} [source=true] - If json files are "sources", tag properties
  * @param {Object[]} [parsers=[]] - Custom file parsers
- * @returns {Object}
+ * @returns {Promise<Object>}
  */
-function combineJSON(arr, deep, collision, source, parsers=[]) {
+async function combineJSON(arr, deep, collision, source, parsers=[]) {
   var i, files = [],
     to_ret = {};
 
@@ -61,14 +61,14 @@ function combineJSON(arr, deep, collision, source, parsers=[]) {
 
       // Iterate over custom parsers, if the file path matches the parser's
       // pattern regex, use it's parse function to generate the object
-      parsers.forEach(({pattern, parse}) => {
+      for (const {pattern, parse} of parsers) {
         if (resolvedPath.match(pattern)) {
-          file_content = parse({
+          file_content = await parse({
             contents: fs.readFileSync(resolvedPath, {encoding:'UTF-8'}),
             filePath: resolvedPath
           });
         }
-      });
+      }
 
       // If there is no file_content then no custom parser ran on that file
       if (!file_content) {


### PR DESCRIPTION
Hi, I think it would be valuable if parsers could be asynchronous.

Essentially parsers allow you to write tokens in any format, as long as you can write a parser for it that parses to the format that style-dictionary understands.

Multiple use cases have come up internally in our product where we actually need to compile or parse tokens but we can't get around the fact that this has to be done asynchronously, which is currently not possible in style-dictionary.

In our fork `browser-style-dictionary` we already introduced this change and it's working alright, but it's important to note that if style-dictionary were to adopt this change, it may need to do a breaking change to the main API `.extend()`. If parsers become async, probably so do `combineJSON` and `extend` by extension. I'm not sure if this is within your breaking change budget for 4.0.0 but it may go together well with other refactors such as ESM-only and modern ES syntax?