### PR TITLE
fix: added packageName as optional property on interface File

### DIFF
--- a/types/File.d.ts
+++ b/types/File.d.ts
@@ -16,6 +16,7 @@ import { TransformedToken } from './TransformedToken';
 
 export interface File {
   className?: string;
+  packageName?: string;
   destination: string;
   format?: string;
   filter?: string | Partial<TransformedToken> | ((token: TransformedToken) => boolean);


### PR DESCRIPTION
*Issue #, if available: N/A*

*Description of changes:*

The `packageName` property is not present on the `File` interface, but is listed in [the docs](https://amzn.github.io/style-dictionary/#/formats?id=composeobject) and is used in testing [here](https://github.com/amzn/style-dictionary/blob/main/__integration__/compose.test.js#L30).


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
