### PR TITLE
fix(docs): Correct custom-file-header example link

### DIFF
--- a/scripts/handlebars/templates/formats.hbs
+++ b/scripts/handlebars/templates/formats.hbs
@@ -203,7 +203,7 @@ Which should output a file that will start like this:
  */
 ```
 
-For an in-depth example see the [custom-file-header](https://github.com/amzn/style-dictionary/examples/advanced/custom-file-header) example.
+For an in-depth example see the [custom-file-header](https://github.com/amzn/style-dictionary/tree/main/examples/advanced/custom-file-header) example.
 
 ## Custom formats
 


### PR DESCRIPTION
Fixes the link to the `custom-file-header` example