### PR TITLE
fix(884): add missing types for formatHelpers

### DIFF
--- a/types/FormatHelpers.d.ts
+++ b/types/FormatHelpers.d.ts
@@ -11,9 +11,10 @@
  * and limitations under the License.
  */
 
-import { Dictionary } from './Dictionary';
-import { TransformedToken } from './TransformedToken';
-import { File } from './File';
+import { Dictionary } from "./Dictionary";
+import { TransformedToken } from "./TransformedToken";
+import { File } from "./File";
+import { DesignToken } from "./DesignToken";
 
 export interface LineFormatting {
   prefix?: string;
@@ -28,7 +29,7 @@ export type TokenFormatterArgs = {
   dictionary: Dictionary;
   format?: "css" | "sass" | "less" | "stylus";
   formatting?: LineFormatting;
-}
+};
 
 export interface CommentFormatting {
   prefix: string;
@@ -45,7 +46,7 @@ export interface FileHeaderArgs {
 
 export interface FormattedVariablesArgs {
   format: "css" | "sass";
-  dictionary: Dictionary
+  dictionary: Dictionary;
   outputReferences?: boolean;
   formatting?: LineFormatting;
 }
@@ -56,4 +57,18 @@ export interface FormatHelpers {
   ) => (token: TransformedToken) => string;
   fileHeader: (args: FileHeaderArgs) => string;
   formattedVariables: (args: FormattedVariablesArgs) => string;
+  minifyDictionary: (dictionary: object) => object;
+  getTypeScriptType: (value: any) => string;
+  iconsWithPrefix: (
+    prefix: string,
+    allTokens: DesignToken[],
+    options: object
+  ) => string;
+  sortByReference: (dictionary: Dictionary) => string;
+  sortByName: (a: DesignToken, b: DesignToken) => number;
+  setSwiftFileProperties: (
+    options: object,
+    objectType: string,
+    transformGroup: string
+  ) => string;
 }

--- a/types/FormatHelpers.d.ts
+++ b/types/FormatHelpers.d.ts
@@ -64,7 +64,7 @@ export interface FormatHelpers {
     allTokens: DesignToken[],
     options: object
   ) => string;
-  sortByReference: (dictionary: Dictionary) => string;
+  sortByReference: (dictionary: Dictionary) => any;
   sortByName: (a: DesignToken, b: DesignToken) => number;
   setSwiftFileProperties: (
     options: object,


### PR DESCRIPTION
*Issue #884 , if available:*

*Description of changes:*

Added missing types for the following formatHelpers:
- minifyDictionary
- getTypeScriptTyp
- iconsWithPrefix
- sortByReference
- sortByName
- setSwiftFileProperties


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
