### PR TITLE
feat: allow deferring transitive transforms from the transformer

### DIFF
--- a/.changeset/great-trainers-shop.md
+++ b/.changeset/great-trainers-shop.md
@@ -1,0 +1,5 @@
+---
+'style-dictionary': patch
+---
+
+Allow transitive transforms to return undefined, by doing this the transformer can mark itself as "deferred" for that specific token. This is useful when references in properties other than "value" need to be resolved first.

--- a/__tests__/exportPlatform.test.js
+++ b/__tests__/exportPlatform.test.js
@@ -12,6 +12,7 @@
  */
 import { expect } from 'chai';
 import StyleDictionary from 'style-dictionary';
+import { usesReferences } from 'style-dictionary/utils';
 import { fileToJSON } from './__helpers.js';
 
 const config = fileToJSON('__tests__/__configs/test.json');
@@ -58,66 +59,68 @@ describe('exportPlatform', () => {
     expect(dictionary.size.padding.base.value.endsWith('px')).to.be.true;
   });
 
-  it('should have applied transforms for props with refs in it', async () => {
-    const StyleDictionaryExtended = await styleDictionary.extend({
-      platforms: {
-        test: {
-          transforms: ['color/css', 'color/darken'],
+  describe('transitive transforms', () => {
+    it('should have applied transforms for props with refs in it', async () => {
+      const StyleDictionaryExtended = await styleDictionary.extend({
+        platforms: {
+          test: {
+            transforms: ['color/css', 'color/darken'],
+          },
         },
-      },
+      });
+      StyleDictionary.registerTransform({
+        type: 'value',
+        name: 'color/darken',
+        transitive: true,
+        matcher: function (prop) {
+          return !!prop.original.transformColor;
+        },
+        transformer: function (prop) {
+          return prop.value + '-darker';
+        },
+      });
+      const dictionary = await StyleDictionaryExtended.exportPlatform('test');
+      expect(dictionary.color.button.active.value).to.equal('#0077CC-darker');
+      expect(dictionary.color.button.hover.value).to.equal('#0077CC-darker-darker');
     });
-    StyleDictionary.registerTransform({
-      type: 'value',
-      name: 'color/darken',
-      transitive: true,
-      matcher: function (prop) {
-        return !!prop.original.transformColor;
-      },
-      transformer: function (prop) {
-        return prop.value + '-darker';
-      },
-    });
-    const dictionary = await StyleDictionaryExtended.exportPlatform('test');
-    expect(dictionary.color.button.active.value).to.equal('#0077CC-darker');
-    expect(dictionary.color.button.hover.value).to.equal('#0077CC-darker-darker');
-  });
 
-  it('should have transitive transforms applied without .value in references', async () => {
-    const sd = new StyleDictionary({
-      tokens: {
-        one: { value: 'foo' },
-        two: { value: '{one.value}' },
-        three: { value: '{two}' },
-        four: { value: '{one}' },
-        five: { value: '{four.value}' },
-        six: { value: '{one}' },
-        seven: { value: '{six}' },
-        eight: { value: '{one.value}' },
-        nine: { value: '{eight.value}' },
-      },
-      transform: {
-        transitive: {
-          type: 'value',
-          transitive: true,
-          transformer: (token) => `${token.value}-bar`,
+    it('should have transitive transforms applied without .value in references', async () => {
+      const sd = new StyleDictionary({
+        tokens: {
+          one: { value: 'foo' },
+          two: { value: '{one.value}' },
+          three: { value: '{two}' },
+          four: { value: '{one}' },
+          five: { value: '{four.value}' },
+          six: { value: '{one}' },
+          seven: { value: '{six}' },
+          eight: { value: '{one.value}' },
+          nine: { value: '{eight.value}' },
         },
-      },
-      platforms: {
-        test: {
-          transforms: ['transitive'],
+        transform: {
+          transitive: {
+            type: 'value',
+            transitive: true,
+            transformer: (token) => `${token.value}-bar`,
+          },
         },
-      },
+        platforms: {
+          test: {
+            transforms: ['transitive'],
+          },
+        },
+      });
+      const dictionary = await sd.exportPlatform('test');
+      expect(dictionary.one.value).to.equal('foo-bar');
+      expect(dictionary.two.value).to.equal('foo-bar-bar');
+      expect(dictionary.three.value).to.equal('foo-bar-bar-bar');
+      expect(dictionary.four.value).to.equal('foo-bar-bar');
+      expect(dictionary.five.value).to.equal('foo-bar-bar-bar');
+      expect(dictionary.six.value).to.equal('foo-bar-bar');
+      expect(dictionary.seven.value).to.equal('foo-bar-bar-bar');
+      expect(dictionary.eight.value).to.equal('foo-bar-bar');
+      expect(dictionary.nine.value).to.equal('foo-bar-bar-bar');
     });
-    const dictionary = await sd.exportPlatform('test');
-    expect(dictionary.one.value).to.equal('foo-bar');
-    expect(dictionary.two.value).to.equal('foo-bar-bar');
-    expect(dictionary.three.value).to.equal('foo-bar-bar-bar');
-    expect(dictionary.four.value).to.equal('foo-bar-bar');
-    expect(dictionary.five.value).to.equal('foo-bar-bar-bar');
-    expect(dictionary.six.value).to.equal('foo-bar-bar');
-    expect(dictionary.seven.value).to.equal('foo-bar-bar-bar');
-    expect(dictionary.eight.value).to.equal('foo-bar-bar');
-    expect(dictionary.nine.value).to.equal('foo-bar-bar-bar');
   });
 
   it('should not have mutated the original tokens', async () => {
@@ -234,156 +237,151 @@ describe('exportPlatform', () => {
     expect(actual).to.eql(expected);
   });
 
-  // describe('token references without .value', async () => {
-  //   const tokens = {
-  //     color: {
-  //       red: { value: '#f00' },
-  //       error: { value: '{color.red}' },
-  //       errorWithValue: { value: '{color.red.value}' },
-  //       danger: { value: '{color.error}' },
-  //       dangerWithValue: { value: '{color.error.value}' },
-  //       dangerErrorValue: { value: '{color.errorWithValue}' },
-  //     },
-  //   };
-  //   const actual = (
-  //     await StyleDictionary.extend({
-  //       tokens,
-  //       platforms: {
-  //         css: {
-  //           transformGroup: 'css',
-  //         },
-  //       },
-  //     })
-  //   ).exportPlatform('css');
-  //   it('should work if referenced directly', () => {
-  //     expect(actual.color.error.value).toEqual('#ff0000');
-  //   });
-  //   it('should work if there is a transitive reference', () => {
-  //     expect(actual.color.danger.value).toEqual('#ff0000');
-  //   });
-  //   it('should work if there is a transitive reference with .value', () => {
-  //     expect(actual.color.errorWithValue.value).toEqual('#ff0000');
-  //     expect(actual.color.dangerWithValue.value).toEqual('#ff0000');
-  //     expect(actual.color.dangerErrorValue.value).toEqual('#ff0000');
-  //   });
-  // });
-  // describe('non-token references', async () => {
-  //   const tokens = {
-  //     nonTokenColor: 'hsl(10,20%,20%)',
-  //     hue: {
-  //       red: '10',
-  //       green: '120',
-  //       blue: '220',
-  //     },
-  //     comment: 'hello',
-  //     color: {
-  //       red: {
-  //         // Note having references as part of the value,
-  //         // either in an object like this, or in an interpolated
-  //         // string like below, requires the use of transitive
-  //         // transforms if you want it to be transformed.
-  //         value: {
-  //           h: '{hue.red}',
-  //           s: '100%',
-  //           l: '50%',
-  //         },
-  //       },
-  //       blue: {
-  //         value: '{nonTokenColor}',
-  //         comment: '{comment}',
-  //       },
-  //       green: {
-  //         value: 'hsl({hue.green}, 50%, 50%)',
-  //       },
-  //     },
-  //   };
-  //   // making the css/color transform transitive so we can be sure the references
-  //   // get resolved properly and transformed.
-  //   const transitiveTransform = Object.assign({}, StyleDictionary.transform['color/css'], {
-  //     transitive: true,
-  //   });
-  //   const actual = (
-  //     await StyleDictionary.extend({
-  //       tokens,
-  //       transform: {
-  //         transitiveTransform,
-  //       },
-  //       platforms: {
-  //         css: {
-  //           transforms: ['attribute/cti', 'name/cti/kebab', 'transitiveTransform'],
-  //         },
-  //       },
-  //     })
-  //   ).exportPlatform('css');
-  //   it('should work if referenced directly', () => {
-  //     expect(actual.color.blue.value).toEqual('#3d2c29');
-  //   });
-  //   it('should work if referenced from a non-value', () => {
-  //     expect(actual.color.blue.comment).toEqual(tokens.comment);
-  //   });
-  //   it('should work if interpolated', () => {
-  //     expect(actual.color.green.value).toEqual('#40bf40');
-  //   });
-  //   it('should work if part of an object value', () => {
-  //     expect(actual.color.red.value).toEqual('#ff2b00');
-  //   });
-  // });
+  describe('token references without .value', async () => {
+    const tokens = {
+      color: {
+        red: { value: '#f00' },
+        error: { value: '{color.red}' },
+        errorWithValue: { value: '{color.red.value}' },
+        danger: { value: '{color.error}' },
+        dangerWithValue: { value: '{color.error.value}' },
+        dangerErrorValue: { value: '{color.errorWithValue}' },
+      },
+    };
+    const dict = new StyleDictionary({
+      tokens,
+      platforms: {
+        css: {
+          transformGroup: 'css',
+        },
+      },
+    });
+    const actual = await dict.exportPlatform('css');
+
+    it('should work if referenced directly', () => {
+      expect(actual.color.error.value).to.equal('#ff0000');
+    });
+
+    it('should work if there is a transitive reference', () => {
+      expect(actual.color.danger.value).to.equal('#ff0000');
+    });
+
+    it('should work if there is a transitive reference with .value', () => {
+      expect(actual.color.errorWithValue.value).to.equal('#ff0000');
+      expect(actual.color.dangerWithValue.value).to.equal('#ff0000');
+      expect(actual.color.dangerErrorValue.value).to.equal('#ff0000');
+    });
+  });
+
+  describe('non-token references', async () => {
+    const tokens = {
+      nonTokenColor: 'hsl(10,20%,20%)',
+      hue: {
+        red: '10',
+        green: '120',
+        blue: '220',
+      },
+      comment: 'hello',
+      color: {
+        red: {
+          // Note having references as part of the value,
+          // either in an object like this, or in an interpolated
+          // string like below, requires the use of transitive
+          // transforms if you want it to be transformed.
+          value: {
+            h: '{hue.red}',
+            s: '100%',
+            l: '50%',
+          },
+        },
+        blue: {
+          value: '{nonTokenColor}',
+          comment: '{comment}',
+        },
+        green: {
+          value: 'hsl({hue.green}, 50%, 50%)',
+        },
+      },
+    };
+    // making the css/color transform transitive so we can be sure the references
+    // get resolved properly and transformed.
+    const transitiveTransform = Object.assign({}, StyleDictionary.transform['color/css'], {
+      transitive: true,
+    });
+    const dict = new StyleDictionary({
+      tokens,
+      transform: {
+        transitiveTransform,
+      },
+      platforms: {
+        css: {
+          transforms: ['attribute/cti', 'name/cti/kebab', 'transitiveTransform'],
+        },
+      },
+    });
+    const actual = await dict.exportPlatform('css');
+    it('should work if referenced directly', () => {
+      expect(actual.color.blue.value).to.equal('#3d2c29');
+    });
+    it('should work if referenced from a non-value', () => {
+      expect(actual.color.blue.comment).to.equal(tokens.comment);
+    });
+    it('should work if interpolated', () => {
+      expect(actual.color.green.value).to.equal('#40bf40');
+    });
+    it('should work if part of an object value', () => {
+      expect(actual.color.red.value).to.equal('#ff2b00');
+    });
+  });
 });
 
-// describe('reference warnings', () => {
-//   const errorMessage = `Problems were found when trying to resolve property references`;
-//   const platforms = {
-//     css: {
-//       transformGroup: `css`,
-//     },
-//   };
+describe('reference warnings', () => {
+  const errorMessage = `Problems were found when trying to resolve property references`;
+  const platforms = {
+    css: {
+      transformGroup: `css`,
+    },
+  };
 
-//   it('should throw if there are simple property reference errors', async () => {
-//     const tokens = {
-//       a: '#ff0000',
-//       b: '{c}',
-//     };
-//     await expect(
-//       StyleDictionary.extend({
-//         tokens,
-//         platforms,
-//       }).then((sd) => sd.exportPlatform('css')),
-//     ).to.eventually.be.rejectedWith(errorMessage);
-//   });
+  it('should throw if there are simple property reference errors', async () => {
+    const tokens = {
+      a: '#ff0000',
+      b: '{c}',
+    };
+    const dict = new StyleDictionary({
+      tokens,
+      platforms,
+    });
 
-//   it('should throw if there are circular reference errors', async () => {
-//     const tokens = {
-//       a: '{b}',
-//       b: '{a}',
-//     };
-//     await expect(
-//       StyleDictionary.extend({
-//         tokens,
-//         platforms,
-//       }).then((sd) => sd.exportPlatform('css')),
-//     ).to.eventually.be.rejectedWith(errorMessage);
-//   });
+    await expect(dict.exportPlatform('css')).to.eventually.be.rejectedWith(errorMessage);
+  });
 
-//   it('should throw if there are complex property reference errors', async () => {
-//     const tokens = {
-//       color: {
-//         core: {
-//           red: { valuer: '#ff0000' }, // notice misspelling
-//           blue: { 'value:': '#0000ff' },
-//         },
-//         danger: { value: '{color.core.red.value}' },
-//         warning: { value: '{color.base.red.valuer}' },
-//         info: { value: '{color.core.blue.value}' },
-//         error: { value: '{color.danger.value}' },
-//       },
-//     };
-//     await expect(
-//       StyleDictionary.extend({
-//         tokens,
-//         platforms,
-//       }).then((sd) => {
-//         sd.exportPlatform('css');
-//       }),
-//     ).to.eventually.be.rejectedWith(errorMessage);
-//   });
-// });
+  it('should throw if there are circular reference errors', async () => {
+    const tokens = {
+      a: '{b}',
+      b: '{a}',
+    };
+    const dict = new StyleDictionary({
+      tokens,
+      platforms,
+    });
+    await expect(dict.exportPlatform('css')).to.eventually.be.rejectedWith(errorMessage);
+  });
+
+  it('should throw if there are complex property reference errors', async () => {
+    const tokens = {
+      color: {
+        core: {
+          red: { valuer: '#ff0000' }, // notice misspelling
+          blue: { 'value:': '#0000ff' },
+        },
+        danger: { value: '{color.core.red.value}' },
+        warning: { value: '{color.base.red.valuer}' },
+        info: { value: '{color.core.blue.value}' },
+        error: { value: '{color.danger.value}' },
+      },
+    };
+    const dict = new StyleDictionary({ tokens, platforms });
+    await expect(dict.exportPlatform('css')).to.eventually.be.rejectedWith(errorMessage);
+  });
+});

--- a/__tests__/transform/property.test.js
+++ b/__tests__/transform/property.test.js
@@ -43,10 +43,35 @@ var options = {
 
 describe('transform', () => {
   describe('token', () => {
-    it('should work', () => {
+    it('transform token and apply transforms', () => {
       const test = token({ attributes: { baz: 'blah' } }, options);
       expect(test).to.have.nested.property('attributes.bar', 'foo');
       expect(test).to.have.property('name', 'hello');
+    });
+
+    // This allows transformObject utility to then consider this token's transformation undefined and thus "deferred"
+    it('returns a token as undefined if transitive transformer dictates that the transformation has to be deferred', () => {
+      const result = token(
+        {
+          value: '16',
+          original: {
+            value: '16',
+          },
+        },
+        {
+          transforms: [
+            {
+              type: 'value',
+              transitive: true,
+              transformer: () => {
+                return undefined;
+              },
+            },
+          ],
+        },
+      );
+
+      expect(result).to.be.undefined;
     });
 
     // Add more tests

--- a/examples/advanced/transitive-transforms/sd.config.js
+++ b/examples/advanced/transitive-transforms/sd.config.js
@@ -1,13 +1,23 @@
-const StyleDictionary = require('style-dictionary');
-const chroma = require('chroma-js');
+import StyleDictionary from 'style-dictionary';
+import { usesReferences } from 'style-dictionary/utils';
+import chroma from 'chroma-js';
 
 const colorTransform = (token) => {
   const { value, modify = [] } = token;
   let color = chroma(value);
 
+  // defer until reference is resolved
+  if (typeof modify === 'string' && usesReferences(modify)) {
+    return undefined;
+  }
+
   // iterate over the modify array (see tokens/color.json)
   // and apply each modification in order
   modify.forEach(({ type, amount }) => {
+    // defer until reference is resolved
+    if (usesReferences(type) || usesReferences(amount)) {
+      return undefined;
+    }
     // modifier type must match a method name in chromajs
     // https://gka.github.io/chroma.js/
     // chroma methods can be chained, so each time we override the color variable
@@ -19,7 +29,7 @@ const colorTransform = (token) => {
   return color.hex();
 };
 
-module.exports = {
+export default {
   // This will match any files ending in json or json5
   // I am using json5 here so I can add comments in the token files for reference
   source: [`tokens/**/*.@(json|json5)`],

--- a/lib/transform/object.js
+++ b/lib/transform/object.js
@@ -12,7 +12,7 @@
  */
 
 import isPlainObject from 'is-plain-obj';
-import usesValueReference from '../utils/references/usesReferences.js';
+import usesReferences from '../utils/references/usesReferences.js';
 import getName from '../utils/references/getName.js';
 import transformToken from './token.js';
 import tokenSetup from './tokenSetup.js';
@@ -76,21 +76,33 @@ export default function transformObject(
       // it is safe to run this multiple times on the same property.
       const setupProperty = tokenSetup(/** @type {Token|TransformedToken} */ (objProp), name, path);
 
-      // If property has a reference, defer its transformations until later
-      if (usesValueReference(setupProperty.value, options)) {
+      const deferProp = () => {
         // If property path isn't in the deferred array, add it now.
         if (deferredPropValueTransforms.indexOf(pathName) === -1) {
           deferredPropValueTransforms.push(pathName);
         }
-
         transformedObj[name] = setupProperty;
         path.pop();
+      };
+
+      // If property has a reference, defer its transformations until later
+      if (usesReferences(setupProperty.value, options)) {
+        deferProp();
         continue;
       }
 
       // If we got here, the property hasn't been transformed yet and
       // does not use a value reference. Transform the property now and assign it.
-      transformedObj[name] = transformToken(setupProperty, options);
+      const transformedToken = transformToken(setupProperty, options);
+      // If a value transform returns undefined, it means the transform wants it to be deferred
+      // e.g. due to a ref existing in a sibling prop that the transform relies on.
+      // Example: { value: "#fff", darken: "{darken-amount}" }
+      if (transformedToken === undefined) {
+        deferProp();
+        continue;
+      }
+
+      transformedObj[name] = transformedToken;
 
       // Remove the property path from the deferred transform list, starting from end of array
       for (let i = deferredPropValueTransforms.length - 1; i >= 0; i--) {

--- a/lib/transform/token.js
+++ b/lib/transform/token.js
@@ -26,7 +26,7 @@ import usesReferences from '../utils/references/usesReferences.js';
  * @private
  * @param {Token} property
  * @param {PlatformConfig} options
- * @returns {Token} - A new property object with transforms applied.
+ * @returns {Token|undefined} - A new property object with transforms applied.
  */
 export default function transformProperty(property, options) {
   const to_ret = structuredClone(property);
@@ -49,7 +49,11 @@ export default function transformProperty(property, options) {
         // Only transform non-referenced values (from original)
         // and transitive transforms if the value has been resolved
         if (!usesReferences(property.original.value, options) || transform.transitive) {
-          to_ret.value = transform.transformer(to_ret, options);
+          const transformedValue = transform.transformer(to_ret, options);
+          if (transformedValue === undefined) {
+            return undefined;
+          }
+          to_ret.value = transformedValue;
         }
       }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "style-dictionary",
-  "version": "4.0.0-prerelease.7",
+  "version": "4.0.0-prerelease.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "style-dictionary",
-      "version": "4.0.0-prerelease.7",
+      "version": "4.0.0-prerelease.8",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/types/Transform.d.ts
+++ b/types/Transform.d.ts
@@ -25,6 +25,6 @@ interface BaseTransform<Type, Value> {
 
 export type NameTransform = BaseTransform<'name', string>;
 export type AttributeTransform = BaseTransform<'attribute', Record<string, unknown>>;
-export type ValueTransform = BaseTransform<'value', unknown>;
+export type ValueTransform = BaseTransform<'value', unknown | undefined>;
 
 export type Transform = NameTransform | AttributeTransform | ValueTransform;


### PR DESCRIPTION
*Issue #, if available:*
fixes https://github.com/amzn/style-dictionary/issues/1073
Related: https://github.com/tokens-studio/sd-transforms/issues/211

See test for use case, but in summary: support transitive transforms that rely on sibling props for metadata in order to do the transformation, and allowing references in them. For this, it's necessary to allow letting the transformer decide that a prop's transformation should be deferred until the next cycle of reference resolutions, since only the transformer has the context about why deferring is necessary. returning `undefined` seemed to make the most sense to me, it says "the transformation could not be defined, so try again later"

I mostly created this draft PR to prove that it can work without breaking other behaviors or types.
TODO before merging:
- [x] approval on the API design
- [x] docs
- [x] changeset
- [x] 1 or 2 more unit tests for transformObject to verify transformer returning undefined makes the token itself undefined.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
