### PR TITLE
fix(types) handle null values in minifyDictionary formatHelper

### DIFF
--- a/lib/common/formatHelpers/minifyDictionary.js
+++ b/lib/common/formatHelpers/minifyDictionary.js
@@ -27,6 +27,10 @@
  * ```
  */
 function minifyDictionary(obj) {
+  if (obj === null || obj === undefined) {
+    return null;
+  }
+  
   if (typeof obj !== 'object' || Array.isArray(obj)) {
     return obj;
   }


### PR DESCRIPTION
#1015

*Description of changes:*

If `minifyDictionary` receives an object that is null or undefined, it returns null. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
