### PR TITLE
fix(types): fixing transform group property type of Config

### DIFF
--- a/types/Config.d.ts
+++ b/types/Config.d.ts
@@ -24,7 +24,7 @@ import { DesignTokens } from './DesignToken';
 export interface Config {
   parsers?: Parser[];
   transform?: Record<string, Transform>;
-  transformGroup?: Record<string, TransformGroup>;
+  transformGroup?: Record<string, TransformGroup['transforms']>;
   format?: Record<string, Formatter>;
   filter?: Record<string, Filter>;
   fileHeader?: Record<string, FileHeader>;


### PR DESCRIPTION
*Issue #832*

*Description of changes:*

The `transformGroup` property of `Config` interface is changed from type `Record<string, TransformGroup>` to type `Record<string, TransformGroup['transforms']>`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
