### PR TITLE
fix(types): fix FileHeader types

### DIFF
--- a/types/FileHeader.d.ts
+++ b/types/FileHeader.d.ts
@@ -11,4 +11,4 @@
  * and limitations under the License.
  */
 
-export type FileHeader = (defaultMessage: string[]) => string[];
+export type FileHeader = (defaultMessage?: string[]) => string[];


### PR DESCRIPTION
*Issue #, if available:*

No issue, but I can create one if you'd like.

*Description of changes:*

I was looking at #708 when this was added, and several places in the code, but I don't see any reason this argument would be required as long as the provided function returns an array. And the [tests don't seem to require it](https://github.com/amzn/style-dictionary/blob/main/__tests__/register/fileHeader.test.js#L88). 

Happy to be proven wrong, but I think this would be a nice (albeit small) improvement for TS users. 😄

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
