### PR TITLE
chore: upgrade glob to latest, verify windows

### DIFF
--- a/.changeset/smooth-bulldogs-type.md
+++ b/.changeset/smooth-bulldogs-type.md
@@ -1,0 +1,5 @@
+---
+'style-dictionary': patch
+---
+
+Fix Windows support by using a Linux/Windows + Node/Browser compatible path utility. Upgrade to latest Glob version. Apply posix: true to prevent breaking change glob update.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,9 +12,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          # use lts, bump this if new major becomes lts
+          node-version: 20.x
           registry-url: 'https://registry.npmjs.org'
 
       - name: Install Dependencies

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -5,17 +5,25 @@ on: pull_request
 jobs:
   verify:
     name: Verify changes
-    runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        # latest node & minimum node according to pkg.json engines
+        node-version: [18.0, 21.x]
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{matrix.os}}
     steps:
-      - uses: actions/checkout@v2
+      - name: Set git to use LF
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.eol lf
+
+      - uses: actions/checkout@v4
 
       - name: Setup Node ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
+          cache: 'npm'
 
       - name: Install Dependencies
         run: npm ci

--- a/__integration__/android.test.js
+++ b/__integration__/android.test.js
@@ -13,6 +13,7 @@
 import { expect } from 'chai';
 import StyleDictionary from 'style-dictionary';
 import { fs } from 'style-dictionary/fs';
+import { resolve } from '../lib/resolve.js';
 import { buildPath } from './_constants.js';
 import { clearOutput } from '../__tests__/__helpers.js';
 
