### PR TITLE
chore: bump husky, change precommit hook, eslint scripts

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-npx lint-staged
+npx commitlint --edit "$1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "docsify-cli": "^4.4.3",
         "eslint": "^8.7.0",
         "eslint-plugin-jest": "^26.0.0",
-        "husky": "^7.0.0",
+        "husky": "^8.0.3",
         "istanbul": "^0.4.5",
         "jest": "^27.4.7",
         "jsdoc-escape-at": "^1.0.1",
@@ -10002,15 +10002,15 @@
       }
     },
     "node_modules/husky": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-7.0.4.tgz",
-      "integrity": "sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
+      "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
       "dev": true,
       "bin": {
         "husky": "lib/bin.js"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/sponsors/typicode"

--- a/package.json
+++ b/package.json
@@ -47,10 +47,10 @@
   ],
   "scripts": {
     "format": "run-p format:*",
-    "format:eslint": "eslint --file index.js \"lib/**/*.js\" \"__tests__/**/*.js\" --fix",
+    "format:eslint": "eslint --fix index.js \"lib/**/*.js\" \"__tests__/**/*.js\"",
     "format:prettier": "prettier \"**/*.{js,md}\" \"package.json\" --write",
     "lint": "run-p lint:*",
-    "lint:eslint": "eslint --fix index.js \"lib/**/*.js\" \"__tests__/**/*.js\"",
+    "lint:eslint": "eslint index.js \"lib/**/*.js\" \"__tests__/**/*.js\"",
     "lint:prettier": "prettier \"**/*.{js,md}\" \"package.json\" --list-different || (echo '↑↑ these files are not prettier formatted ↑↑' && exit 1)",
     "test": "run-p test:*",
     "test:unit": "jest --runInBand --silent --coverage",
@@ -98,17 +98,12 @@
       "^.+\\.jsx?$": "babel-jest"
     }
   },
-  "husky": {
-    "hooks": {
-      "pre-commit": "npm test && lint-staged",
-      "commit-msg": "commitlint -E HUSKY_GIT_PARAMS"
-    }
-  },
   "lint-staged": {
     "*.js": [
-      "npm run lint",
-      "git add"
-    ]
+      "eslint",
+      "prettier --list-different"
+    ],
+    "*.md": "prettier --list-different"
   },
   "commitlint": {
     "extends": [
@@ -164,7 +159,7 @@
     "docsify-cli": "^4.4.3",
     "eslint": "^8.7.0",
     "eslint-plugin-jest": "^26.0.0",
-    "husky": "^7.0.0",
+    "husky": "^8.0.3",
     "istanbul": "^0.4.5",
     "jest": "^27.4.7",
     "jsdoc-escape-at": "^1.0.1",


### PR DESCRIPTION
- No more npm test on precommit hook, takes a long time, we will let CI in Pull Requests do this verification step in the future. This also now blocks v4 branch from creating release commit, since tests are (knowingly) broken at the moment on this branch.
- Update husky, use commitlint (it's installed but not used in any hooks to verify commits) and lint-staged properly for eslint/prettier on precommit.
- Fix eslint scripts, both were doing "--fix" and one of the scripts was incorrectly using "--file" flag with no argument


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
