### PR TITLE
fix: escape double quotes for ts outputStringLiterals

### DIFF
--- a/__tests__/common/formatHelpers/getTypeScriptType.test.js
+++ b/__tests__/common/formatHelpers/getTypeScriptType.test.js
@@ -47,9 +47,10 @@ describe('common', () => {
       });
 
       it('should handle outputStringLiterals', () => {
-        const stringValue = 'I am a string';
+        const stringValue = 'I "am" a string';
         const options = { outputStringLiterals: true};
-        expect(getTypeScriptType(stringValue, options)).toEqual(`"${stringValue}"`);
+        /* eslint-disable no-useless-escape */
+        expect(getTypeScriptType(stringValue, options)).toEqual(`\"I \\\"am\\\" a string\"`);
       });
     });
   });

--- a/__tests__/formats/__snapshots__/typeScriptEs6Declarations.test.js.snap
+++ b/__tests__/formats/__snapshots__/typeScriptEs6Declarations.test.js.snap
@@ -8,5 +8,6 @@ exports[`formats typescript/es6-declarations with outputStringLiterals should ma
 
 /** Used for errors */
 export const colorRed : \\"#FF0000\\";
+export const fontFamily : \\"\\\\\\"Source Sans Pro\\\\\\", Arial, sans-serif\\";
 "
 `;

--- a/__tests__/formats/typeScriptEs6Declarations.test.js
+++ b/__tests__/formats/typeScriptEs6Declarations.test.js
@@ -26,7 +26,13 @@ const properties = {
       "name": "colorRed",
       "value": "#FF0000"
     }
-  }
+  },
+  "font": {
+    "family": {
+      "name": "fontFamily",
+      "value": '"Source Sans Pro", Arial, sans-serif',
+    },
+  },
 };
 
 const formatter = formats['typescript/es6-declarations'].bind(file);

--- a/lib/common/formatHelpers/getTypeScriptType.js
+++ b/lib/common/formatHelpers/getTypeScriptType.js
@@ -42,7 +42,7 @@ function getTypeScriptType(value, options = {})  {
 
   if (Array.isArray(value)) return getArrayType(value)
   if (typeof value === 'object') return getObjectType(value)
-  if (outputStringLiterals && typeof value === 'string') return `"${value}"`
+  if (outputStringLiterals && typeof value === 'string') return `"${value.replace(/"/g, '\\"')}"`
   if (['string', 'number', 'boolean'].includes(typeof value)) return typeof value
 
   return 'any'


### PR DESCRIPTION
Escaping double quotes when generating string literal types is useful when a token value is referencing a font family name.