### PR TITLE
fix(types): fix filter config key expected matcher value

### DIFF
--- a/types/Config.d.ts
+++ b/types/Config.d.ts
@@ -26,7 +26,7 @@ export interface Config {
   transform?: Record<string, Transform>;
   transformGroup?: Record<string, TransformGroup>;
   format?: Record<string, Formatter>;
-  filter?: Record<string, Filter>;
+  filter?: Record<string, Filter['matcher']>;
   fileHeader?: Record<string, FileHeader>;
   action?: Record<string, Action>;
   include?: string[];

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -66,7 +66,7 @@ declare namespace StyleDictionary {
     transformGroup: Record<string, TransformGroup['transforms']>;
     format: Record<string, Formatter>;
     action: Record<string, Action>;
-    filter: Record<string, Filter>;
+    filter: Record<string, Filter['matcher']>;
     fileHeader: Record<string, FileHeader>;
     parsers: Parser[];
 


### PR DESCRIPTION
*Description of changes:*

The `filter` config key expect an object of type `{ name: string, matcher: Matcher }` and not `{ name: string, matcher: Filter }`.   
Which is different from `registerFilter` that accept a `Filter` object.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
