### PR TITLE
Fix documentation bugs (formats) 

### DIFF
--- a/lib/common/formatHelpers/getTypeScriptType.js
+++ b/lib/common/formatHelpers/getTypeScriptType.js
@@ -30,7 +30,8 @@ const { unique } = require('../../utils/es6_');
  *    }).join('\n');
  *   }
  * });
- *
+ *```
+ * 
  * @param {*} value A value to check the type of.
  * @return {String} A valid name for a TypeScript type.
  * ```

--- a/lib/common/formatHelpers/getTypeScriptType.js
+++ b/lib/common/formatHelpers/getTypeScriptType.js
@@ -30,11 +30,10 @@ const { unique } = require('../../utils/es6_');
  *    }).join('\n');
  *   }
  * });
- *```
- * 
+ *``` 
  * @param {*} value A value to check the type of.
  * @return {String} A valid name for a TypeScript type.
- * ```
+ *
  */
  function getTypeScriptType(value)  {
   if (Array.isArray(value)) return getArrayType(value)

--- a/scripts/handlebars/templates/formats.hbs
+++ b/scripts/handlebars/templates/formats.hbs
@@ -47,7 +47,7 @@ Formats can take configuration to make them more flexible. This allows you to re
 }
 ```
 
-In this example we are adding the `mapName` configuration to the `scss/map-deep` format. This will change the name of the SCSS map in the output. Not all formats have the configuration options; format configuration is defined by the format itself. To see the configurtion options of a format, take a look at the documentation of the [specific format](#pre-defined-formats)
+In this example we are adding the `mapName` configuration to the `scss/map-deep` format. This will change the name of the SCSS map in the output. Not all formats have the configuration options; format configuration is defined by the format itself. To see the configuration options of a format, take a look at the documentation of the [specific format](#pre-defined-formats)
 
 ## Filtering tokens
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fixes to documentation:
* Fix typo in [format configuration](https://amzn.github.io/style-dictionary/#/formats?id=format-configuration) section
* FIx faulty markdown messing up the `getTypeScriptType` section in [format configuration](https://amzn.github.io/style-dictionary/#/formats?id=gettypescripttype) 

**Before**
![image](https://user-images.githubusercontent.com/17575446/157421423-b90162f7-ca94-4856-8198-baad7bf048bf.png)

**After** (previewing of markdown in Visual Studio after running `npm run generate-docs`) 
![image](https://user-images.githubusercontent.com/17575446/157424629-d23f4670-46df-4f74-9afb-bd7bf54b3cfa.png)

Not sure if I should include the generated `.docs/formats.md` in this PR... but I guess it will be overwritten anyway when building the release, right? 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
