### PR TITLE
fix(docs): formatting for `options.import` at compose/object

### DIFF
--- a/lib/common/formats.js
+++ b/lib/common/formats.js
@@ -709,7 +709,7 @@ declare const ${moduleName}: ${JSON.stringify(treeWalker(dictionary.tokens), nul
    * @param {String} className The name of the generated Kotlin object
    * @param {String} packageName The package for the generated Kotlin object
    * @param {Object} options
-   * * @param {String[]} [options.import=androidx.compose.ui.unit.*] - Modules to import. Can be a string or array of string
+   * @param {String[]} [options.import=['androidx.compose.ui.graphics.Color', 'androidx.compose.ui.unit.*']] - Modules to import. Can be a string or array of strings
    * @param {Boolean} [options.showFileHeader=true] - Whether or not to include a comment that has the build date
    * @param {Boolean} [options.outputReferences=false] - Whether or not to keep [references](/#/formats?id=references-in-output-files) (a -> b -> c) in the output.
    * @example
@@ -915,7 +915,7 @@ declare const ${moduleName}: ${JSON.stringify(treeWalker(dictionary.tokens), nul
    * @kind member
    * @param {Object} options
    * @param {String} [options.accessControl=public] - Level of [access](https://docs.swift.org/swift-book/LanguageGuide/AccessControl.html) of the generated swift object
-   * @param {String[]} [options.import=UIKit] - Modules to import. Can be a string or array of string
+   * @param {String[]} [options.import=UIKit] - Modules to import. Can be a string or array of strings
    * @param {String} [options.className] - The name of the generated Swift class
    * @param {Boolean} [options.showFileHeader=true] - Whether or not to include a comment that has the build date
    * @param {Boolean} [options.outputReferences=false] - Whether or not to keep [references](/#/formats?id=references-in-output-files) (a -> b -> c) in the output.
@@ -957,7 +957,7 @@ declare const ${moduleName}: ${JSON.stringify(treeWalker(dictionary.tokens), nul
    * @kind member
    * @param {Object} options
    * @param {String} [options.accessControl=public] - Level of [access](https://docs.swift.org/swift-book/LanguageGuide/AccessControl.html) of the generated swift object
-   * @param {String[]} [options.import=UIKit] - Modules to import. Can be a string or array of string
+   * @param {String[]} [options.import=UIKit] - Modules to import. Can be a string or array of strings
    * @param {Boolean} [options.showFileHeader=true] - Whether or not to include a comment that has the build date
    * @param {Boolean} [options.outputReferences=false] - Whether or not to keep [references](/#/formats?id=references-in-output-files) (a -> b -> c) in the output.
    * @example


### PR DESCRIPTION
Super small documentation improvements 🔍 
* Fixes default value formatting for `options.import` at `compose/object` format documentation
* Also aligns writing of _array of string**s**_ across formats


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
