### PR TITLE
fix: escape double quotes for ts outputStringLiterals

### DIFF
--- a/.changeset/green-wolves-heal.md
+++ b/.changeset/green-wolves-heal.md
@@ -1,0 +1,5 @@
+---
+'style-dictionary': patch
+---
+
+Escape double quotes for ts outputStringLiterals

--- a/__tests__/common/formatHelpers/getTypeScriptType.test.js
+++ b/__tests__/common/formatHelpers/getTypeScriptType.test.js
@@ -62,9 +62,9 @@ describe('common', () => {
       });
 
       it('should handle outputStringLiterals', () => {
-        const stringValue = 'I am a string';
+        const stringValue = 'I "am" a string';
         const options = { outputStringLiterals: true };
-        expect(getTypeScriptType(stringValue, options)).to.equal(`"${stringValue}"`);
+        expect(getTypeScriptType(stringValue, options)).to.equal('"I \\"am\\" a string"');
       });
     });
   });

--- a/__tests__/formats/__snapshots__/typeScriptEs6Declarations.test.snap.js
+++ b/__tests__/formats/__snapshots__/typeScriptEs6Declarations.test.snap.js
@@ -9,6 +9,7 @@ snapshots["formats typescript/es6-declarations with outputStringLiterals should 
 
 /** Used for errors */
 export const colorRed : "#FF0000";
+export const fontFamily : "\\"Source Sans Pro\\", Arial, sans-serif";
 `;
 /* end snapshot formats typescript/es6-declarations with outputStringLiterals should match snapshot */
 

--- a/__tests__/formats/typeScriptEs6Declarations.test.js
+++ b/__tests__/formats/typeScriptEs6Declarations.test.js
@@ -28,6 +28,12 @@ const tokens = {
       value: '#FF0000',
     },
   },
+  font: {
+    family: {
+      name: 'fontFamily',
+      value: '"Source Sans Pro", Arial, sans-serif',
+    },
+  },
 };
 
 const format = formats['typescript/es6-declarations'];

--- a/lib/common/formatHelpers/getTypeScriptType.js
+++ b/lib/common/formatHelpers/getTypeScriptType.js
@@ -45,7 +45,7 @@ export default function getTypeScriptType(value, options = {}) {
 
   if (Array.isArray(value)) return getArrayType(value);
   if (typeof value === 'object') return getObjectType(value);
-  if (outputStringLiterals && typeof value === 'string') return `"${value}"`;
+  if (outputStringLiterals && typeof value === 'string') return `"${value.replace(/"/g, '\\"')}"`;
   if (['string', 'number', 'boolean'].includes(typeof value)) return typeof value;
 
   return 'any';


### PR DESCRIPTION
Escaping double quotes when generating string literal types is useful when a token value is referencing a font family name.