### PR TITLE
fix: allow outputReferences to work on non-string values

### DIFF
--- a/lib/common/formatHelpers/createPropertyFormatter.js
+++ b/lib/common/formatHelpers/createPropertyFormatter.js
@@ -104,41 +104,42 @@ function createPropertyFormatter({
     if (outputReferences && dictionary.usesReference(prop.original.value)) {
       // Formats that use this function expect `value` to be a string
       // or else you will get '[object Object]' in the output
-      if (typeof value === 'string') {
-        const refs = dictionary.getReferences(prop.original.value);
+      const refs = dictionary.getReferences(prop.original.value);
 
-        // original can either be string value or an object value
-        const originalIsString = typeof prop.original.value === 'string';
+      // original can either be an object value, which requires transitive value transformation in web CSS formats
+      // or a different (primitive) type, meaning it can be stringified.
+      const originalIsObject = typeof prop.original.value === 'object' && prop.original.value !== null;
 
-        // Set the value to the original value with refs first, undoing value-changing transitive transforms
-        if (originalIsString) {
-          value = prop.original.value;
-        }
+      if (!originalIsObject) {
+        // when original is object value, we replace value by matching ref.value and putting a var instead.
+        // Due to the original.value being an object, it requires transformation, so undoing the transformation
+        // by replacing value with original.value is not possible.
 
-        refs.forEach(ref => {
-          // value should be a string that contains the resolved reference
-          // because Style Dictionary resolved this in the resolution step.
-          // Here we are undoing that by replacing the value with
-          // the reference's name
-          if (ref.value && ref.name) {
-            const replaceFunc = function() {
-              if (format === 'css') {
-                if (outputReferenceFallbacks) {
-                  return `var(${prefix}${ref.name}, ${ref.value})`;
-                } else {
-                  return `var(${prefix}${ref.name})`;
-                }
-              } else {
-                return `${prefix}${ref.name}`;
-              }
-            }
-            // when original is object value, we replace value by matching ref.value and putting a var instead
-            // when original is string value, we replace value by matching original.value and putting a var instead
-            // this is more friendly to transitive transforms that transform the string values
-            value = value.replace(originalIsString ? new RegExp(`{${ref.path.join('.')}(.value)?}`, 'g') : ref.value, replaceFunc);
-          }
-        });
+        // when original is string value, we replace value by matching original.value and putting a var instead
+        // this is more friendly to transitive transforms that transform the string values
+        value = prop.original.value;
       }
+
+      refs.forEach(ref => {
+        // value should be a string that contains the resolved reference
+        // because Style Dictionary resolved this in the resolution step.
+        // Here we are undoing that by replacing the value with
+        // the reference's name
+        if (ref.value && ref.name) {
+          const replaceFunc = function() {
+            if (format === 'css') {
+              if (outputReferenceFallbacks) {
+                return `var(${prefix}${ref.name}, ${ref.value})`;
+              } else {
+                return `var(${prefix}${ref.name})`;
+              }
+            } else {
+              return `${prefix}${ref.name}`;
+            }
+          }
+          value = value.replace(originalIsObject ? ref.value : new RegExp(`{${ref.path.join('.')}(.value)?}`, 'g'), replaceFunc);
+        }
+      });
     }
 
     to_ret_prop += prop.attributes.category === 'asset' ? `"${value}"` : value;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Adds more tests to outputReferences / createPropertyFormatter
- Allow outputReferences to work on primitives that aren't strings (but are perfectly stringifyable due to them being primitives)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
