### PR TITLE
feat(formats) Use TSDoc comment format for typescript/es6-declarations

### DIFF
--- a/__tests__/formats/__snapshots__/all.test.js.snap
+++ b/__tests__/formats/__snapshots__/all.test.js.snap
@@ -752,7 +752,8 @@ exports[`formats all should match typescript/es6-declarations snapshot 1`] = `
  * Generated on Sat, 01 Jan 2000 00:00:00 GMT
  */
 
-export const color_red : string; // comment"
+/** comment */
+export const color_red : string;"
 `;
 
 exports[`formats all should match typescript/module-declarations snapshot 1`] = `

--- a/__tests__/formats/__snapshots__/typeScriptEs6Declarations.test.js.snap
+++ b/__tests__/formats/__snapshots__/typeScriptEs6Declarations.test.js.snap
@@ -6,5 +6,6 @@ exports[`formats typescript/es6-declarations with outputStringLiterals should ma
  * Generated on Sat, 01 Jan 2000 00:00:00 GMT
  */
 
+/** Used for errors */
 export const colorRed : \\"#FF0000\\";"
 `;

--- a/__tests__/formats/typeScriptEs6Declarations.test.js
+++ b/__tests__/formats/typeScriptEs6Declarations.test.js
@@ -22,6 +22,7 @@ const file = {
 const properties = {
   "color": {
     "red": {
+      "comment": "Used for errors",
       "name": "colorRed",
       "value": "#FF0000"
     }

--- a/lib/common/formats.js
+++ b/lib/common/formats.js
@@ -407,9 +407,10 @@ module.exports = {
   'typescript/es6-declarations': function({dictionary, file, options}) {
     return fileHeader({file}) +
       dictionary.allProperties.map(function(prop) {
-        var to_ret_prop = 'export const ' + prop.name + ' : ' + getTypeScriptType(prop.value, options) + ';';
+        let to_ret_prop = '';
         if (prop.comment)
-          to_ret_prop = to_ret_prop.concat(' // ' + prop.comment);
+          to_ret_prop += '/** ' + prop.comment + ' */\n';
+        to_ret_prop += 'export const ' + prop.name + ' : ' + getTypeScriptType(prop.value, options) + ';';
         return to_ret_prop;
       }).join('\n');
   },


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Use [TSDoc](https://tsdoc.org/) comment format for `typescript/es6-declarations`

*Why:* So developers can see the comment on hover in their editor (e.g. VSCode)

*Before:*
![Screenshot 2023-03-15 at 3 49 30 PM](https://user-images.githubusercontent.com/127199/225460633-4bdf0708-9caf-4a35-b879-d24c8a728f6e.png)

*After:*
![image](https://user-images.githubusercontent.com/127199/225460731-4aa922a6-0a8b-4343-adff-d637e5e896ce.png)



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
