### PR TITLE
docs: fix small readme typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ float const SizeFontBase = 16.00f;
 
 ## Quick Start
 
-The style dictionary framework comes with some example code to get you stared. Install the node module globally, create a directory and `cd` into it.
+The style dictionary framework comes with some example code to get you started. Install the node module globally, create a directory and `cd` into it.
 
 ```
 $ npm i -g style-dictionary


### PR DESCRIPTION
*Description of changes:*

I discovered a very small typo in the main README: stared > started.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
