### PR TITLE
update docs add log attribute in configuration doc

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -149,6 +149,7 @@ You would then change your npm script or CLI command to run that file with Node:
 | tokens | Object | The tokens object is a way to include inline design tokens as opposed to using the `source` and `include` arrays. 
 | properties | Object | **DEPRECATED** The properties object has been renamed to `tokens`. Using the `properties` object will still work for backwards compatibility. 
 | platforms | Object[Platform] | An object containing [platform](#platform) config objects that describe how the Style Dictionary should build for that platform. You can add any arbitrary attributes on this object that will get passed to formats and actions (more on these in a bit). This is useful for things like build paths, name prefixes, variable names, etc.
+| log | String (optional) | The default log value is `warn`. However, if you change it to `error`, collisions will cause the StyleDictionary process to stop. 
 
 ### Platform
 


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Add log option  in doc and possible values of it i.e. `warn` and `error`

Link of the PR where I found this option but couldn't find in the docs.
https://github.com/amzn/style-dictionary/pull/48/commits/ae4b184c160fc9a24351ee8d6cc7d3d762f3d9d2#r1214118923

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
