### PR TITLE
fix(transforms): consistent usage of 'token' instead of 'prop'

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,11 +280,11 @@ const StyleDictionary = require('style-dictionary').extend('config.json');
 StyleDictionary.registerTransform({
   name: 'time/seconds',
   type: 'value',
-  matcher: function(prop) {
-    return prop.attributes.category === 'time';
+  matcher: function(token) {
+    return token.attributes.category === 'time';
   },
-  transformer: function(prop) {
-    return (parseInt(prop.original.value) / 1000).toString() + 's';
+  transformer: function(token) {
+    return (parseInt(token.original.value) / 1000).toString() + 's';
   }
 });
 

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -20,11 +20,11 @@ const StyleDictionary = require('style-dictionary').extend('config.json');
 StyleDictionary.registerTransform({
   name: 'time/seconds',
   type: 'value',
-  matcher: function(prop) {
-    return prop.attributes.category === 'time';
+  matcher: function(token) {
+    return token.attributes.category === 'time';
   },
-  transformer: function(prop) {
-    return (parseInt(prop.original.value) / 1000).toString() + 's';
+  transformer: function(token) {
+    return (parseInt(token.original.value) / 1000).toString() + 's';
   }
 });
 
@@ -40,8 +40,8 @@ const StyleDictionary = require('style-dictionary').extend('config.json');
 StyleDictionary.registerTransform({
   name: 'name/uppercase',
   type: 'name',
-  transformer: function(prop) {
-    return prop.path.join('_').toUpperCase();
+  transformer: function(token) {
+    return token.path.join('_').toUpperCase();
   }
 });
 

--- a/lib/common/transforms.js
+++ b/lib/common/transforms.js
@@ -412,7 +412,7 @@ module.exports = {
    * Transforms the value into a Color class for Compose
    *
    * ```kotlin
-   * // Matches: prop.attributes.category === 'color'
+   * // Matches: token.attributes.category === 'color'
    * // Returns:
    * Color(0xFF009688)
    * ```
@@ -422,8 +422,8 @@ module.exports = {
   'color/composeColor': {
     type: 'value',
     matcher: isColor,
-    transformer: function (prop) {
-      var str = Color(prop.value).toHex8();
+    transformer: function (token) {
+      var str = Color(token.value).toHex8();
       return 'Color(0x' + str.slice(6) + str.slice(0,6) + ')'
     }
   },
@@ -742,7 +742,7 @@ module.exports = {
    * Transforms the value from a REM size on web into a scale-independent pixel (sp) value for font sizes in Compose. It WILL scale the number by a factor of 16 (or the value of 'basePxFontSize' on the platform in your config).
    *
    * ```kotlin
-   * // Matches: prop.attributes.category === 'size' && prop.attributes.type === 'font'
+   * // Matches: token.attributes.category === 'size' && token.attributes.type === 'font'
    * // Returns:
    * "16.0.sp"
    * ```
@@ -752,10 +752,10 @@ module.exports = {
   'size/compose/remToSp': {
     type: 'value',
     matcher: isFontSize,
-    transformer: function(prop, options) {
-      const val = parseFloat(prop.value);
+    transformer: function(token, options) {
+      const val = parseFloat(token.value);
       const baseFont = getBasePxFontSize(options);
-      if (isNaN(val)) throwSizeError(prop.name, prop.value, 'sp');
+      if (isNaN(val)) throwSizeError(token.name, token.value, 'sp');
       return (val * baseFont).toFixed(2) + '.sp';
     }
   },
@@ -765,7 +765,7 @@ module.exports = {
    * Transforms the value from a REM size on web into a density-independent pixel (dp) value for font sizes in Compose. It WILL scale the number by a factor of 16 (or the value of 'basePxFontSize' on the platform in your config).
    *
    * ```kotlin
-   * // Matches: prop.attributes.category === 'size' && prop.attributes.type !== 'font'
+   * // Matches: token.attributes.category === 'size' && token.attributes.type !== 'font'
    * // Returns:
    * "16.0.dp"
    * ```
@@ -775,10 +775,10 @@ module.exports = {
   'size/compose/remToDp': {
     type: 'value',
     matcher: isNotFontSize,
-    transformer: function(prop, options) {
-      const val = parseFloat(prop.value);
+    transformer: function(token, options) {
+      const val = parseFloat(token.value);
       const baseFont = getBasePxFontSize(options);
-      if (isNaN(val)) throwSizeError(prop.name, prop.value, 'dp');
+      if (isNaN(val)) throwSizeError(token.name, token.value, 'dp');
       return (val * baseFont).toFixed(2) + '.dp';
     }
   },
@@ -787,7 +787,7 @@ module.exports = {
    * Adds the .em Compose extension to the end of a number. Does not scale the value
    *
    * ```kotlin
-   * // Matches: prop.attributes.category === 'size' && prop.attributes.type === 'font'
+   * // Matches: token.attributes.category === 'size' && token.attributes.type === 'font'
    * // Returns:
    * "16.0em"
    * ```
@@ -797,9 +797,9 @@ module.exports = {
   'size/compose/em': {
     type: 'value',
     matcher: isFontSize,
-    transformer: function(prop) {
-      const val = parseFloat(prop.value);
-      if (isNaN(val)) throwSizeError(prop.name, prop.value, 'em');
+    transformer: function(token) {
+      const val = parseFloat(token.value);
+      if (isNaN(val)) throwSizeError(token.name, token.value, 'em');
       return val + '.em';
     }
   },


### PR DESCRIPTION
*Description of changes:*

While working on custom transforms based on the code of existing ones, I noticed a minor discrepancy between the parameter names in `transformer`s and `matcher`s in `lib/common/transforms.js`.

It seems that there was a big work done in https://github.com/amzn/style-dictionary/pull/617/files#diff-a910c29ae52c0bba61129dd0dc3a9a3fee3293e35c3ecb177ec257e65119832c to force this behavior.

This PR suggests to modify `lib/common/transforms.js` to use `token` everywhere and also to modify `README.md` and `docs/extending.md` to reflect this change in the doc as well.

---

*Not directly linked to this PR:*

I needed to execute locally `npm test -- -u` to be able to have passed tests locally and to commit my modifications. `__integration__/__snapshots__/compose.test.js.snap` and `__tests__/formats/__snapshots__/all.test.js.snap` were modified this way:

```diff
diff --git a/__integration__/__snapshots__/compose.test.js.snap b/__integration__/__snapshots__/compose.test.js.snap
index eb7f42d..08bd161 100644
--- a/__integration__/__snapshots__/compose.test.js.snap
+++ b/__integration__/__snapshots__/compose.test.js.snap
@@ -10,7 +10,6 @@ exports[`integration compose compose/object should match snapshot 1`] = `
 
 package com.example.tokens;
 
-
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.*
 
@@ -191,7 +190,6 @@ exports[`integration compose compose/object with references should match snapsho
 
 package com.example.tokens;
 
-
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.*
 
diff --git a/__tests__/formats/__snapshots__/all.test.js.snap b/__tests__/formats/__snapshots__/all.test.js.snap
index 15230d2..68a3634 100644
--- a/__tests__/formats/__snapshots__/all.test.js.snap
+++ b/__tests__/formats/__snapshots__/all.test.js.snap
@@ -90,7 +90,6 @@ exports[`formats all should match compose/object snapshot 1`] = `
 
 package ;
 
-
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.*
```

I haven't commited these files here because not linked to this PR. But maybe there's something to do in the _main_ branch. IDK enough the project to know if it is needed :)

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