@@ -54,7 +55,7 @@ describe('integration', () => {
     await sd.buildAllPlatforms();
 
     describe(`android/resources`, () => {
-      const output = fs.readFileSync(`${buildPath}resources.xml`, {
+      const output = fs.readFileSync(resolve(`${buildPath}resources.xml`), {
         encoding: 'UTF-8',
       });
 
@@ -63,7 +64,7 @@ describe('integration', () => {
       });
 
       describe(`with references`, () => {
-        const output = fs.readFileSync(`${buildPath}resourcesWithReferences.xml`, {
+        const output = fs.readFileSync(resolve(`${buildPath}resourcesWithReferences.xml`), {
           encoding: 'UTF-8',
         });
 
@@ -73,7 +74,7 @@ describe('integration', () => {
       });
 
       describe(`with filter`, () => {
-        const output = fs.readFileSync(`${buildPath}colors.xml`, {
+        const output = fs.readFileSync(resolve(`${buildPath}colors.xml`), {
           encoding: 'UTF-8',
         });
 

--- a/__integration__/compose.test.js
+++ b/__integration__/compose.test.js
@@ -13,6 +13,7 @@
 import { expect } from 'chai';
 import StyleDictionary from 'style-dictionary';
 import { fs } from 'style-dictionary/fs';
+import { resolve } from '../lib/resolve.js';
 import { buildPath } from './_constants.js';
 import { clearOutput } from '../__tests__/__helpers.js';
 
@@ -51,7 +52,7 @@ describe('integration', () => {
     await sd.buildAllPlatforms();
 
     describe(`compose/object`, () => {
-      const output = fs.readFileSync(`${buildPath}StyleDictionary.kt`, {
+      const output = fs.readFileSync(resolve(`${buildPath}StyleDictionary.kt`), {
         encoding: `UTF-8`,
       });
 
@@ -60,7 +61,7 @@ describe('integration', () => {
       });
 
       describe(`with references`, () => {
-        const output = fs.readFileSync(`${buildPath}StyleDictionaryWithReferences.kt`, {
+        const output = fs.readFileSync(resolve(`${buildPath}StyleDictionaryWithReferences.kt`), {
           encoding: `UTF-8`,
         });
 

--- a/__integration__/css.test.js
+++ b/__integration__/css.test.js
@@ -13,6 +13,7 @@
 import { expect } from 'chai';
 import StyleDictionary from 'style-dictionary';
 import { fs } from 'style-dictionary/fs';
+import { resolve } from '../lib/resolve.js';
 import { buildPath } from './_constants.js';
 import { clearOutput } from '../__tests__/__helpers.js';
 
@@ -65,7 +66,7 @@ describe('integration', () => {
     await sd.buildAllPlatforms();
 
     describe('css/variables', () => {
-      const output = fs.readFileSync(`${buildPath}variables.css`, {
+      const output = fs.readFileSync(resolve(`${buildPath}variables.css`), {
         encoding: 'UTF-8',
       });
       it(`should match snapshot`, async () => {
@@ -73,7 +74,7 @@ describe('integration', () => {
       });
 
       describe(`with references`, () => {
-        const output = fs.readFileSync(`${buildPath}variablesWithReferences.css`, {
+        const output = fs.readFileSync(resolve(`${buildPath}variablesWithReferences.css`), {
           encoding: 'UTF-8',
         });
         it(`should match snapshot`, async () => {
@@ -82,7 +83,7 @@ describe('integration', () => {
       });
 
       describe(`with selector`, () => {
-        const output = fs.readFileSync(`${buildPath}variablesWithSelector.css`, {
+        const output = fs.readFileSync(resolve(`${buildPath}variablesWithSelector.css`), {
           encoding: 'UTF-8',
         });
         it(`should match snapshot`, async () => {

--- a/__integration__/customFileHeader.test.js
+++ b/__integration__/customFileHeader.test.js
@@ -13,6 +13,7 @@
 import { expect } from 'chai';
 import StyleDictionary from 'style-dictionary';
 import { fs } from 'style-dictionary/fs';
+import { resolve } from '../lib/resolve.js';
 import { buildPath } from './_constants.js';
 import { clearOutput } from '../__tests__/__helpers.js';
 
@@ -109,21 +110,21 @@ describe(`integration`, () => {
 
     describe('file options', () => {
       it(`registered file header should match snapshot`, async () => {
-        const output = fs.readFileSync(`${buildPath}registeredFileHeader.css`, {
+        const output = fs.readFileSync(resolve(`${buildPath}registeredFileHeader.css`), {
           encoding: 'UTF-8',
         });
         await expect(output).to.matchSnapshot();
       });
 
       it(`config file header should match snapshot`, async () => {
-        const output = fs.readFileSync(`${buildPath}configFileHeader.css`, {
+        const output = fs.readFileSync(resolve(`${buildPath}configFileHeader.css`), {
           encoding: 'UTF-8',
         });
         await expect(output).to.matchSnapshot();
       });
 
       it(`inline file header should match snapshot`, async () => {
-        const output = fs.readFileSync(`${buildPath}inlineFileHeader.css`, {
+        const output = fs.readFileSync(resolve(`${buildPath}inlineFileHeader.css`), {
           encoding: 'UTF-8',
         });
         await expect(output).to.matchSnapshot();
@@ -132,21 +133,21 @@ describe(`integration`, () => {
 
     describe('platform options', () => {
       it(`no file options should match snapshot`, async () => {
-        const output = fs.readFileSync(`${buildPath}noOptions.js`, {
+        const output = fs.readFileSync(resolve(`${buildPath}noOptions.js`), {
           encoding: 'UTF-8',
         });
         await expect(output).to.matchSnapshot();
       });
 
       it(`showFileHeader should match snapshot`, async () => {
-        const output = fs.readFileSync(`${buildPath}showFileHeader.js`, {
+        const output = fs.readFileSync(resolve(`${buildPath}showFileHeader.js`), {
           encoding: 'UTF-8',
         });
         await expect(output).to.matchSnapshot();
       });
 
       it(`file header override should match snapshot`, async () => {
-        const output = fs.readFileSync(`${buildPath}fileHeaderOverride.js`, {
+        const output = fs.readFileSync(resolve(`${buildPath}fileHeaderOverride.js`), {
           encoding: 'UTF-8',
         });
         await expect(output).to.matchSnapshot();

--- a/__integration__/customFormats.test.js
+++ b/__integration__/customFormats.test.js
@@ -13,6 +13,7 @@
 import { expect } from 'chai';
 import StyleDictionary from 'style-dictionary';
 import { fs } from 'style-dictionary/fs';
+import { resolve } from '../lib/resolve.js';
 import { buildPath } from './_constants.js';
 import { clearOutput } from '../__tests__/__helpers.js';
 
@@ -89,7 +90,7 @@ describe('integration', () => {
     await sd.buildAllPlatforms();
 
     describe(`inline custom with new args`, async () => {
-      const output = fs.readFileSync(`${buildPath}inlineCustomFormatWithNewArgs.json`, {
+      const output = fs.readFileSync(resolve(`${buildPath}inlineCustomFormatWithNewArgs.json`), {
         encoding: 'UTF-8',
       });
       it(`should match snapshot`, async () => {
@@ -107,7 +108,7 @@ describe('integration', () => {
     });
 
     describe(`register custom format with new args`, () => {
-      const output = fs.readFileSync(`${buildPath}registerCustomFormatWithNewArgs.json`, {
+      const output = fs.readFileSync(resolve(`${buildPath}registerCustomFormatWithNewArgs.json`), {
         encoding: 'UTF-8',
       });
 

--- a/__integration__/flutter.test.js
+++ b/__integration__/flutter.test.js
@@ -13,6 +13,7 @@
 import { expect } from 'chai';
 import StyleDictionary from 'style-dictionary';
 import { fs } from 'style-dictionary/fs';
+import { resolve } from '../lib/resolve.js';
 import { buildPath } from './_constants.js';
 import { clearOutput } from '../__tests__/__helpers.js';
 
@@ -77,7 +78,7 @@ describe('integration', () => {
     await sd.buildAllPlatforms();
 
     describe(`flutter/class.dart`, () => {
-      const output = fs.readFileSync(`${buildPath}style_dictionary.dart`, {
+      const output = fs.readFileSync(resolve(`${buildPath}style_dictionary.dart`), {
         encoding: `UTF-8`,
       });
 
@@ -86,9 +87,12 @@ describe('integration', () => {
       });
 
       describe(`with references`, () => {
-        const output = fs.readFileSync(`${buildPath}style_dictionary_with_references.dart`, {
-          encoding: `UTF-8`,
-        });
+        const output = fs.readFileSync(
+          resolve(`${buildPath}style_dictionary_with_references.dart`),
+          {
+            encoding: `UTF-8`,
+          },
+        );
 
         it(`should match snapshot`, async () => {
           await expect(output).to.matchSnapshot();
@@ -96,7 +100,7 @@ describe('integration', () => {
       });
 
       describe(`separate`, () => {
-        const output = fs.readFileSync(`${buildPath}style_dictionary_color.dart`, {
+        const output = fs.readFileSync(resolve(`${buildPath}style_dictionary_color.dart`), {
           encoding: `UTF-8`,
         });
         it(`should match snapshot`, async () => {

--- a/__integration__/iOSObjectiveC.test.js
+++ b/__integration__/iOSObjectiveC.test.js
@@ -13,6 +13,7 @@
 import { expect } from 'chai';
 import StyleDictionary from 'style-dictionary';
 import { fs } from 'style-dictionary/fs';
+import { resolve } from '../lib/resolve.js';
 import { buildPath } from './_constants.js';
 import { clearOutput } from '../__tests__/__helpers.js';
 
@@ -78,49 +79,49 @@ describe('integration', () => {
     await sd.buildAllPlatforms();
 
     it(`ios/singleton.m should match snapshot`, async () => {
-      const output = fs.readFileSync(`${buildPath}singleton.m`, {
+      const output = fs.readFileSync(resolve(`${buildPath}singleton.m`), {
         encoding: `UTF-8`,
       });
       await expect(output).to.matchSnapshot();
     });
 
     it(`ios/singleton.h should match snapshot`, async () => {
-      const output = fs.readFileSync(`${buildPath}singleton.h`, {
+      const output = fs.readFileSync(resolve(`${buildPath}singleton.h`), {
         encoding: `UTF-8`,
       });
       await expect(output).to.matchSnapshot();
     });
 
     it(`ios/color.m should match snapshot`, async () => {
-      const output = fs.readFileSync(`${buildPath}color.m`, {
+      const output = fs.readFileSync(resolve(`${buildPath}color.m`), {
         encoding: `UTF-8`,
       });
       await expect(output).to.matchSnapshot();
     });
 
     it(`ios/color.h should match snapshot`, async () => {
-      const output = fs.readFileSync(`${buildPath}color.h`, {
+      const output = fs.readFileSync(resolve(`${buildPath}color.h`), {
         encoding: `UTF-8`,
       });
       await expect(output).to.matchSnapshot();
     });
 
     it(`ios/macros.h should match snapshot`, async () => {
-      const output = fs.readFileSync(`${buildPath}macros.h`, {
+      const output = fs.readFileSync(resolve(`${buildPath}macros.h`), {
         encoding: `UTF-8`,
       });
       await expect(output).to.matchSnapshot();
     });
 
     it(`ios/static.h should match snapshot`, async () => {
-      const output = fs.readFileSync(`${buildPath}static.h`, {
+      const output = fs.readFileSync(resolve(`${buildPath}static.h`), {
         encoding: `UTF-8`,
       });
       await expect(output).to.matchSnapshot();
     });
 
     it(`ios/static.m should match snapshot`, async () => {
-      const output = fs.readFileSync(`${buildPath}static.m`, {
+      const output = fs.readFileSync(resolve(`${buildPath}static.m`), {
         encoding: `UTF-8`,
       });
       await expect(output).to.matchSnapshot();

--- a/__integration__/objectValues.test.js
+++ b/__integration__/objectValues.test.js
@@ -14,6 +14,7 @@ import { expect } from 'chai';
 import Color from 'tinycolor2';
 import StyleDictionary from 'style-dictionary';
 import { fs } from 'style-dictionary/fs';
+import { resolve } from '../lib/resolve.js';
 import { buildPath } from './_constants.js';
 import { clearOutput } from '../__tests__/__helpers.js';
 
@@ -213,7 +214,7 @@ describe('integration', () => {
   describe('object values', async () => {
     describe('css/variables', () => {
       describe(`hsl syntax`, () => {
-        const output = fs.readFileSync(`${buildPath}hsl.css`, {
+        const output = fs.readFileSync(resolve(`${buildPath}hsl.css`), {
           encoding: 'UTF-8',
         });
         it(`should match snapshot`, async () => {
@@ -221,7 +222,7 @@ describe('integration', () => {
         });
 
         describe(`with references`, () => {
-          const output = fs.readFileSync(`${buildPath}hslWithReferences.css`, {
+          const output = fs.readFileSync(resolve(`${buildPath}hslWithReferences.css`), {
             encoding: 'UTF-8',
           });
           it(`should match snapshot`, async () => {
@@ -231,7 +232,7 @@ describe('integration', () => {
       });
 
       describe(`hex syntax`, () => {
-        const output = fs.readFileSync(`${buildPath}hex.css`, {
+        const output = fs.readFileSync(resolve(`${buildPath}hex.css`), {
           encoding: 'UTF-8',
         });
         it(`should match snapshot`, async () => {
@@ -239,7 +240,7 @@ describe('integration', () => {
         });
 
         describe(`with references`, () => {
-          const output = fs.readFileSync(`${buildPath}hexWithReferences.css`, {
+          const output = fs.readFileSync(resolve(`${buildPath}hexWithReferences.css`), {
             encoding: 'UTF-8',
           });
           it(`should match snapshot`, async () => {
@@ -249,7 +250,7 @@ describe('integration', () => {
       });
 
       describe(`border`, () => {
-        const output = fs.readFileSync(`${buildPath}border.css`, {
+        const output = fs.readFileSync(resolve(`${buildPath}border.css`), {
           encoding: 'UTF-8',
         });
         it(`should match snapshot`, async () => {
@@ -257,7 +258,7 @@ describe('integration', () => {
         });
 
         describe(`with references`, () => {
-          const output = fs.readFileSync(`${buildPath}borderWithReferences.css`, {
+          const output = fs.readFileSync(resolve(`${buildPath}borderWithReferences.css`), {
             encoding: 'UTF-8',
           });
           it(`should match snapshot`, async () => {
@@ -268,14 +269,14 @@ describe('integration', () => {
 
       describe('shadow', () => {
         it(`should match snapshot`, async () => {
-          const output = fs.readFileSync(`${buildPath}shadow.css`, {
+          const output = fs.readFileSync(resolve(`${buildPath}shadow.css`), {
             encoding: 'UTF-8',
           });
           await expect(output).to.matchSnapshot();
         });
 
         it(`should match snapshot with references`, async () => {
-          const output = fs.readFileSync(`${buildPath}shadowWithReferences.css`, {
+          const output = fs.readFileSync(resolve(`${buildPath}shadowWithReferences.css`), {
             encoding: 'UTF-8',
           });
           await expect(output).to.matchSnapshot();
@@ -284,7 +285,7 @@ describe('integration', () => {
     });
 
     describe('scss/variables', () => {
-      const output = fs.readFileSync(`${buildPath}border.scss`, {
+      const output = fs.readFileSync(resolve(`${buildPath}border.scss`), {
         encoding: 'UTF-8',
       });
       it(`should match snapshot`, async () => {
@@ -292,7 +293,7 @@ describe('integration', () => {
       });
 
       describe(`with references`, () => {
-        const output = fs.readFileSync(`${buildPath}borderWithReferences.scss`, {
+        const output = fs.readFileSync(resolve(`${buildPath}borderWithReferences.scss`), {
           encoding: 'UTF-8',
         });
         it(`should match snapshot`, async () => {

--- a/__integration__/scss.test.js
+++ b/__integration__/scss.test.js
@@ -14,6 +14,7 @@ import { expect } from 'chai';
 import StyleDictionary from 'style-dictionary';
 import { fs } from 'style-dictionary/fs';
 import { compileString } from 'sass';
+import { resolve } from '../lib/resolve.js';
 import { buildPath } from './_constants.js';
 import { clearOutput } from '../__tests__/__helpers.js';
 
@@ -89,7 +90,7 @@ describe(`integration`, () => {
     await sd.buildAllPlatforms();
 
     describe(`scss/variables`, () => {
-      const output = fs.readFileSync(`${buildPath}variables.scss`, {
+      const output = fs.readFileSync(resolve(`${buildPath}variables.scss`), {
         encoding: 'UTF-8',
       });
 
@@ -103,7 +104,7 @@ describe(`integration`, () => {
       });
 
       describe(`with themeable`, () => {
-        const output = fs.readFileSync(`${buildPath}variables-themeable.scss`, {
+        const output = fs.readFileSync(resolve(`${buildPath}variables-themeable.scss`), {
           encoding: 'UTF-8',
         });
         it(`should have a valid scss syntax`, () => {
@@ -117,7 +118,7 @@ describe(`integration`, () => {
       });
 
       describe(`with outputReferences`, () => {
-        const output = fs.readFileSync(`${buildPath}variables-with-references.scss`, {
+        const output = fs.readFileSync(resolve(`${buildPath}variables-with-references.scss`), {
           encoding: 'UTF-8',
         });
         it(`should have a valid scss syntax`, () => {
@@ -131,9 +132,12 @@ describe(`integration`, () => {
       });
 
       describe(`with filter and output references`, () => {
-        const output = fs.readFileSync(`${buildPath}filtered-variables-with-references.scss`, {
-          encoding: 'UTF-8',
-        });
+        const output = fs.readFileSync(
+          resolve(`${buildPath}filtered-variables-with-references.scss`),
+          {
+            encoding: 'UTF-8',
+          },
+        );
         it(`should match snapshot`, async () => {
           await expect(output).to.matchSnapshot();
         });
@@ -141,7 +145,7 @@ describe(`integration`, () => {
     });
 
     describe(`scss/map-flat`, () => {
-      const output = fs.readFileSync(`${buildPath}map-flat.scss`, {
+      const output = fs.readFileSync(resolve(`${buildPath}map-flat.scss`), {
         encoding: 'UTF-8',
       });
 
@@ -156,7 +160,7 @@ describe(`integration`, () => {
     });
 
     describe(`scss/map-deep`, () => {
-      const output = fs.readFileSync(`${buildPath}map-deep.scss`, {
+      const output = fs.readFileSync(resolve(`${buildPath}map-deep.scss`), {
         encoding: 'UTF-8',
       });
 
@@ -170,7 +174,7 @@ describe(`integration`, () => {
       });
 
       describe(`with outputReferences`, () => {
-        const output = fs.readFileSync(`${buildPath}map-deep-with-references.scss`, {
+        const output = fs.readFileSync(resolve(`${buildPath}map-deep-with-references.scss`), {
           encoding: 'UTF-8',
         });
         it(`should have a valid scss syntax`, () => {
@@ -184,7 +188,7 @@ describe(`integration`, () => {
       });
 
       describe(`without themeable`, () => {
-        const output = fs.readFileSync(`${buildPath}map-deep-not-themeable.scss`, {
+        const output = fs.readFileSync(resolve(`${buildPath}map-deep-not-themeable.scss`), {
           encoding: 'UTF-8',
         });
         it(`should have a valid scss syntax`, () => {

--- a/__integration__/showFileHeader.test.js
+++ b/__integration__/showFileHeader.test.js
@@ -13,6 +13,7 @@
 import { expect } from 'chai';
 import StyleDictionary from 'style-dictionary';
 import { fs } from 'style-dictionary/fs';
+import { resolve } from '../lib/resolve.js';
 import { buildPath } from './_constants.js';
 import { clearOutput } from '../__tests__/__helpers.js';
 
@@ -70,14 +71,14 @@ describe('integration', () => {
 
     describe(`without platform options`, () => {
       it(`should show file header if no file options set`, async () => {
-        const output = fs.readFileSync(`${buildPath}platform-none-file-none.css`, {
+        const output = fs.readFileSync(resolve(`${buildPath}platform-none-file-none.css`), {
           encoding: 'UTF-8',
         });
         await expect(output).to.matchSnapshot();
       });
 
       it(`should not show file header if file options set to false`, async () => {
-        const output = fs.readFileSync(`${buildPath}platform-none-file-false.css`, {
+        const output = fs.readFileSync(resolve(`${buildPath}platform-none-file-false.css`), {
           encoding: 'UTF-8',
         });
         await expect(output).to.matchSnapshot();
@@ -86,14 +87,14 @@ describe('integration', () => {
 
     describe(`with platform options set to false`, () => {
       it(`should not show file header if no file options set`, async () => {
-        const output = fs.readFileSync(`${buildPath}platform-false-file-none.css`, {
+        const output = fs.readFileSync(resolve(`${buildPath}platform-false-file-none.css`), {
           encoding: 'UTF-8',
         });
         await expect(output).to.matchSnapshot();
       });
 
       it(`should show file header if file options set to true`, async () => {
-        const output = fs.readFileSync(`${buildPath}platform-false-file-true.css`, {
+        const output = fs.readFileSync(resolve(`${buildPath}platform-false-file-true.css`), {
           encoding: 'UTF-8',
         });
         await expect(output).to.matchSnapshot();

--- a/__integration__/swift.test.js
+++ b/__integration__/swift.test.js
@@ -13,6 +13,7 @@
 import { expect } from 'chai';
 import StyleDictionary from 'style-dictionary';
 import { fs } from 'style-dictionary/fs';
+import { resolve } from '../lib/resolve.js';
 import { buildPath } from './_constants.js';
 import { clearOutput } from '../__tests__/__helpers.js';
 
@@ -49,7 +50,7 @@ describe('integration', () => {
     await sd.buildAllPlatforms();
 
     describe(`ios-swift/class.swift`, () => {
-      const output = fs.readFileSync(`${buildPath}style_dictionary.swift`, {
+      const output = fs.readFileSync(resolve(`${buildPath}style_dictionary.swift`), {
         encoding: `UTF-8`,
       });
 
@@ -58,9 +59,12 @@ describe('integration', () => {
       });
 
       describe(`with references`, () => {
-        const output = fs.readFileSync(`${buildPath}style_dictionary_with_references.swift`, {
-          encoding: `UTF-8`,
-        });
+        const output = fs.readFileSync(
+          resolve(`${buildPath}style_dictionary_with_references.swift`),
+          {
+            encoding: `UTF-8`,
+          },
+        );
 
         it(`should match snapshot`, async () => {
           await expect(output).to.matchSnapshot();

--- a/__tests__/__helpers.js
+++ b/__tests__/__helpers.js
@@ -13,6 +13,7 @@
 
 import { expect } from 'chai';
 import { fs } from 'style-dictionary/fs';
+import { resolve } from '../lib/resolve.js';
 
 export const expectThrowsAsync = async (method, errorMessage) => {
   let error = null;
@@ -27,8 +28,8 @@ export const expectThrowsAsync = async (method, errorMessage) => {
   }
 };
 
-export const fileToJSON = (path, _fs = fs) => {
-  return JSON.parse(_fs.readFileSync(path, 'utf-8'));
+export const fileToJSON = (_path, _fs = fs) => {
+  return JSON.parse(_fs.readFileSync(resolve(_path), 'utf-8'));
 };
 
 export const clearOutput = (outputFolder = '__tests__/__output', _fs = fs) => {

--- a/__tests__/__setup.js
+++ b/__tests__/__setup.js
@@ -1,6 +1,6 @@
 import { use } from 'chai';
 import chaiAsPromised from '@esm-bundle/chai-as-promised';
-import path from '@bundled-es-modules/path-browserify';
+import { dirname } from 'path-unified';
 import { fs } from 'style-dictionary/fs';
 import { chaiWtrSnapshot } from '../snapshot-plugin/chai-wtr-snapshot.js';
 import { fixDate } from './__helpers.js';
@@ -18,11 +18,11 @@ import { fixDate } from './__helpers.js';
 fixDate();
 
 function ensureDirectoryExistence(filePath) {
-  const dirname = path.dirname(filePath);
-  if (fs.existsSync(dirname)) {
+  const dir = dirname(filePath);
+  if (fs.existsSync(dir)) {
     return true;
   }
-  fs.mkdirSync(dirname, { recursive: true });
+  fs.mkdirSync(dir, { recursive: true });
 }
 
 function mirrorFile(file, contents) {

--- a/__tests__/buildFiles.test.js
+++ b/__tests__/buildFiles.test.js
@@ -12,6 +12,7 @@
  */
 import { expect } from 'chai';
 import { fs } from 'style-dictionary/fs';
+import { resolve } from '../lib/resolve.js';
 import buildFiles from '../lib/buildFiles.js';
 import { clearOutput, fileExists } from './__helpers.js';
 
@@ -115,7 +116,7 @@ describe('buildFiles', () => {
   it('should work with a filter', () => {
     buildFiles(dictionary, platformWithFilter);
     expect(fileExists('__tests__/__output/test.json')).to.be.true;
-    const output = JSON.parse(fs.readFileSync('__tests__/__output/test.json'));
+    const output = JSON.parse(fs.readFileSync(resolve('__tests__/__output/test.json')));
     expect(output).to.have.property('bingo');
     expect(output).to.not.have.property('foo');
     Object.values(output).forEach((property) => {

--- a/__tests__/common/transforms.test.js
+++ b/__tests__/common/transforms.test.js
@@ -11,7 +11,7 @@
  * and limitations under the License.
  */
 import { expect } from 'chai';
-import path from '@bundled-es-modules/path-browserify';
+import { join } from 'path-unified';
 import Color from 'tinycolor2';
 import transforms from '../../lib/common/transforms.js';
 
@@ -830,7 +830,7 @@ describe('common', () => {
         var value = transforms['asset/path'].transformer({
           value: 'foo.json',
         });
-        expect(value).to.equal(path.join('foo.json'));
+        expect(value).to.equal(join('foo.json'));
       });
     });
   });

--- a/__tests__/utils/combineJSON.test.js
+++ b/__tests__/utils/combineJSON.test.js
@@ -11,7 +11,7 @@
  * and limitations under the License.
  */
 import { expect } from 'chai';
-import path from '@bundled-es-modules/path-browserify';
+import { join } from 'path-unified';
 import yaml from 'yaml';
 import { expectThrowsAsync } from '../__helpers.js';
 import combineJSON from '../../lib/utils/combineJSON.js';
@@ -29,7 +29,7 @@ describe('utils', () => {
     });
 
     it('should handle js modules that export objects', async () => {
-      const absPath = path.join('__tests__', '__json_files', '*.js');
+      const absPath = join('__tests__', '__json_files', '*.js');
       const relativePath = '__tests__/__json_files/*.js';
       const test = await combineJSON([absPath, relativePath]);
       expect(typeof test).to.equal('object');

--- a/__tests__/utils/convertToBase64.test.js
+++ b/__tests__/utils/convertToBase64.test.js
@@ -22,8 +22,16 @@ describe('utils', () => {
     });
 
     it('should error if filePath isnt a file', () => {
-      expect(convertToBase64.bind(null, 'foo')).to.throw(
-        "ENOENT: no such file or directory, open 'foo'",
+      let errMessage;
+      try {
+        convertToBase64('foo');
+      } catch (e) {
+        errMessage = e.message;
+      }
+      // Note: on windows fs.readFileSync ENOENT error puts the full path in the error
+      // on linux only the name of the filepath "foo"
+      expect(errMessage).to.satisfy((msg) =>
+        msg.startsWith('ENOENT: no such file or directory, open'),
       );
     });
 

--- a/bin/style-dictionary.js
+++ b/bin/style-dictionary.js
@@ -34,7 +34,7 @@ function getConfigPath(options) {
     }
   }
 
-  return path.resolve(configPath);
+  return configPath;
 }
 
 program.version(pkg.version).description(pkg.description).usage('[command] [options]');

--- a/lib/StyleDictionary.js
+++ b/lib/StyleDictionary.js
@@ -12,8 +12,9 @@
  */
 
 import JSON5 from 'json5';
-import path from '@bundled-es-modules/path-browserify';
+import { extname } from 'path-unified';
 import { fs } from 'style-dictionary/fs';
+import { resolve } from './resolve.js';
 import { deepmerge } from './utils/deepmerge.js';
 import { Register } from './Register.js';
 
@@ -150,13 +151,18 @@ export default class StyleDictionary extends Register {
     // JSON file or a plain object. Potentially refactor.
     if (typeof config === 'string') {
       // get ext name without leading .
-      const ext = path.extname(config).replace(/^\./, '');
+      const ext = extname(config).replace(/^\./, '');
+      // import path in Node has to be relative to cwd, in browser to root
+      const cfgFilePath = resolve(config);
       if (['json', 'json5', 'jsonc'].includes(ext)) {
-        options = JSON5.parse(/** @type {string} */ (fs.readFileSync(config, 'utf-8')));
+        options = JSON5.parse(/** @type {string} */ (fs.readFileSync(cfgFilePath, 'utf-8')));
       } else {
-        // import path in Node has to be relative to cwd, in browser to root
-        const fileToImport = path.resolve(typeof window === 'object' ? '' : process.cwd(), config);
-        options = (await import(/* webpackIgnore: true */ fileToImport)).default;
+        let _filePath = cfgFilePath;
+        if (typeof window !== 'object' && process?.platform === 'win32') {
+          // Windows FS compatibility. If in browser, we use an FS shim which doesn't require this Windows workaround
+          _filePath = new URL(`file:///${_filePath}`).href;
+        }
+        options = (await import(/* webpackIgnore: true */ _filePath)).default;
       }
     } else {
       options = config;

--- a/lib/buildFile.js
+++ b/lib/buildFile.js
@@ -11,7 +11,7 @@
  * and limitations under the License.
  */
 
-import path from '@bundled-es-modules/path-browserify';
+import { dirname } from 'path-unified';
 import chalk from 'chalk';
 import { fs } from 'style-dictionary/fs';
 import filterTokens from './filterTokens.js';
@@ -53,8 +53,8 @@ export default function buildFile(file, platform = {}, dictionary) {
     fullDestination = platform.buildPath + fullDestination;
   }
 
-  const dirname = path.dirname(fullDestination);
-  if (!fs.existsSync(dirname)) fs.mkdirSync(dirname, { recursive: true });
+  const dir = dirname(fullDestination);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
 
   const filteredTokens = filterTokens(dictionary, filter);
   const filteredDictionary = Object.assign({}, dictionary, {

--- a/lib/cleanDir.js
+++ b/lib/cleanDir.js
@@ -12,7 +12,7 @@
  */
 
 import chalk from 'chalk';
-import path from '@bundled-es-modules/path-browserify';
+import { dirname } from 'path-unified';
 import { fs } from 'style-dictionary/fs';
 
 /**
@@ -37,20 +37,20 @@ export default function cleanDir(file, platform = {}) {
     destination = platform.buildPath + destination;
   }
 
-  let dirname = path.dirname(destination);
+  let dir = dirname(destination);
 
-  while (dirname) {
-    if (fs.existsSync(dirname)) {
-      if (fs.readdirSync(dirname, 'buffer').length === 0) {
-        console.log(chalk.bold.red('-') + ' ' + dirname);
-        fs.rmdirSync(dirname);
+  while (dir) {
+    if (fs.existsSync(dir)) {
+      if (fs.readdirSync(dir, 'buffer').length === 0) {
+        console.log(chalk.bold.red('-') + ' ' + dir);
+        fs.rmdirSync(dir);
       } else {
         break;
       }
     }
 
-    dirname = dirname.split('/');
-    dirname.pop();
-    dirname = dirname.join('/');
+    const splitDir = dir.split('/');
+    splitDir.pop();
+    dir = splitDir.join('/');
   }
 }

--- a/lib/common/transforms.js
+++ b/lib/common/transforms.js
@@ -12,7 +12,7 @@
  */
 
 import Color from 'tinycolor2';
-import path from '@bundled-es-modules/path-browserify';
+import { join } from 'path-unified';
 import { snakeCase, kebabCase, camelCase } from 'change-case';
 import convertToBase64 from '../utils/convertToBase64.js';
 
@@ -1129,7 +1129,7 @@ export default {
     type: 'value',
     matcher: isAsset,
     transformer: function (token) {
-      return path.join(process.cwd(), token.value);
+      return join(process.cwd(), token.value);
     },
   },
 

--- a/lib/resolve.js
+++ b/lib/resolve.js
@@ -1,0 +1,9 @@
+import { posix, win32 } from 'path-unified';
+
+/**
+ * If we're on Windows AND we're not in browser context, use win32 resolve (with \'s)
+ * The reason why we want posix on browsers in windows is because @bundled-es-modules/memfs is used
+ * which is an in-memory filesystem shim that actually uses posix style paths, even on Windows.
+ */
+export const resolve =
+  process?.platform === 'win32' && typeof window !== 'object' ? win32.resolve : posix.resolve;

--- a/lib/utils/combineJSON.js
+++ b/lib/utils/combineJSON.js
@@ -12,9 +12,10 @@
  */
 
 import JSON5 from 'json5';
-import glob from '@bundled-es-modules/glob';
-import path from '@bundled-es-modules/path-browserify';
+import { globSync } from '@bundled-es-modules/glob';
+import { extname } from 'path-unified';
 import { fs } from 'style-dictionary/fs';
+import { resolve } from '../resolve.js';
 import deepExtend from './deepExtend.js';
 
 /**
@@ -60,7 +61,7 @@ export default async function combineJSON(
   let files = [];
 
   for (let i = 0; i < arr.length; i++) {
-    const new_files = glob.sync(arr[i], { fs }).sort();
+    const new_files = globSync(arr[i], { fs, posix: true }).sort();
     files = files.concat(new_files);
   }
 
@@ -76,7 +77,7 @@ export default async function combineJSON(
       parsers.forEach(({ pattern, parse }) => {
         if (filePath.match(pattern)) {
           file_content = parse({
-            contents: /** @type {string} */ (fs.readFileSync(filePath, { encoding: 'utf-8' })),
+            contents: /** @type {string} */ (fs.readFileSync(resolve(filePath), 'utf-8')),
             filePath,
           });
         }
@@ -84,14 +85,18 @@ export default async function combineJSON(
 
       // If there is no file_content then no custom parser ran on that file
       if (!file_content) {
-        if (['.js', '.mjs'].includes(path.extname(filePath))) {
-          const fileToImport = path.resolve(
-            typeof window === 'object' ? '' : process.cwd(),
-            filePath,
-          );
-          file_content = (await import(fileToImport)).default;
+        if (['.js', '.mjs'].includes(extname(filePath))) {
+          let _filePath = resolve(filePath);
+          // eslint-disable-next-line no-undef
+          if (typeof window !== 'object' && process?.platform === 'win32') {
+            // Windows FS compatibility. If in browser, we use an FS shim which doesn't require this Windows workaround
+            _filePath = new URL(`file:///${_filePath}`).href;
+          }
+          file_content = (await import(/* webpackIgnore: true */ _filePath)).default;
         } else {
-          file_content = JSON5.parse(/** @type {string} */ (fs.readFileSync(filePath, 'utf-8')));
+          file_content = JSON5.parse(
+            /** @type {string} */ (fs.readFileSync(resolve(filePath), 'utf-8')),
+          );
         }
       }
     } catch (e) {

--- a/lib/utils/convertToBase64.js
+++ b/lib/utils/convertToBase64.js
@@ -12,6 +12,7 @@
  */
 
 import { fs } from 'style-dictionary/fs';
+import { resolve } from '../resolve.js';
 
 /**
  * Takes a file and converts it to a base64 string.
@@ -22,6 +23,6 @@ import { fs } from 'style-dictionary/fs';
 export default function convertToBase64(filePath) {
   if (typeof filePath !== 'string') throw new Error('filePath name must be a string');
 
-  const body = /** @type {string} */ (fs.readFileSync(filePath, 'utf-8'));
+  const body = /** @type {string} */ (fs.readFileSync(resolve(filePath), 'utf-8'));
   return btoa(body);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,15 +11,15 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@bundled-es-modules/deepmerge": "^4.3.1",
-        "@bundled-es-modules/glob": "^10.3.5",
+        "@bundled-es-modules/glob": "^10.3.12",
         "@bundled-es-modules/memfs": "^4.2.3",
-        "@bundled-es-modules/path-browserify": "^1.0.2",
         "chalk": "^5.3.0",
         "change-case": "^5.3.0",
         "commander": "^8.3.0",
         "is-plain-obj": "^4.1.0",
         "json5": "^2.2.2",
         "lodash-es": "^4.17.21",
+        "path-unified": "^0.1.0",
         "tinycolor2": "^1.6.0"
       },
       "bin": {
@@ -2264,15 +2264,14 @@
       }
     },
     "node_modules/@bundled-es-modules/glob": {
-      "version": "10.3.5",
-      "resolved": "https://registry.npmjs.org/@bundled-es-modules/glob/-/glob-10.3.5.tgz",
-      "integrity": "sha512-Jn0WAgPKHfOm81mmF9RpzjTr/rdsOESoW9MVvaBBkXDhPhmeeqBugzfXlF0y56atlicKERqrXvW3D6jTQHU7Dw==",
+      "version": "10.3.12",
+      "resolved": "https://registry.npmjs.org/@bundled-es-modules/glob/-/glob-10.3.12.tgz",
+      "integrity": "sha512-bhuyc0iOXLikdJN4WTWTDMWO8HTRCkwsY/K6VVKoJhchVo0CdqQslYgTI2G5WM6yGJK/eMosQ+TWev0jEqSo0Q==",
       "hasInstallScript": true,
       "dependencies": {
         "buffer": "^6.0.3",
         "events": "^3.3.0",
-        "glob": "^10.3.3",
-        "patch-package": "^8.0.0",
+        "glob": "^10.3.10",
         "path": "^0.12.7",
         "stream": "^0.0.2",
         "string_decoder": "^1.3.0",
@@ -2288,18 +2287,18 @@
       }
     },
     "node_modules/@bundled-es-modules/glob/node_modules/glob": {
-      "version": "10.3.4",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.4.tgz",
-      "integrity": "sha512-6LFElP3A+i/Q8XQKEvZjkEWEOTgAIALR9AO2rwT8bgPhDd1anmqDJDZ6lLddI4ehxxxR1S5RIqKe1uapMQfYaQ==",
+      "version": "10.3.10",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
+      "integrity": "sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==",
       "dependencies": {
         "foreground-child": "^3.1.0",
-        "jackspeak": "^2.0.3",
+        "jackspeak": "^2.3.5",
         "minimatch": "^9.0.1",
         "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
         "path-scurry": "^1.10.1"
       },
       "bin": {
-        "glob": "dist/cjs/src/bin.js"
+        "glob": "dist/esm/bin.mjs"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -2320,14 +2319,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@bundled-es-modules/glob/node_modules/minipass": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.3.tgz",
-      "integrity": "sha512-LhbbwCfz3vsb12j/WkWQPZfKTsgqIe1Nf/ti1pKjYESGLHIVjWU96G9/ljLH4F9mWNVhlQOm0VySdAWzf05dpg==",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/@bundled-es-modules/glob/node_modules/safe-buffer": {
@@ -2370,14 +2361,6 @@
         "process": "^0.11.10",
         "stream": "^0.0.2",
         "util": "^0.12.5"
-      }
-    },
-    "node_modules/@bundled-es-modules/path-browserify": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@bundled-es-modules/path-browserify/-/path-browserify-1.0.2.tgz",
-      "integrity": "sha512-wC1f5y1etCEOO/3zUKlro5JCDKqZ3TAvjXUu9lSpaYHiKTyn0Iwlyfum789+V+DIAH32AJBb3JsWPalDvpvi6Q==",
-      "dependencies": {
-        "path-browserify": "^1.0.1"
       }
     },
     "node_modules/@changesets/apply-release-plan": {
@@ -5734,7 +5717,8 @@
     "node_modules/@yarnpkg/lockfile": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
-      "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ=="
+      "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
+      "dev": true
     },
     "node_modules/accepts": {
       "version": "1.3.8",
@@ -6130,6 +6114,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
       "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+      "dev": true,
       "engines": {
         "node": ">= 4.0.0"
       }
@@ -6373,6 +6358,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -6382,6 +6368,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
       "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
       "dependencies": {
         "fill-range": "^7.0.1"
       },
@@ -7087,7 +7074,8 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "node_modules/config-master": {
       "version": "3.1.0",
@@ -9204,6 +9192,7 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
       "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -9285,6 +9274,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
       "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
+      "dev": true,
       "dependencies": {
         "micromatch": "^4.0.2"
       }
@@ -9396,7 +9386,8 @@
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -9587,6 +9578,7 @@
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
       "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -9718,7 +9710,8 @@
     "node_modules/graceful-fs": {
       "version": "4.2.6",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
+      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
+      "dev": true
     },
     "node_modules/grapheme-splitter": {
       "version": "1.0.4",
@@ -9822,6 +9815,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -10167,6 +10161,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -10362,6 +10357,7 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
       "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "dev": true,
       "bin": {
         "is-docker": "cli.js"
       },
@@ -10519,6 +10515,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
       "engines": {
         "node": ">=0.12.0"
       }
@@ -10743,6 +10740,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
       "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
       "dependencies": {
         "is-docker": "^2.0.0"
       },
@@ -10871,9 +10869,9 @@
       }
     },
     "node_modules/jackspeak": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.3.3.tgz",
-      "integrity": "sha512-R2bUw+kVZFS/h1AZqBKrSgDmdmjApzgY0AlCPumopFiAlbUxE2gf+SCuBzQ0cP5hHmUmFYF5yw55T97Th5Kstg==",
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.3.6.tgz",
+      "integrity": "sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==",
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
       },
@@ -11144,6 +11142,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.2.tgz",
       "integrity": "sha512-eunSSaEnxV12z+Z73y/j5N37/In40GK4GmsSy+tEHJMxknvqnA7/djeYtAgW0GsWHUfg+847WJjKaEylk2y09g==",
+      "dev": true,
       "dependencies": {
         "jsonify": "^0.0.1"
       },
@@ -11172,6 +11171,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -11183,6 +11183,7 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
       "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -11270,6 +11271,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
       "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+      "dev": true,
       "dependencies": {
         "graceful-fs": "^4.1.11"
       }
@@ -12153,6 +12155,7 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
       "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+      "dev": true,
       "dependencies": {
         "braces": "^3.0.1",
         "picomatch": "^2.2.3"
@@ -12225,6 +12228,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -12235,7 +12239,8 @@
     "node_modules/minimist": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+      "dev": true
     },
     "node_modules/minimist-options": {
       "version": "4.1.0",
@@ -12258,6 +12263,14 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.4.tgz",
+      "integrity": "sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/mitt": {
@@ -13097,6 +13110,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -13162,6 +13176,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13459,6 +13474,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.0.tgz",
       "integrity": "sha512-da8BVIhzjtgScwDJ2TtKsfT5JFWz1hYoBl9rUQ1f38MC2HwnEIkK8VN3dKMKcP7P7bvvgzNDbfNHtx3MsQb5vA==",
+      "dev": true,
       "dependencies": {
         "@yarnpkg/lockfile": "^1.1.0",
         "chalk": "^4.1.2",
@@ -13488,6 +13504,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -13503,6 +13520,7 @@
       "version": "3.8.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.8.0.tgz",
       "integrity": "sha512-eXTggHWSooYhq49F2opQhuHWgzucfF2YgODK4e1566GQs5BIfP30B0oenwBJHfWxAs2fyPB1s7Mg949zLf61Yw==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -13517,6 +13535,7 @@
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
       "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
       "dependencies": {
         "at-least-node": "^1.0.0",
         "graceful-fs": "^4.2.0",
@@ -13531,6 +13550,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -13542,6 +13562,7 @@
       "version": "7.4.2",
       "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
       "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+      "dev": true,
       "dependencies": {
         "is-docker": "^2.0.0",
         "is-wsl": "^2.1.1"
@@ -13557,6 +13578,7 @@
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
       "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "dev": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -13568,6 +13590,7 @@
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
       "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -13582,6 +13605,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
       "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -13589,7 +13613,8 @@
     "node_modules/patch-package/node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/path": {
       "version": "0.12.7",
@@ -13599,11 +13624,6 @@
         "process": "^0.11.1",
         "util": "^0.10.3"
       }
-    },
-    "node_modules/path-browserify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
-      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -13618,6 +13638,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13652,19 +13673,11 @@
       }
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.1.tgz",
-      "integrity": "sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.1.0.tgz",
+      "integrity": "sha512-/1clY/ui8CzjKFyjdvwPWJUYKiFVXG2I2cY0ssG7h4+hwk+XOIX7ZSG9Q7TW8TW3Kp3BUSqgFWBLgL4PJ+Blag==",
       "engines": {
         "node": "14 || >=16.14"
-      }
-    },
-    "node_modules/path-scurry/node_modules/minipass": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.3.tgz",
-      "integrity": "sha512-LhbbwCfz3vsb12j/WkWQPZfKTsgqIe1Nf/ti1pKjYESGLHIVjWU96G9/ljLH4F9mWNVhlQOm0VySdAWzf05dpg==",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/path-type": {
@@ -13675,6 +13688,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/path-unified": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/path-unified/-/path-unified-0.1.0.tgz",
+      "integrity": "sha512-/Oaz9ZJforrkmFrwkR/AcvjVsCAwGSJHO0X6O6ISj8YeFbATjIEBXLDcZfnK3MO4uvCBrJTdVIxdOc79PMqSdg=="
     },
     "node_modules/path/node_modules/inherits": {
       "version": "2.0.3",
@@ -13714,6 +13732,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
       "engines": {
         "node": ">=8.6"
       },
@@ -15785,6 +15804,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -15961,6 +15981,7 @@
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
       "dependencies": {
         "os-tmpdir": "~1.0.2"
       },
@@ -15990,6 +16011,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -16430,6 +16452,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
       "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "dev": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -16807,7 +16830,8 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     },
     "node_modules/write-file-atomic": {
       "version": "3.0.3",
@@ -16873,6 +16897,7 @@
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.4.tgz",
       "integrity": "sha512-8aAvwVUSHpfEqTQ4w/KMlf3HcRdt50E5ODIQJBw1fQ5RL34xabzxtUlzTXVqc4rkZsPbvrXKWnABCD7kWSmocA==",
+      "dev": true,
       "engines": {
         "node": ">= 14"
       }

--- a/package.json
+++ b/package.json
@@ -100,9 +100,9 @@
   "homepage": "https://github.com/amzn/style-dictionary",
   "dependencies": {
     "@bundled-es-modules/deepmerge": "^4.3.1",
-    "@bundled-es-modules/glob": "^10.3.5",
+    "@bundled-es-modules/glob": "^10.3.12",
     "@bundled-es-modules/memfs": "^4.2.3",
-    "@bundled-es-modules/path-browserify": "^1.0.2",
+    "path-unified": "^0.1.0",
     "chalk": "^5.3.0",
     "change-case": "^5.3.0",
     "commander": "^8.3.0",

--- a/scripts/inject-version.js
+++ b/scripts/inject-version.js
@@ -1,11 +1,11 @@
 import fs from 'node:fs';
-import glob from 'glob';
+import { globSync } from 'glob';
 import { execSync } from 'child_process';
 
 const { version, name } = JSON.parse(fs.readFileSync('package.json', 'utf-8'));
 
 // examples
-const packageJSONs = glob.sync('./examples/*/*/package.json', {});
+const packageJSONs = globSync('./examples/*/*/package.json', {});
 packageJSONs.forEach(function (filePath) {
   let pkg = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
   if (pkg.devDependencies) {

--- a/types/typeless-modules/bundled-path.d.ts
+++ b/types/typeless-modules/bundled-path.d.ts
@@ -1,1 +1,0 @@
-declare module '@bundled-es-modules/path-browserify';

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -1,22 +1,22 @@
 import { playwrightLauncher } from '@web/test-runner-playwright';
 import { snapshotPlugin } from '@web/test-runner-commands/plugins';
 import fs from 'node:fs';
-import glob from '@bundled-es-modules/glob';
+import { globSync } from '@bundled-es-modules/glob';
 
-const filesToMirror = glob
-  .sync(
-    [
-      '__tests__/__assets/**/*',
-      '__tests__/__configs/**/*',
-      '__tests__/__json_files/**/*',
-      '__tests__/__tokens/**/*',
-      '__integration__/tokens/**/*',
-    ],
-    {
-      fs,
-      nodir: true,
-    },
-  ) // sort because for some reason glob result is not sorted like filesystem is (alphabetically)
+const filesToMirror = globSync(
+  [
+    '__tests__/__assets/**/*',
+    '__tests__/__configs/**/*',
+    '__tests__/__json_files/**/*',
+    '__tests__/__tokens/**/*',
+    '__integration__/tokens/**/*',
+  ],
+  {
+    fs,
+    nodir: true,
+    posix: true,
+  },
+) // sort because for some reason glob result is not sorted like filesystem is (alphabetically)
   .sort()
   .map((filePath) => [filePath, fs.readFileSync(filePath, 'utf-8')]);
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/amzn/style-dictionary/issues/1066 -> for v4

Upgrade glob to latest, but mainly, tests to verify on Windows in the CI.

Right now, I expect this will break some tests on Windows where filePath will contain `\\` instead of `/`.

If true, I'll set posix: true in the glob options and see if that fixes the tests on windows.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
