### PR TITLE
Ignore docs and examples from the published npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,3 +3,6 @@
 .editorconfig
 images/
 test/
+examples/
+docs/
+.jsdoc.json


### PR DESCRIPTION
*Issue #, if available:* Closes https://github.com/amzn/style-dictionary/issues/914

*Description of changes:*

This PR changes the `.npmignore` to exclude files related to examples and documentation from the published NPM package. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
