### PR TITLE
W3C Syntax refactor to allow value & type token names/groups

### DIFF
--- a/.changeset/cuddly-cheetahs-drum.md
+++ b/.changeset/cuddly-cheetahs-drum.md
@@ -1,0 +1,5 @@
+---
+'style-dictionary': minor
+---
+
+Rename `typeW3CDelegate` utility function to `typeDtcgDelegate`, as using "W3C" is highly discouraged when the standard isn't a W3C standard yet.

--- a/.changeset/grumpy-peaches-flow.md
+++ b/.changeset/grumpy-peaches-flow.md
@@ -2,4 +2,4 @@
 'style-dictionary': patch
 ---
 
-Fix small issue in type w3c delegate utility type tracking.
+Fix small issue in type DTCG delegate utility type tracking.

--- a/.changeset/neat-zoos-reflect.md
+++ b/.changeset/neat-zoos-reflect.md
@@ -2,4 +2,4 @@
 'style-dictionary': minor
 ---
 
-Support the use of "value"/"type"/"description" as token names or token group names, at the sacrifice of now no longer being able to combine non-W3C and W3C syntax within the same token dictionary.
+Support the use of "value"/"type"/"description" as token names or token group names, at the sacrifice of now no longer being able to combine non-DTCG and DTCG syntax within the same token dictionary.

--- a/.changeset/neat-zoos-reflect.md
+++ b/.changeset/neat-zoos-reflect.md
@@ -1,0 +1,5 @@
+---
+'style-dictionary': minor
+---
+
+Support the use of "value"/"type"/"description" as token names or token group names, at the sacrifice of now no longer being able to combine non-W3C and W3C syntax within the same token dictionary.

--- a/.changeset/ninety-geckos-build.md
+++ b/.changeset/ninety-geckos-build.md
@@ -2,4 +2,4 @@
 'style-dictionary': patch
 ---
 
-Expose typeW3CDelegate utility. Don't take "value" into account anymore to determine that it's a design token, use $value.
+Expose `typeDtcgDelegate` utility. Don't take `value` into account anymore to determine that it's a design token, use `$value`.

--- a/.changeset/rich-pianos-walk.md
+++ b/.changeset/rich-pianos-walk.md
@@ -2,4 +2,4 @@
 'style-dictionary': minor
 ---
 
-Support W3C Draft specification for Design Tokens, by adding support for $value, $type and $description properties.
+Support Design Token Community Group Draft specification for Design Tokens, by adding support for $value, $type and $description properties.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,14 +22,14 @@
 
 ### Patch Changes
 
-- 0c1a36f: Fix small issue in type w3c delegate utility type tracking.
-- 0c1a36f: Expose typeW3CDelegate utility. Don't take "value" into account anymore to determine that it's a design token, use $value.
+- 0c1a36f: Fix small issue in type DTCG delegate utility type tracking.
+- 0c1a36f: Expose `typeDtcgDelegate` utility. Don't take `value` into account anymore to determine that it's a design token, use `$value`.
 
 ## 4.0.0-prerelease.9
 
 ### Minor Changes
 
-- 294fd0e: Support W3C Draft specification for Design Tokens, by adding support for $value, $type and $description properties.
+- 294fd0e: Support Design Token Community Group Draft specification for Design Tokens, by adding support for $value, $type and $description properties.
 
 ### Patch Changes
 

--- a/__integration__/__snapshots__/customFormats.test.snap.js
+++ b/__integration__/__snapshots__/customFormats.test.snap.js
@@ -962,7 +962,8 @@ snapshots["inline custom with new args should match snapshot"] =
   },
   "options": {
     "otherOption": "Test",
-    "showFileHeader": true
+    "showFileHeader": true,
+    "usesW3C": false
   }
 }`;
 /* end snapshot inline custom with new args should match snapshot */
@@ -1893,7 +1894,8 @@ snapshots["register custom format with new args should match snapshot"] =
   },
   "options": {
     "otherOption": "Test",
-    "showFileHeader": true
+    "showFileHeader": true,
+    "usesW3C": false
   }
 }`;
 /* end snapshot register custom format with new args should match snapshot */

--- a/__integration__/__snapshots__/customFormats.test.snap.js
+++ b/__integration__/__snapshots__/customFormats.test.snap.js
@@ -963,7 +963,7 @@ snapshots["inline custom with new args should match snapshot"] =
   "options": {
     "otherOption": "Test",
     "showFileHeader": true,
-    "usesW3C": false
+    "usesDtcg": false
   }
 }`;
 /* end snapshot inline custom with new args should match snapshot */
@@ -1895,7 +1895,7 @@ snapshots["register custom format with new args should match snapshot"] =
   "options": {
     "otherOption": "Test",
     "showFileHeader": true,
-    "usesW3C": false
+    "usesDtcg": false
   }
 }`;
 /* end snapshot register custom format with new args should match snapshot */

--- a/__integration__/w3c-forward-compat.test.js
+++ b/__integration__/w3c-forward-compat.test.js
@@ -58,14 +58,14 @@ describe('integration', () => {
           type: 'value',
           matcher: (token) => token.$type === 'color',
           transformer: (token) => {
-            return Color(token.$value).toRgbString();
+            return Color(sd.options.usesW3C ? token.$value : token.value).toRgbString();
           },
         },
         'custom/add/px': {
           type: 'value',
           matcher: (token) => token.$type === 'dimension',
           transformer: (token) => {
-            return `${token.$value}px`;
+            return `${sd.options.usesW3C ? token.$value : token.value}px`;
           },
         },
       },

--- a/__integration__/w3c-forward-compat.test.js
+++ b/__integration__/w3c-forward-compat.test.js
@@ -29,7 +29,7 @@ describe('integration', () => {
    * - $type special property & inherits from ancestors
    * - $description special property
    */
-  describe('W3C DTCG draft spec forward compatibility', async () => {
+  describe('DTCG draft spec forward compatibility', async () => {
     const sd = new StyleDictionary({
       tokens: {
         colors: {
@@ -58,14 +58,14 @@ describe('integration', () => {
           type: 'value',
           matcher: (token) => token.$type === 'color',
           transformer: (token) => {
-            return Color(sd.options.usesW3C ? token.$value : token.value).toRgbString();
+            return Color(sd.options.usesDtcg ? token.$value : token.value).toRgbString();
           },
         },
         'custom/add/px': {
           type: 'value',
           matcher: (token) => token.$type === 'dimension',
           transformer: (token) => {
-            return `${sd.options.usesW3C ? token.$value : token.value}px`;
+            return `${sd.options.usesDtcg ? token.$value : token.value}px`;
           },
         },
       },

--- a/__tests__/StyleDictionary.test.js
+++ b/__tests__/StyleDictionary.test.js
@@ -326,4 +326,17 @@ describe('StyleDictionary class + extend method', () => {
     expect(sd.tokens.dimensions.nested.deep.lg.$type).to.equal('dimension');
     expect(sd.tokens.dimensions.nope.$type).to.equal('spacing');
   });
+
+  it('should detect usage of W3C draft spec tokens', async () => {
+    const sd = new StyleDictionary({
+      tokens: {
+        datalist: {
+          key: { color: { $value: '#222' } },
+          value: { color: { $value: '#000' } },
+        },
+      },
+    });
+    await sd.hasInitialized;
+    expect(sd.options.usesW3C).to.be.true;
+  });
 });

--- a/__tests__/StyleDictionary.test.js
+++ b/__tests__/StyleDictionary.test.js
@@ -327,7 +327,7 @@ describe('StyleDictionary class + extend method', () => {
     expect(sd.tokens.dimensions.nope.$type).to.equal('spacing');
   });
 
-  it('should detect usage of W3C draft spec tokens', async () => {
+  it('should detect usage of DTCG draft spec tokens', async () => {
     const sd = new StyleDictionary({
       tokens: {
         datalist: {
@@ -337,6 +337,6 @@ describe('StyleDictionary class + extend method', () => {
       },
     });
     await sd.hasInitialized;
-    expect(sd.options.usesW3C).to.be.true;
+    expect(sd.options.usesDtcg).to.be.true;
   });
 });

--- a/__tests__/buildFile.test.js
+++ b/__tests__/buildFile.test.js
@@ -39,23 +39,25 @@ describe('buildFile', () => {
   });
 
   it('should error if format doesnt exist or isnt a function', () => {
-    expect(buildFile.bind(null, { destination: '__tests__output/test.txt' }, {}, {})).to.throw(
+    expect(buildFile.bind(null, { destination: '__tests__output/test.txt' }, {}, {}, {})).to.throw(
       'Please enter a valid file format',
     );
     expect(
-      buildFile.bind(null, { destination: '__tests__output/test.txt', format: {} }, {}, {}),
+      buildFile.bind(null, { destination: '__tests__output/test.txt', format: {} }, {}, {}, {}),
     ).to.throw('Please enter a valid file format');
     expect(
-      buildFile.bind(null, { destination: '__tests__/__output/test.txt', format: [] }, {}, {}),
+      buildFile.bind(null, { destination: '__tests__/__output/test.txt', format: [] }, {}, {}, {}),
     ).to.throw('Please enter a valid file format');
   });
 
   it('should error if destination doesnt exist or isnt a string', () => {
-    expect(buildFile.bind(null, { format }, {}, {})).to.throw('Please enter a valid destination');
-    expect(buildFile.bind(null, { format, destination: [] }, {}, {})).to.throw(
+    expect(buildFile.bind(null, { format }, {}, {}, {})).to.throw(
       'Please enter a valid destination',
     );
-    expect(buildFile.bind(null, { format, destination: {} }, {}, {})).to.throw(
+    expect(buildFile.bind(null, { format, destination: [] }, {}, {}, {})).to.throw(
+      'Please enter a valid destination',
+    );
+    expect(buildFile.bind(null, { format, destination: {} }, {}, {}, {})).to.throw(
       'Please enter a valid destination',
     );
   });
@@ -81,7 +83,7 @@ describe('buildFile', () => {
 
     it('should generate warning messages for output name collisions', () => {
       GroupMessages.clear(PROPERTY_NAME_COLLISION_WARNINGS);
-      buildFile({ destination, format }, {}, dictionary);
+      buildFile({ destination, format }, {}, dictionary, {});
 
       const collisions = dictionary.allTokens
         .map(
@@ -107,7 +109,7 @@ describe('buildFile', () => {
 
     it('should not warn users if the format is a nested format', () => {
       const consoleStub = stubMethod(console, 'log');
-      buildFile({ destination, format: nestedFormat }, {}, dictionary);
+      buildFile({ destination, format: nestedFormat }, {}, dictionary, {});
       expect(consoleStub.calledWith(chalk.bold.green(`✔︎ ${destination}`))).to.be.true;
     });
   });
@@ -137,6 +139,7 @@ describe('buildFile', () => {
       },
       {},
       dictionary,
+      {},
     );
     expect(fileExists('__tests__/__output/test.emptyTokens')).to.be.false;
   });
@@ -150,6 +153,7 @@ describe('buildFile', () => {
       {
         buildPath: '__tests__/__output/',
       },
+      {},
       {},
     );
     expect(fileExists('__tests__/__output/test.txt')).to.be.true;

--- a/__tests__/buildFiles.test.js
+++ b/__tests__/buildFiles.test.js
@@ -104,17 +104,17 @@ describe('buildFiles', () => {
   });
 
   it('should work without buildPath', () => {
-    buildFiles(dictionary, platform);
+    buildFiles(dictionary, platform, {});
     expect(fileExists('__tests__/__output/test.json')).to.be.true;
   });
 
   it('should work with buildPath', () => {
-    buildFiles(dictionary, platformWithBuildPath);
+    buildFiles(dictionary, platformWithBuildPath, {});
     expect(fileExists('__tests__/__output/test.json')).to.be.true;
   });
 
   it('should work with a filter', () => {
-    buildFiles(dictionary, platformWithFilter);
+    buildFiles(dictionary, platformWithFilter, {});
     expect(fileExists('__tests__/__output/test.json')).to.be.true;
     const output = JSON.parse(fs.readFileSync(resolve('__tests__/__output/test.json')));
     expect(output).to.have.property('bingo');

--- a/__tests__/cleanDir.test.js
+++ b/__tests__/cleanDir.test.js
@@ -34,6 +34,7 @@ describe('cleanDir', () => {
       { destination: 'test.txt', format },
       { buildPath: '__tests__/__output/extradir1/extradir2/' },
       {},
+      {},
     );
     cleanFile(
       { destination: 'test.txt', format },

--- a/__tests__/cleanDirs.test.js
+++ b/__tests__/cleanDirs.test.js
@@ -55,7 +55,7 @@ describe('cleanDirs', () => {
   });
 
   it('should delete without buildPath', () => {
-    buildFiles(dictionary, platform);
+    buildFiles(dictionary, platform, {});
     cleanFiles(platform);
     cleanDirs(platform);
     expect(dirExists('__tests__/__output/extradir1/extradir2')).to.be.false;
@@ -63,7 +63,7 @@ describe('cleanDirs', () => {
   });
 
   it('should delete with buildPath', () => {
-    buildFiles(dictionary, platformWithBuildPath);
+    buildFiles(dictionary, platformWithBuildPath, {});
     cleanFiles(platformWithBuildPath);
     cleanDirs(platformWithBuildPath);
     expect(dirExists('__tests__/__output/extradir1/extradir2')).to.be.false;

--- a/__tests__/cleanFile.test.js
+++ b/__tests__/cleanFile.test.js
@@ -29,7 +29,7 @@ describe('cleanFile', () => {
   });
 
   it('should delete a file properly', () => {
-    buildFile({ destination: 'test.txt', format }, { buildPath: '__tests__/__output/' }, {});
+    buildFile({ destination: 'test.txt', format }, { buildPath: '__tests__/__output/' }, {}, {});
     cleanFile({ destination: 'test.txt', format }, { buildPath: '__tests__/__output/' }, {});
     expect(fileExists('__tests__/__output/test.txt')).to.be.false;
   });

--- a/__tests__/cleanFiles.test.js
+++ b/__tests__/cleanFiles.test.js
@@ -54,13 +54,13 @@ describe('cleanFiles', () => {
   });
 
   it('should delete without buildPath', () => {
-    buildFiles(dictionary, platform);
+    buildFiles(dictionary, platform, {});
     cleanFiles(platform);
     expect(fileExists('__tests__/__output/test.json')).to.be.false;
   });
 
   it('should delete with buildPath', () => {
-    buildFiles(dictionary, platformWithBuildPath);
+    buildFiles(dictionary, platformWithBuildPath, {});
     cleanFiles(platformWithBuildPath);
     expect(fileExists('__tests__/t__/__output/test.json')).to.be.false;
   });

--- a/__tests__/common/formatHelpers/__snapshots__/createPropertyFormatter.test.snap.js
+++ b/__tests__/common/formatHelpers/__snapshots__/createPropertyFormatter.test.snap.js
@@ -34,15 +34,15 @@ snapshots["common formatHelpers createPropertyFormatter commentStyle allows over
 $color-green: #00FF00;`;
 /* end snapshot common formatHelpers createPropertyFormatter commentStyle allows overriding formatting commentStyle 2 */
 
-snapshots["common formatHelpers createPropertyFormatter commentStyle supports W3C spec $description property for comments 1"] = 
+snapshots["common formatHelpers createPropertyFormatter commentStyle supports DTCG spec $description property for comments 1"] = 
 `  --color-red: #FF0000; /* Foo bar qux red */`;
-/* end snapshot common formatHelpers createPropertyFormatter commentStyle supports W3C spec $description property for comments 1 */
+/* end snapshot common formatHelpers createPropertyFormatter commentStyle supports DTCG spec $description property for comments 1 */
 
-snapshots["common formatHelpers createPropertyFormatter commentStyle supports W3C spec $description property for comments 2"] = 
+snapshots["common formatHelpers createPropertyFormatter commentStyle supports DTCG spec $description property for comments 2"] = 
 `  --color-green: #00FF00; /* Foo bar qux green */`;
-/* end snapshot common formatHelpers createPropertyFormatter commentStyle supports W3C spec $description property for comments 2 */
+/* end snapshot common formatHelpers createPropertyFormatter commentStyle supports DTCG spec $description property for comments 2 */
 
-snapshots["common formatHelpers createPropertyFormatter commentStyle supports W3C spec $description property for comments 3"] = 
+snapshots["common formatHelpers createPropertyFormatter commentStyle supports DTCG spec $description property for comments 3"] = 
 `  /**
    * Foo
    * bar
@@ -50,5 +50,5 @@ snapshots["common formatHelpers createPropertyFormatter commentStyle supports W3
    * blue
    */
   --color-blue: #0000FF;`;
-/* end snapshot common formatHelpers createPropertyFormatter commentStyle supports W3C spec $description property for comments 3 */
+/* end snapshot common formatHelpers createPropertyFormatter commentStyle supports DTCG spec $description property for comments 3 */
 

--- a/__tests__/common/formatHelpers/createPropertyFormatter.test.js
+++ b/__tests__/common/formatHelpers/createPropertyFormatter.test.js
@@ -359,7 +359,7 @@ describe('common', () => {
           await expect(sassRed).to.matchSnapshot(2);
         });
 
-        it('supports W3C spec $description property for comments', async () => {
+        it('supports DTCG spec $description property for comments', async () => {
           const descriptionDictionary = {
             color: {
               red: {

--- a/__tests__/common/transforms.test.js
+++ b/__tests__/common/transforms.test.js
@@ -175,20 +175,32 @@ describe('common', () => {
 
     describe('attribute/color', () => {
       it('should handle normal colors', () => {
-        const attributes = transforms['attribute/color'].transformer({
-          value: '#aaaaaa',
-        });
+        const attributes = transforms['attribute/color'].transformer(
+          {
+            value: '#aaaaaa',
+          },
+          {},
+          {},
+        );
         expect(attributes).to.have.nested.property('rgb.a', 1);
         expect(attributes).to.have.nested.property('rgb.r', 170);
         expect(attributes).to.have.nested.property('hsl.s', 0);
       });
       it('should handle colors with transparency', () => {
-        const attributes = transforms['attribute/color'].transformer({
-          value: '#aaaaaa99',
-        });
-        const attributes2 = transforms['attribute/color'].transformer({
-          value: 'rgba(170,170,170,0.6)',
-        });
+        const attributes = transforms['attribute/color'].transformer(
+          {
+            value: '#aaaaaa99',
+          },
+          {},
+          {},
+        );
+        const attributes2 = transforms['attribute/color'].transformer(
+          {
+            value: 'rgba(170,170,170,0.6)',
+          },
+          {},
+          {},
+        );
         expect(attributes).to.have.nested.property('rgb.a', 0.6);
         expect(attributes).to.have.nested.property('rgb.r', 170);
         expect(attributes).to.have.nested.property('hsl.s', 0);
@@ -209,9 +221,9 @@ describe('common', () => {
           attributes: { category: 'size', component: 'button' },
         };
 
-        const attrs = transforms['attribute/cti'].transformer(prop);
-        const attrsShort = transforms['attribute/cti'].transformer(propShort);
-        const attrsOverride = transforms['attribute/cti'].transformer(propOverride);
+        const attrs = transforms['attribute/cti'].transformer(prop, {}, {});
+        const attrsShort = transforms['attribute/cti'].transformer(propShort, {}, {});
+        const attrsOverride = transforms['attribute/cti'].transformer(propOverride, {}, {});
 
         it('should assign attributes correctly', () => {
           expect(attrs).eql({
@@ -242,52 +254,80 @@ describe('common', () => {
 
     describe('color/hex', () => {
       it('should handle hex colors', () => {
-        const value = transforms['color/hex'].transformer({
-          value: '#aaaaaa',
-        });
+        const value = transforms['color/hex'].transformer(
+          {
+            value: '#aaaaaa',
+          },
+          {},
+          {},
+        );
         expect(value).to.equal('#aaaaaa');
       });
 
       it('should handle hex8 colors', () => {
-        const value = transforms['color/hex'].transformer({
-          value: '#aaaaaaaa',
-        });
+        const value = transforms['color/hex'].transformer(
+          {
+            value: '#aaaaaaaa',
+          },
+          {},
+          {},
+        );
         expect(value).to.equal('#aaaaaa');
       });
 
       it('should handle rgb colors', () => {
-        const value = transforms['color/hex'].transformer({
-          value: 'rgb(170,170,170)',
-        });
+        const value = transforms['color/hex'].transformer(
+          {
+            value: 'rgb(170,170,170)',
+          },
+          {},
+          {},
+        );
         expect(value).to.equal('#aaaaaa');
       });
 
       it('should handle rgb (object) colors', () => {
-        const value = transforms['color/hex'].transformer({
-          value: {
-            r: '170',
-            g: '170',
-            b: '170',
+        const value = transforms['color/hex'].transformer(
+          {
+            value: {
+              r: '170',
+              g: '170',
+              b: '170',
+            },
           },
-        });
-        const value2 = transforms['color/hex'].transformer({
-          value: 'rgb(170,170,170)',
-        });
+          {},
+          {},
+        );
+        const value2 = transforms['color/hex'].transformer(
+          {
+            value: 'rgb(170,170,170)',
+          },
+          {},
+          {},
+        );
         expect(value).to.equal('#aaaaaa');
         expect(value2).to.equal('#aaaaaa');
       });
 
       it('should handle hsl colors', () => {
-        const value = transforms['color/hex'].transformer({
-          value: {
-            h: '0',
-            s: '0',
-            l: '0.5',
+        const value = transforms['color/hex'].transformer(
+          {
+            value: {
+              h: '0',
+              s: '0',
+              l: '0.5',
+            },
           },
-        });
-        const value2 = transforms['color/hex'].transformer({
-          value: 'hsl(0,0,0.5)',
-        });
+          {},
+          {},
+        );
+        const value2 = transforms['color/hex'].transformer(
+          {
+            value: 'hsl(0,0,0.5)',
+          },
+          {},
+          {},
+        );
         expect(value).to.equal('#808080');
         expect(value2).to.equal('#808080');
       });
@@ -295,130 +335,194 @@ describe('common', () => {
 
     describe('color/hex8', () => {
       it('should handle hex colors', () => {
-        const value = transforms['color/hex8'].transformer({
-          value: '#aaaaaa',
-        });
+        const value = transforms['color/hex8'].transformer(
+          {
+            value: '#aaaaaa',
+          },
+          {},
+          {},
+        );
         expect(value).to.equal('#aaaaaaff');
       });
 
       it('should handle rgb colors', () => {
-        const value = transforms['color/hex8'].transformer({
-          value: 'rgb(170,170,170)',
-        });
+        const value = transforms['color/hex8'].transformer(
+          {
+            value: 'rgb(170,170,170)',
+          },
+          {},
+          {},
+        );
         expect(value).to.equal('#aaaaaaff');
       });
 
       it('should handle rgba colors', () => {
-        const value = transforms['color/hex8'].transformer({
-          value: 'rgba(170,170,170,0.6)',
-        });
+        const value = transforms['color/hex8'].transformer(
+          {
+            value: 'rgba(170,170,170,0.6)',
+          },
+          {},
+          {},
+        );
         expect(value).to.equal('#aaaaaa99');
       });
     });
 
     describe('color/hex8android', () => {
       it('should handle colors without alpha', () => {
-        const value = transforms['color/hex8android'].transformer({
-          value: '#aaaaaa',
-        });
+        const value = transforms['color/hex8android'].transformer(
+          {
+            value: '#aaaaaa',
+          },
+          {},
+          {},
+        );
         expect(value).to.equal('#ffaaaaaa');
       });
 
       it('should handle colors with alpha', () => {
-        const value = transforms['color/hex8android'].transformer({
-          value: '#aaaaaa99',
-        });
+        const value = transforms['color/hex8android'].transformer(
+          {
+            value: '#aaaaaa99',
+          },
+          {},
+          {},
+        );
         expect(value).to.equal('#99aaaaaa');
       });
     });
 
     describe('color/rgb', () => {
       it('should handle normal colors', () => {
-        const value = transforms['color/rgb'].transformer({
-          value: '#aaaaaa',
-        });
+        const value = transforms['color/rgb'].transformer(
+          {
+            value: '#aaaaaa',
+          },
+          {},
+          {},
+        );
         expect(value).to.equal('rgb(170, 170, 170)');
       });
 
       it('should handle colors with transparency', () => {
-        const value = transforms['color/rgb'].transformer({
-          value: '#aaaaaa99',
-        });
+        const value = transforms['color/rgb'].transformer(
+          {
+            value: '#aaaaaa99',
+          },
+          {},
+          {},
+        );
         expect(value).to.equal('rgba(170, 170, 170, 0.6)');
       });
     });
 
     describe('color/hsl-4', () => {
       it('should handle normal colors', () => {
-        const value = transforms['color/hsl-4'].transformer({
-          value: '#009688',
-        });
+        const value = transforms['color/hsl-4'].transformer(
+          {
+            value: '#009688',
+          },
+          {},
+          {},
+        );
         expect(value).to.equal('hsl(174 100% 29%)');
       });
 
       it('should handle colors with transparency', () => {
-        const value = transforms['color/hsl-4'].transformer({
-          value: '#00968899',
-        });
+        const value = transforms['color/hsl-4'].transformer(
+          {
+            value: '#00968899',
+          },
+          {},
+          {},
+        );
         expect(value).to.equal('hsl(174 100% 29% / 0.6)');
       });
     });
 
     describe('color/hsl', () => {
       it('should handle normal colors', () => {
-        const value = transforms['color/hsl'].transformer({
-          value: '#009688',
-        });
+        const value = transforms['color/hsl'].transformer(
+          {
+            value: '#009688',
+          },
+          {},
+          {},
+        );
         expect(value).to.equal('hsl(174, 100%, 29%)');
       });
 
       it('should handle colors with transparency', () => {
-        const value = transforms['color/hsl'].transformer({
-          value: '#00968899',
-        });
+        const value = transforms['color/hsl'].transformer(
+          {
+            value: '#00968899',
+          },
+          {},
+          {},
+        );
         expect(value).to.equal('hsla(174, 100%, 29%, 0.6)');
       });
     });
 
     describe('color/composeColor', () => {
       it('should handle color without alpha', () => {
-        const value = transforms['color/composeColor'].transformer({
-          value: '#aaaaaa',
-        });
+        const value = transforms['color/composeColor'].transformer(
+          {
+            value: '#aaaaaa',
+          },
+          {},
+          {},
+        );
         expect(value).to.equal('Color(0xffaaaaaa)');
       });
 
       it('should handle color with alpha', () => {
-        const value = transforms['color/composeColor'].transformer({
-          value: '#aaaaaaff',
-        });
+        const value = transforms['color/composeColor'].transformer(
+          {
+            value: '#aaaaaaff',
+          },
+          {},
+          {},
+        );
         expect(value).to.equal('Color(0xffaaaaaa)');
       });
     });
 
     describe('color/UIColor', () => {
       it('should handle normal colors', () => {
-        const value = transforms['color/UIColor'].transformer({
-          value: '#aaaaaa',
-        });
+        const value = transforms['color/UIColor'].transformer(
+          {
+            value: '#aaaaaa',
+          },
+          {},
+          {},
+        );
         expect(value).to.equal(
           '[UIColor colorWithRed:0.667f green:0.667f blue:0.667f alpha:1.000f]',
         );
       });
 
       it('should retain enough precision when converting to decimal', () => {
-        const value = transforms['color/UIColor'].transformer({
-          value: '#1d1d1d',
-        });
+        const value = transforms['color/UIColor'].transformer(
+          {
+            value: '#1d1d1d',
+          },
+          {},
+          {},
+        );
         expect(value).to.equal(
           '[UIColor colorWithRed:0.114f green:0.114f blue:0.114f alpha:1.000f]',
         );
       });
 
       it('should handle colors with transparency', () => {
-        const value = transforms['color/UIColor'].transformer({
-          value: '#aaaaaa99',
-        });
+        const value = transforms['color/UIColor'].transformer(
+          {
+            value: '#aaaaaa99',
+          },
+          {},
+          {},
+        );
         expect(value).to.equal(
           '[UIColor colorWithRed:0.667f green:0.667f blue:0.667f alpha:0.600f]',
         );
@@ -427,78 +531,118 @@ describe('common', () => {
 
     describe('color/UIColorSwift', () => {
       it('should handle normal colors', () => {
-        const value = transforms['color/UIColorSwift'].transformer({
-          value: '#aaaaaa',
-        });
+        const value = transforms['color/UIColorSwift'].transformer(
+          {
+            value: '#aaaaaa',
+          },
+          {},
+          {},
+        );
         expect(value).to.equal('UIColor(red: 0.667, green: 0.667, blue: 0.667, alpha: 1)');
       });
 
       it('should retain enough precision when converting to decimal', () => {
-        const value = transforms['color/UIColorSwift'].transformer({
-          value: '#1d1d1d',
-        });
+        const value = transforms['color/UIColorSwift'].transformer(
+          {
+            value: '#1d1d1d',
+          },
+          {},
+          {},
+        );
         expect(value).to.equal('UIColor(red: 0.114, green: 0.114, blue: 0.114, alpha: 1)');
       });
 
       it('should handle colors with transparency', () => {
-        const value = transforms['color/UIColorSwift'].transformer({
-          value: '#aaaaaa99',
-        });
+        const value = transforms['color/UIColorSwift'].transformer(
+          {
+            value: '#aaaaaa99',
+          },
+          {},
+          {},
+        );
         expect(value).to.equal('UIColor(red: 0.667, green: 0.667, blue: 0.667, alpha: 0.6)');
       });
     });
 
     describe('color/ColorSwiftUI', () => {
       it('should handle normal colors', () => {
-        const value = transforms['color/ColorSwiftUI'].transformer({
-          value: '#aaaaaa',
-        });
+        const value = transforms['color/ColorSwiftUI'].transformer(
+          {
+            value: '#aaaaaa',
+          },
+          {},
+          {},
+        );
         expect(value).to.equal('Color(red: 0.667, green: 0.667, blue: 0.667, opacity: 1)');
       });
 
       it('should retain enough precision when converting to decimal', () => {
-        const value = transforms['color/ColorSwiftUI'].transformer({
-          value: '#1d1d1d',
-        });
+        const value = transforms['color/ColorSwiftUI'].transformer(
+          {
+            value: '#1d1d1d',
+          },
+          {},
+          {},
+        );
         expect(value).to.equal('Color(red: 0.114, green: 0.114, blue: 0.114, opacity: 1)');
       });
 
       it('should handle colors with transparency', () => {
-        const value = transforms['color/ColorSwiftUI'].transformer({
-          value: '#aaaaaa99',
-        });
+        const value = transforms['color/ColorSwiftUI'].transformer(
+          {
+            value: '#aaaaaa99',
+          },
+          {},
+          {},
+        );
         expect(value).to.equal('Color(red: 0.667, green: 0.667, blue: 0.667, opacity: 0.6)');
       });
     });
 
     describe('color/hex8flutter', () => {
       it('should handle colors without alpha', () => {
-        const value = transforms['color/hex8flutter'].transformer({
-          value: '#aaaaaa',
-        });
+        const value = transforms['color/hex8flutter'].transformer(
+          {
+            value: '#aaaaaa',
+          },
+          {},
+          {},
+        );
         expect(value).to.equal('Color(0xFFAAAAAA)');
       });
 
       it('should handle colors with alpha', () => {
-        const value = transforms['color/hex8flutter'].transformer({
-          value: '#aaaaaa99',
-        });
+        const value = transforms['color/hex8flutter'].transformer(
+          {
+            value: '#aaaaaa99',
+          },
+          {},
+          {},
+        );
         expect(value).to.equal('Color(0x99AAAAAA)');
       });
     });
 
     describe('color/css', () => {
       it('should handle normal colors', () => {
-        const value = transforms['color/css'].transformer({
-          value: 'rgb(170, 170, 170)',
-        });
+        const value = transforms['color/css'].transformer(
+          {
+            value: 'rgb(170, 170, 170)',
+          },
+          {},
+          {},
+        );
         expect(value).to.equal('#aaaaaa');
       });
 
       it('should handle colors with transparency', () => {
-        const value = transforms['color/css'].transformer({
-          value: '#aaaaaa99',
-        });
+        const value = transforms['color/css'].transformer(
+          {
+            value: '#aaaaaa99',
+          },
+          {},
+          {},
+        );
         expect(value).to.equal('rgba(170, 170, 170, 0.6)');
       });
     });
@@ -506,11 +650,13 @@ describe('common', () => {
     describe('color/sketch', () => {
       it('should retain hex specificity', () => {
         const originalHex = '#0b7dbb';
-        const value = transforms['color/sketch'].transformer({
-          original: {
+        const value = transforms['color/sketch'].transformer(
+          {
             value: originalHex,
           },
-        });
+          {},
+          {},
+        );
         const newHex = Color({
           r: value.red * 255,
           g: value.green * 255,
@@ -522,28 +668,44 @@ describe('common', () => {
 
     describe('size/sp', () => {
       it('should work', () => {
-        const value = transforms['size/sp'].transformer({
-          value: '12px',
-        });
-        const value2 = transforms['size/sp'].transformer({
-          value: '12',
-        });
+        const value = transforms['size/sp'].transformer(
+          {
+            value: '12px',
+          },
+          {},
+          {},
+        );
+        const value2 = transforms['size/sp'].transformer(
+          {
+            value: '12',
+          },
+          {},
+          {},
+        );
         expect(value).to.equal('12.00sp');
         expect(value2).to.equal('12.00sp');
       });
       it('should throw an error if prop value is Nan', () => {
-        expect(() => transforms['size/sp'].transformer({ value: 'a' })).to.throw();
+        expect(() => transforms['size/sp'].transformer({ value: 'a' }, {}, {})).to.throw();
       });
     });
 
     describe('size/dp', () => {
       it('should work', () => {
-        const value = transforms['size/dp'].transformer({
-          value: '12px',
-        });
-        const value2 = transforms['size/dp'].transformer({
-          value: '12',
-        });
+        const value = transforms['size/dp'].transformer(
+          {
+            value: '12px',
+          },
+          {},
+          {},
+        );
+        const value2 = transforms['size/dp'].transformer(
+          {
+            value: '12',
+          },
+          {},
+          {},
+        );
         expect(value).to.equal('12.00dp');
         expect(value2).to.equal('12.00dp');
       });
@@ -554,180 +716,237 @@ describe('common', () => {
 
     describe('size/object', () => {
       it('should work', () => {
-        const value = transforms['size/object'].transformer({
-          value: '1px',
-        });
+        const value = transforms['size/object'].transformer(
+          {
+            value: '1px',
+          },
+          {},
+          {},
+        );
         expect(value.original).to.equal('1px');
         expect(value.number).to.equal(1);
         expect(value.decimal).equal(0.01);
         expect(value.scale).to.equal(16);
       });
       it('should work with custom base font', () => {
-        const value = transforms['size/object'].transformer({ value: '1' }, { basePxFontSize: 14 });
+        const value = transforms['size/object'].transformer(
+          { value: '1' },
+          { basePxFontSize: 14 },
+          {},
+        );
         expect(value.original).to.equal('1');
         expect(value.number).to.equal(1);
         expect(value.decimal).equal(0.01);
         expect(value.scale).to.equal(14);
       });
       it('should throw an error if prop value is NaN', () => {
-        expect(() => transforms['size/object'].transformer({ value: 'a' })).to.throw();
+        expect(() => transforms['size/object'].transformer({ value: 'a' }, {}, {})).to.throw();
       });
     });
 
     describe('size/remToSp', () => {
       it('should work', () => {
-        const value = transforms['size/remToSp'].transformer({
-          value: '1',
-        });
+        const value = transforms['size/remToSp'].transformer(
+          {
+            value: '1',
+          },
+          {},
+          {},
+        );
         expect(value).to.equal('16.00sp');
       });
       it('converts rem to sp using custom base font', () => {
         const value = transforms['size/remToSp'].transformer(
           { value: '1' },
           { basePxFontSize: 14 },
+          {},
         );
         expect(value).to.equal('14.00sp');
       });
       it('should throw an error if prop value is Nan', () => {
-        expect(() => transforms['size/dp'].transformer({ value: 'a' })).to.throw();
+        expect(() => transforms['size/dp'].transformer({ value: 'a' }, {}, {})).to.throw();
       });
     });
 
     describe('size/remToDp', () => {
       it('should work', () => {
-        const value = transforms['size/remToDp'].transformer({
-          value: '1',
-        });
+        const value = transforms['size/remToDp'].transformer(
+          {
+            value: '1',
+          },
+          {},
+          {},
+        );
         expect(value).to.equal('16.00dp');
       });
       it('converts rem to dp using custom base font', () => {
         const value = transforms['size/remToDp'].transformer(
           { value: '1' },
           { basePxFontSize: 14 },
+          {},
         );
         expect(value).to.equal('14.00dp');
       });
       it('should throw an error if prop value is Nan', () => {
-        expect(() => transforms['size/dp'].transformer({ value: 'a' })).to.throw();
+        expect(() => transforms['size/dp'].transformer({ value: 'a' }, {}, {})).to.throw();
       });
     });
 
     describe('size/px', () => {
       it('should work', () => {
-        const value = transforms['size/px'].transformer({
-          value: '10',
-        });
+        const value = transforms['size/px'].transformer(
+          {
+            value: '10',
+          },
+          {},
+          {},
+        );
         expect(value).to.equal('10px');
       });
       it('should throw an error if prop value is Nan', () => {
-        expect(() => transforms['size/dp'].transformer({ value: 'a' })).to.throw();
+        expect(() => transforms['size/dp'].transformer({ value: 'a' }, {}, {})).to.throw();
       });
     });
 
     describe('size/remToPt', () => {
       it('should work', () => {
-        const value = transforms['size/remToPt'].transformer({
-          value: '1',
-        });
+        const value = transforms['size/remToPt'].transformer(
+          {
+            value: '1',
+          },
+          {},
+          {},
+        );
         expect(value).to.equal('16.00f');
       });
       it('converts rem to pt using custom base font', () => {
         const value = transforms['size/remToPt'].transformer(
           { value: '1' },
           { basePxFontSize: 14 },
+          {},
         );
         expect(value).to.equal('14.00f');
       });
       it('should throw an error if prop value is Nan', () => {
-        expect(() => transforms['size/dp'].transformer({ value: 'a' })).to.throw();
+        expect(() => transforms['size/dp'].transformer({ value: 'a' }, {}, {})).to.throw();
       });
     });
 
     describe('size/compose/remToSp', () => {
       it('should work', () => {
-        const value = transforms['size/compose/remToSp'].transformer({
-          value: '1',
-        });
+        const value = transforms['size/compose/remToSp'].transformer(
+          {
+            value: '1',
+          },
+          {},
+          {},
+        );
         expect(value).to.equal('16.00.sp');
       });
       it('converts rem to sp using custom base font', () => {
         const value = transforms['size/compose/remToSp'].transformer(
           { value: '1' },
           { basePxFontSize: 14 },
+          {},
         );
         expect(value).to.equal('14.00.sp');
       });
       it('should throw an error if prop value is Nan', () => {
-        expect(() => transforms['size/compose/remToSp'].transformer({ value: 'a' })).to.throw();
+        expect(() =>
+          transforms['size/compose/remToSp'].transformer({ value: 'a' }, {}, {}),
+        ).to.throw();
       });
     });
 
     describe('size/compose/em', () => {
       it('should work', () => {
-        const value = transforms['size/compose/em'].transformer({
-          value: '10',
-        });
+        const value = transforms['size/compose/em'].transformer(
+          {
+            value: '10',
+          },
+          {},
+          {},
+        );
         expect(value).to.equal('10.em');
       });
       it('should throw an error if prop value is Nan', () => {
-        expect(() => transforms['size/compose/em'].transformer({ value: 'a' })).to.throw();
+        expect(() => transforms['size/compose/em'].transformer({ value: 'a' }, {}, {})).to.throw();
       });
     });
 
     describe('size/compose/remToDp', () => {
       it('should work', () => {
-        const value = transforms['size/compose/remToDp'].transformer({
-          value: '1',
-        });
+        const value = transforms['size/compose/remToDp'].transformer(
+          {
+            value: '1',
+          },
+          {},
+          {},
+        );
         expect(value).to.equal('16.00.dp');
       });
       it('converts rem to dp using custom base font', () => {
         const value = transforms['size/compose/remToDp'].transformer(
           { value: '1' },
           { basePxFontSize: 14 },
+          {},
         );
         expect(value).to.equal('14.00.dp');
       });
       it('should throw an error if prop value is Nan', () => {
-        expect(() => transforms['size/compose/remToDp'].transformer({ value: 'a' })).to.throw();
+        expect(() =>
+          transforms['size/compose/remToDp'].transformer({ value: 'a' }, {}, {}),
+        ).to.throw();
       });
     });
 
     describe('size/swift/remToCGFloat', () => {
       it('should work', () => {
-        const value = transforms['size/swift/remToCGFloat'].transformer({
-          value: '1',
-        });
+        const value = transforms['size/swift/remToCGFloat'].transformer(
+          {
+            value: '1',
+          },
+          {},
+          {},
+        );
         expect(value).to.equal('CGFloat(16.00)');
       });
       it('converts rem to CGFloat using custom base font', () => {
         const value = transforms['size/swift/remToCGFloat'].transformer(
           { value: '1' },
           { basePxFontSize: 14 },
+          {},
         );
         expect(value).to.equal('CGFloat(14.00)');
       });
       it('should throw an error if prop value is Nan', () => {
-        expect(() => transforms['size/rem/remToCGFloat'].transformer({ value: 'a' })).to.throw();
+        expect(() =>
+          transforms['size/rem/remToCGFloat'].transformer({ value: 'a' }, {}, {}),
+        ).to.throw();
       });
     });
 
     describe('size/remToPx', () => {
       it('should work', () => {
-        const value = transforms['size/remToPx'].transformer({
-          value: '1',
-        });
+        const value = transforms['size/remToPx'].transformer(
+          {
+            value: '1',
+          },
+          {},
+          {},
+        );
         expect(value).to.equal('16px');
       });
       it('converts rem to px using custom base font', () => {
         const value = transforms['size/remToPx'].transformer(
           { value: '1' },
           { basePxFontSize: 14 },
+          {},
         );
         expect(value).to.equal('14px');
       });
       it('should throw an error if prop value is Nan', () => {
-        expect(() => transforms['size/dp'].transformer({ value: 'a' })).to.throw();
+        expect(() => transforms['size/dp'].transformer({ value: 'a' }, {}, {})).to.throw();
       });
     });
 
@@ -736,45 +955,54 @@ describe('common', () => {
 
       ['12', '12px', '12rem'].forEach((value) => {
         it(`ignoring unit, scales "${value}" to rem`, () => {
-          expect(pxToRemTransformer({ value })).to.equal('0.75rem');
+          expect(pxToRemTransformer({ value }, {}, {})).to.equal('0.75rem');
         });
       });
       it('converts pixel to rem using custom base font', () => {
-        expect(pxToRemTransformer({ value: '14px' }, { basePxFontSize: 14 })).to.equal('1rem');
+        expect(pxToRemTransformer({ value: '14px' }, { basePxFontSize: 14 }, {})).to.equal('1rem');
       });
       ['0', '0px', '0rem'].forEach((value) => {
         it(`zero value "${value}" is returned without a unit`, () => {
-          expect(pxToRemTransformer({ value })).to.equal('0');
+          expect(pxToRemTransformer({ value }, {}, {})).to.equal('0');
         });
       });
       it('should throw an error if prop value is Nan', () => {
-        expect(() => pxToRemTransformer({ value: 'a' })).to.throw();
+        expect(() => pxToRemTransformer({ value: 'a' }, {}, {})).to.throw();
       });
     });
 
     describe('size/rem', () => {
       it('should work', () => {
-        const value = transforms['size/rem'].transformer({
-          value: '1',
-        });
+        const value = transforms['size/rem'].transformer(
+          {
+            value: '1',
+          },
+          {},
+          {},
+        );
         expect(value).to.equal('1rem');
       });
       it('should throw an error if prop value is Nan', () => {
-        expect(() => transforms['size/dp'].transformer({ value: 'a' })).to.throw();
+        expect(() => transforms['size/dp'].transformer({ value: 'a' }, {}, {})).to.throw();
       });
     });
 
     describe('size/flutter/remToDouble', () => {
       it('should work', () => {
-        const value = transforms['size/flutter/remToDouble'].transformer({
-          value: '1',
-        });
+        const value = transforms['size/flutter/remToDouble'].transformer(
+          {
+            value: '1',
+          },
+          {},
+          {},
+        );
         expect(value).to.equal('16.00');
       });
       it('converts rem to double using custom base font', () => {
         const value = transforms['size/flutter/remToDouble'].transformer(
           { value: '1' },
           { basePxFontSize: 14 },
+          {},
         );
         expect(value).to.equal('14.00');
       });
@@ -782,54 +1010,78 @@ describe('common', () => {
 
     describe('content/quote', () => {
       it('should work', () => {
-        const value = transforms['content/quote'].transformer({
-          value: 'hello',
-        });
+        const value = transforms['content/quote'].transformer(
+          {
+            value: 'hello',
+          },
+          {},
+          {},
+        );
         expect(value).to.equal("'hello'");
       });
     });
 
     describe('content/icon', () => {
       it('should work', () => {
-        const value = transforms['content/icon'].transformer({
-          value: '&#xE001;',
-        });
+        const value = transforms['content/icon'].transformer(
+          {
+            value: '&#xE001;',
+          },
+          {},
+          {},
+        );
         expect(value).to.equal("'\\E001'");
       });
     });
 
     describe('content/objC/literal', () => {
       it('should work', () => {
-        const value = transforms['content/objC/literal'].transformer({
-          value: 'hello',
-        });
+        const value = transforms['content/objC/literal'].transformer(
+          {
+            value: 'hello',
+          },
+          {},
+          {},
+        );
         expect(value).to.equal('@"hello"');
       });
     });
 
     describe('asset/objC/literal', () => {
       it('should work', () => {
-        const value = transforms['asset/objC/literal'].transformer({
-          value: 'hello',
-        });
+        const value = transforms['asset/objC/literal'].transformer(
+          {
+            value: 'hello',
+          },
+          {},
+          {},
+        );
         expect(value).to.equal('@"hello"');
       });
     });
 
     describe('font/objC/literal', () => {
       it('should work', () => {
-        const value = transforms['font/objC/literal'].transformer({
-          value: 'hello',
-        });
+        const value = transforms['font/objC/literal'].transformer(
+          {
+            value: 'hello',
+          },
+          {},
+          {},
+        );
         expect(value).to.equal('@"hello"');
       });
     });
 
     describe('time/seconds', () => {
       it('should work', () => {
-        const value = transforms['time/seconds'].transformer({
-          value: '1000',
-        });
+        const value = transforms['time/seconds'].transformer(
+          {
+            value: '1000',
+          },
+          {},
+          {},
+        );
         expect(value).to.equal('1.00s');
       });
     });
@@ -839,9 +1091,13 @@ describe('common', () => {
     // the filePath of the token to determine where the asset is located relative to the token that refers to it
     describe.skip('asset/path', () => {
       it('should work', () => {
-        const value = transforms['asset/path'].transformer({
-          value: 'foo.json',
-        });
+        const value = transforms['asset/path'].transformer(
+          {
+            value: 'foo.json',
+          },
+          {},
+          {},
+        );
         expect(value).to.equal(join('foo.json'));
       });
     });

--- a/__tests__/exportPlatform.test.js
+++ b/__tests__/exportPlatform.test.js
@@ -209,7 +209,7 @@ describe('exportPlatform', () => {
     expect(dictionary.color.red.value.h).to.equal(20);
   });
 
-  it('should handle .value and non .value references per the W3C spec', async () => {
+  it('should handle .value and non .value references per the DTCG spec', async () => {
     const tokens = {
       colors: {
         red: { value: '#f00' },
@@ -437,7 +437,7 @@ describe('exportPlatform', () => {
     });
   });
 
-  describe('w3c forward compatibility', () => {
+  describe('DTCG forward compatibility', () => {
     it('should allow using $value instead of value', async () => {
       const sd = new StyleDictionary({
         tokens: {
@@ -469,7 +469,7 @@ describe('exportPlatform', () => {
               return token.$type === 'dimension';
             },
             transformer: (token) => {
-              return `${sd.options.usesW3C ? token.$value : token.value}px`;
+              return `${sd.options.usesDtcg ? token.$value : token.value}px`;
             },
           },
         },

--- a/__tests__/formats/__snapshots__/all.test.snap.js
+++ b/__tests__/formats/__snapshots__/all.test.snap.js
@@ -228,7 +228,6 @@ export default tokens;
 
 declare interface DesignToken {
       value?: any;
-      $value?: any;
       name?: string;
       comment?: string;
       themeable?: boolean;

--- a/__tests__/transform/object.test.js
+++ b/__tests__/transform/object.test.js
@@ -13,7 +13,7 @@
 import { expect } from 'chai';
 import transformObject from '../../lib/transform/object.js';
 
-const options = {
+const config = {
   transforms: [
     {
       type: 'attribute',
@@ -63,11 +63,11 @@ describe('transform', () => {
         color: '#FFFF00',
       };
 
-      const actual = transformObject(objectToTransform, options);
+      const actual = transformObject(objectToTransform, config, {});
       expect(actual).to.eql(expected);
     });
 
-    it('returns expected result when called with an with value leaf', () => {
+    it('returns expected result when called with value leaf', () => {
       const objectToTransform = {
         font: {
           base: {
@@ -93,7 +93,7 @@ describe('transform', () => {
         },
       };
 
-      const actual = transformObject(objectToTransform, options);
+      const actual = transformObject(objectToTransform, config, {});
       expect(actual).to.eql(expected);
     });
 
@@ -116,7 +116,7 @@ describe('transform', () => {
         },
       };
 
-      transformObject(objectToTransform, options, transformationContext);
+      transformObject(objectToTransform, config, {}, transformationContext);
 
       expect(transformedPropRefs).to.eql(['spacing.base']);
       expect(deferredPropValueTransforms).to.eql(['spacing.medium']);

--- a/__tests__/transform/property.test.js
+++ b/__tests__/transform/property.test.js
@@ -13,7 +13,7 @@
 import { expect } from 'chai';
 import token from '../../lib/transform/token.js';
 
-const options = {
+const config = {
   transforms: [
     {
       type: 'attribute',
@@ -44,7 +44,7 @@ const options = {
 describe('transform', () => {
   describe('token', () => {
     it('transform token and apply transforms', () => {
-      const test = token({ attributes: { baz: 'blah' } }, options);
+      const test = token({ attributes: { baz: 'blah' } }, config, {});
       expect(test).to.have.nested.property('attributes.bar', 'foo');
       expect(test).to.have.property('name', 'hello');
     });
@@ -69,6 +69,7 @@ describe('transform', () => {
             },
           ],
         },
+        {},
       );
 
       expect(result).to.be.undefined;

--- a/__tests__/utils/combineJSON.test.js
+++ b/__tests__/utils/combineJSON.test.js
@@ -18,14 +18,20 @@ import combineJSON from '../../lib/utils/combineJSON.js';
 
 describe('utils', () => {
   describe('combineJSON', () => {
-    it('should return an object', async () => {
+    it('should return an object with usesW3C & tokens prop', async () => {
       const test = await combineJSON(['__tests__/__json_files/*.json']);
       expect(typeof test).to.equal('object');
+      const { tokens, usesW3C } = test;
+      expect(typeof tokens).to.equal('object');
+      expect(typeof usesW3C).to.equal('boolean');
     });
 
     it('should handle wildcards', async () => {
       const test = await combineJSON(['__tests__/__json_files/*.json']);
       expect(typeof test).to.equal('object');
+      const { tokens, usesW3C } = test;
+      expect(typeof tokens).to.equal('object');
+      expect(typeof usesW3C).to.equal('boolean');
     });
 
     it('should handle js modules that export objects', async () => {
@@ -33,23 +39,26 @@ describe('utils', () => {
       const relativePath = '__tests__/__json_files/*.js';
       const test = await combineJSON([absPath, relativePath]);
       expect(typeof test).to.equal('object');
+      const { tokens, usesW3C } = test;
+      expect(typeof tokens).to.equal('object');
+      expect(typeof usesW3C).to.equal('boolean');
     });
 
     it('should do a deep merge', async () => {
-      const test = await combineJSON(['__tests__/__json_files/shallow/*.json'], true);
-      expect(test).to.have.property('a', 2);
-      expect(test.b).to.eql({ a: 1, c: 2 });
-      expect(test).to.have.nested.property('d.e.f.g', 1);
-      expect(test).to.have.nested.property('d.e.f.h', 2);
+      const { tokens } = await combineJSON(['__tests__/__json_files/shallow/*.json'], true);
+      expect(tokens).to.have.property('a', 2);
+      expect(tokens.b).to.eql({ a: 1, c: 2 });
+      expect(tokens).to.have.nested.property('d.e.f.g', 1);
+      expect(tokens).to.have.nested.property('d.e.f.h', 2);
     });
 
     it('should do a shallow merge', async () => {
-      const test = await combineJSON(['__tests__/__json_files/shallow/*.json']);
-      expect(test).to.have.property('a', 2);
-      expect(test.b).to.eql({ c: 2 });
-      expect(test).to.have.deep.property('c', [3, 4]);
-      expect(test).not.to.have.nested.property('d.e.f.g');
-      expect(test).to.have.nested.property('d.e.f.h', 2);
+      const { tokens } = await combineJSON(['__tests__/__json_files/shallow/*.json']);
+      expect(tokens).to.have.property('a', 2);
+      expect(tokens.b).to.eql({ c: 2 });
+      expect(tokens).to.have.deep.property('c', [3, 4]);
+      expect(tokens).not.to.have.nested.property('d.e.f.g');
+      expect(tokens).to.have.nested.property('d.e.f.h', 2);
     });
 
     it('should fail on invalid JSON', async () => {
@@ -73,15 +82,15 @@ describe('utils', () => {
     });
 
     it('should support json5', async () => {
-      const test = await combineJSON(['__tests__/__json_files/shallow/*.json5']);
-      expect(test).to.have.property('json5A', 5);
-      expect(test.d).to.have.property('json5e', 1);
+      const { tokens } = await combineJSON(['__tests__/__json_files/shallow/*.json5']);
+      expect(tokens).to.have.property('json5A', 5);
+      expect(tokens.d).to.have.property('json5e', 1);
     });
 
     it('should support jsonc', async () => {
-      const test = await combineJSON(['__tests__/__json_files/shallow/*.jsonc']);
-      expect(test).to.have.property('jsonCA', 5);
-      expect(test.d).to.have.property('jsonCe', 1);
+      const { tokens } = await combineJSON(['__tests__/__json_files/shallow/*.jsonc']);
+      expect(tokens).to.have.property('jsonCA', 5);
+      expect(tokens.d).to.have.property('jsonCe', 1);
     });
 
     describe('custom parsers', () => {
@@ -93,15 +102,15 @@ describe('utils', () => {
             parse: ({ contents }) => yaml.parse(contents),
           },
         ];
-        const output = await combineJSON(
+        const { tokens } = await combineJSON(
           [`__tests__/__json_files/yaml.yaml`],
           false,
           null,
           false,
           parsers,
         );
-        expect(output).to.have.property('foo', 'bar');
-        expect(output).to.have.property('bar', '{foo}');
+        expect(tokens).to.have.property('foo', 'bar');
+        expect(tokens).to.have.property('bar', '{foo}');
       });
 
       it('should multiple parsers on the same file', async () => {
@@ -120,14 +129,14 @@ describe('utils', () => {
             },
           },
         ];
-        const output = await combineJSON(
+        const { tokens } = await combineJSON(
           [`__tests__/__json_files/simple.json`],
           false,
           null,
           false,
           parsers,
         );
-        expect(output).to.have.property('test', 'test');
+        expect(tokens).to.have.property('test', 'test');
       });
     });
   });

--- a/__tests__/utils/combineJSON.test.js
+++ b/__tests__/utils/combineJSON.test.js
@@ -18,20 +18,20 @@ import combineJSON from '../../lib/utils/combineJSON.js';
 
 describe('utils', () => {
   describe('combineJSON', () => {
-    it('should return an object with usesW3C & tokens prop', async () => {
+    it('should return an object with usesDtcg & tokens prop', async () => {
       const test = await combineJSON(['__tests__/__json_files/*.json']);
       expect(typeof test).to.equal('object');
-      const { tokens, usesW3C } = test;
+      const { tokens, usesDtcg } = test;
       expect(typeof tokens).to.equal('object');
-      expect(typeof usesW3C).to.equal('boolean');
+      expect(typeof usesDtcg).to.equal('boolean');
     });
 
     it('should handle wildcards', async () => {
       const test = await combineJSON(['__tests__/__json_files/*.json']);
       expect(typeof test).to.equal('object');
-      const { tokens, usesW3C } = test;
+      const { tokens, usesDtcg } = test;
       expect(typeof tokens).to.equal('object');
-      expect(typeof usesW3C).to.equal('boolean');
+      expect(typeof usesDtcg).to.equal('boolean');
     });
 
     it('should handle js modules that export objects', async () => {
@@ -39,9 +39,9 @@ describe('utils', () => {
       const relativePath = '__tests__/__json_files/*.js';
       const test = await combineJSON([absPath, relativePath]);
       expect(typeof test).to.equal('object');
-      const { tokens, usesW3C } = test;
+      const { tokens, usesDtcg } = test;
       expect(typeof tokens).to.equal('object');
-      expect(typeof usesW3C).to.equal('boolean');
+      expect(typeof usesDtcg).to.equal('boolean');
     });
 
     it('should do a deep merge', async () => {

--- a/__tests__/utils/preprocess.test.js
+++ b/__tests__/utils/preprocess.test.js
@@ -11,10 +11,10 @@
  * and limitations under the License.
  */
 import { expect } from 'chai';
-import { typeW3CDelegate } from '../../lib/utils/preprocess.js';
+import { typeDtcgDelegate } from '../../lib/utils/preprocess.js';
 
 describe('utils', () => {
-  describe('typeW3CDelegate', () => {
+  describe('typeDtcgDelegate', () => {
     it('should correctly let tokens inherit the $type property while respecting local overrides', () => {
       const tokens = {
         dimension: {
@@ -52,7 +52,7 @@ describe('utils', () => {
         },
       };
 
-      expect(typeW3CDelegate(tokens)).to.eql({
+      expect(typeDtcgDelegate(tokens)).to.eql({
         dimension: {
           $type: 'dimension',
           scale: {

--- a/__tests__/utils/reference/getReferences.test.js
+++ b/__tests__/utils/reference/getReferences.test.js
@@ -12,9 +12,7 @@
  */
 
 import { expect } from 'chai';
-import getReferences, {
-  getReferences as publicGetReferences,
-} from '../../../lib/utils/references/getReferences.js';
+import { _getReferences, getReferences } from '../../../lib/utils/references/getReferences.js';
 
 const tokens = {
   color: {
@@ -53,33 +51,33 @@ describe('utils', () => {
     describe('getReferences()', () => {
       describe('public API', () => {
         it('should not collect errors but rather throw immediately when using public API', () => {
-          expect(() => publicGetReferences('{foo.bar}', tokens)).to.throw(
+          expect(() => getReferences('{foo.bar}', tokens)).to.throw(
             `Reference doesn't exist: tries to reference foo.bar, which is not defined.`,
           );
         });
       });
 
       it(`should return an empty array if the value has no references`, () => {
-        expect(getReferences(tokens.color.red.value, tokens)).to.eql([]);
+        expect(_getReferences(tokens.color.red.value, tokens)).to.eql([]);
       });
 
       it(`should work with a single reference`, () => {
-        expect(getReferences(tokens.color.danger.value, tokens)).to.eql([{ value: '#f00' }]);
+        expect(_getReferences(tokens.color.danger.value, tokens)).to.eql([{ value: '#f00' }]);
       });
 
       it(`should work with object values`, () => {
-        expect(getReferences(tokens.border.primary.value, tokens)).to.eql([
+        expect(_getReferences(tokens.border.primary.value, tokens)).to.eql([
           { value: '#f00' },
           { value: '2px' },
         ]);
       });
 
       it(`should work with objects that have numbers`, () => {
-        expect(getReferences(tokens.border.secondary.value, tokens)).to.eql([{ value: '#f00' }]);
+        expect(_getReferences(tokens.border.secondary.value, tokens)).to.eql([{ value: '#f00' }]);
       });
 
       it(`should work with interpolated values`, () => {
-        expect(getReferences(tokens.border.tertiary.value, tokens)).to.eql([
+        expect(_getReferences(tokens.border.tertiary.value, tokens)).to.eql([
           { value: '2px' },
           { value: '#f00' },
         ]);

--- a/docs/using_reference_utils.md
+++ b/docs/using_reference_utils.md
@@ -51,7 +51,7 @@ const flat = flattenTokens(sd);
  */
 ```
 
-> You can pass a second argument `usesW3C`, if set to true, the flattenTokens utility will assume W3C syntax (`$value` props)
+> You can pass a second argument `usesDtcg`, if set to true, the flattenTokens utility will assume DTCG syntax (`$value` props)
 
 ### usesReference
 
@@ -102,7 +102,7 @@ resolveReferences('solid {spacing.2} {colors.black}', sd.tokens); // alternative
 ```
 
 > You can pass a third `options` argument where you can pass some configuration options for how references are resolved
-> Most notable option for public usage is `usesW3C`, if set to true, the resolveReferences utility will assume W3C syntax (`$value` props)
+> Most notable option for public usage is `usesDtcg`, if set to true, the resolveReferences utility will assume DTCG syntax (`$value` props)
 
 ### getReferences
 
@@ -143,7 +143,7 @@ getReferences(sd, 'solid {spacing.2} {colors.black}'); // alternative way, yet i
 ```
 
 > You can pass a third `options` argument where you can pass some configuration options for how references are resolved
-> Most notable option for public usage is `usesW3C`, if set to true, the resolveReferences utility will assume W3C syntax (`$value` props)
+> Most notable option for public usage is `usesDtcg`, if set to true, the resolveReferences utility will assume DTCG syntax (`$value` props)
 
 #### Complicated example
 
@@ -273,12 +273,12 @@ export const SemanticBgPrimary = ColorsBlack;
 export const Border = `solid ${Spacing2} ${SemanticBgPrimary}`;
 ```
 
-> Note that the above example does not support W3C syntax, but this could be quite easily added,
-> since you can query `sd.options.usesW3C` or inside a formatter functions `dictionary.options.usesW3C`
+> Note that the above example does not support DTCG syntax, but this could be quite easily added,
+> since you can query `sd.options.usesDtcg` or inside a formatter functions `dictionary.options.usesDtcg`
 
-### typeW3CDelegate
+### typeDtcgDelegate
 
-This function processes your ["W3C Design Token Community Group Draft spec"-compliant](https://design-tokens.github.io/community-group/format/) dictionary of tokens, and ensures that `$type` inheritance is applied.
+This function processes your ["Design Token Community Group Draft spec"-compliant](https://design-tokens.github.io/community-group/format/) dictionary of tokens, and ensures that `$type` inheritance is applied.
 
 We built this utility because it's cheaper to apply the inheritance once, rather than on every access of a token's "$type" property, checking the ancestor tree to find it.
 

--- a/docs/using_reference_utils.md
+++ b/docs/using_reference_utils.md
@@ -41,7 +41,7 @@ const sd = new StyleDictionary({
   },
 });
 
-const flat = flattenTokens(sd, sd.tokens.border.value);
+const flat = flattenTokens(sd);
 /**
  * [
  *   { value: '#000', type: 'color', name: 'colors-black' },
@@ -50,6 +50,8 @@ const flat = flattenTokens(sd, sd.tokens.border.value);
  * ]
  */
 ```
+
+> You can pass a second argument `usesW3C`, if set to true, the flattenTokens utility will assume W3C syntax (`$value` props)
 
 ### usesReference
 
@@ -99,6 +101,9 @@ resolveReferences(sd.tokens.border.value, sd.tokens); // "solid 2px #000"
 resolveReferences('solid {spacing.2} {colors.black}', sd.tokens); // alternative way, yet identical to line above -> "solid 2px #000"
 ```
 
+> You can pass a third `options` argument where you can pass some configuration options for how references are resolved
+> Most notable option for public usage is `usesW3C`, if set to true, the resolveReferences utility will assume W3C syntax (`$value` props)
+
 ### getReferences
 
 Whether or not a token value contains references
@@ -136,6 +141,9 @@ getReferences(sd, 'solid {spacing.2} {colors.black}'); // alternative way, yet i
  * ]
  */
 ```
+
+> You can pass a third `options` argument where you can pass some configuration options for how references are resolved
+> Most notable option for public usage is `usesW3C`, if set to true, the resolveReferences utility will assume W3C syntax (`$value` props)
 
 #### Complicated example
 
@@ -264,6 +272,9 @@ export const ZIndexAboveFold = 1;
 export const SemanticBgPrimary = ColorsBlack;
 export const Border = `solid ${Spacing2} ${SemanticBgPrimary}`;
 ```
+
+> Note that the above example does not support W3C syntax, but this could be quite easily added,
+> since you can query `sd.options.usesW3C` or inside a formatter functions `dictionary.options.usesW3C`
 
 ### typeW3CDelegate
 

--- a/lib/StyleDictionary.js
+++ b/lib/StyleDictionary.js
@@ -25,6 +25,8 @@ import deepExtend from './utils/deepExtend.js';
 import resolveObject from './utils/resolveObject.js';
 import getName from './utils/references/getName.js';
 import GroupMessages from './utils/groupMessages.js';
+import flattenTokens from './utils/flattenTokens.js';
+import { detectW3CSyntax } from './utils/detectW3CSyntax.js';
 import { preprocess } from './utils/preprocess.js';
 
 import transformObject from './transform/object.js';
@@ -34,7 +36,6 @@ import buildFiles from './buildFiles.js';
 import cleanFiles from './cleanFiles.js';
 import cleanDirs from './cleanDirs.js';
 import cleanActions from './cleanActions.js';
-import flattenTokens from './utils/flattenTokens.js';
 
 /**
  * @typedef {import('../types/Config.d.ts').Config} Config
@@ -147,6 +148,7 @@ export default class StyleDictionary extends Register {
     let includeTokens = {};
     /** @type {Tokens} */
     let sourceTokens = {};
+
     // Overloaded method, can accept a string as a path that points to a JS or
     // JSON file or a plain object. Potentially refactor.
     if (typeof config === 'string') {
@@ -176,9 +178,12 @@ export default class StyleDictionary extends Register {
     });
     this.options = options;
 
-    // Creating a new object and copying over the options
-    // Also keeping an options object in case
+    let { usesW3C } = this.options;
 
+    // Try to detect W3C if not specified by user in options
+    if (this.tokens && usesW3C === undefined) {
+      usesW3C = detectW3CSyntax(this.tokens);
+    }
     // grab the inline tokens, ones either defined in the configuration object
     // or that already exist from extending another style dictionary instance
     // with `tokens` keys
@@ -188,14 +193,28 @@ export default class StyleDictionary extends Register {
     if (this.options.include) {
       if (!Array.isArray(this.options.include)) throw new Error('include must be an array');
 
-      includeTokens = await combineJSON(this.options.include, true, undefined, false, this.parsers);
+      const result = await combineJSON(
+        this.options.include,
+        true,
+        undefined,
+        false,
+        this.parsers,
+        this.options.usesW3C,
+      );
+
+      includeTokens = result.tokens;
+      // If it wasn't known yet whether W3C is used, combineJSON util will have auto-detected it
+      if (usesW3C === undefined) {
+        usesW3C = result.usesW3C;
+      }
     }
 
     // Update tokens with current package's source
     // These highest precedence
     if (this.options.source) {
       if (!Array.isArray(this.options.source)) throw new Error('source must be an array');
-      sourceTokens = await combineJSON(
+
+      const result = await combineJSON(
         this.options.source,
         true,
         /** @param {Token} prop */
@@ -209,7 +228,14 @@ export default class StyleDictionary extends Register {
         },
         true,
         this.parsers,
+        this.options.usesW3C,
       );
+
+      sourceTokens = result.tokens;
+      // If it wasn't known yet whether W3C is used, combineJSON util will have auto-detected it
+      if (usesW3C === undefined) {
+        usesW3C = result.usesW3C;
+      }
 
       if (GroupMessages.count(PROPERTY_VALUE_COLLISIONS) > 0) {
         const collisions = GroupMessages.flush(PROPERTY_VALUE_COLLISIONS).join('\n');
@@ -226,6 +252,7 @@ export default class StyleDictionary extends Register {
     // Merge inline, include, and source tokens
     const unprocessedTokens = deepExtend([{}, inlineTokens, includeTokens, sourceTokens]);
     this.tokens = await preprocess(unprocessedTokens, this.preprocessors);
+    this.options = { ...this.options, usesW3C };
     this.hasInitializedResolve(null);
 
     // For chaining
@@ -306,7 +333,12 @@ export default class StyleDictionary extends Register {
       // values like "1px solid {color.border.base}" we want to
       // transform the original value (color.border.base) before
       // replacing that value in the string.
-      const transformed = transformObject(exportableResult, platformConfig, transformationContext);
+      const transformed = transformObject(
+        exportableResult,
+        platformConfig,
+        this.options,
+        transformationContext,
+      );
 
       // referenced values, that have not (yet) been transformed should be excluded from resolving
       const ignorePathsToResolve = deferredPropValueTransforms.map((p) => getName([p, 'value']));
@@ -365,7 +397,9 @@ export default class StyleDictionary extends Register {
     // transform the original value (color.border.base) before
     // replacing that value in the string.
     const tokens = await this.exportPlatform(platform);
-    this.allTokens = /** @type {TransformedToken[]} */ (flattenTokens(tokens));
+    this.allTokens = /** @type {TransformedToken[]} */ (
+      flattenTokens(tokens, this.options.usesW3C)
+    );
     // This is the dictionary object we pass to the file
     // building and action methods.
     return { dictionary: { tokens, allTokens: this.allTokens }, platformConfig };
@@ -377,8 +411,8 @@ export default class StyleDictionary extends Register {
    */
   async buildPlatform(platform) {
     const { dictionary, platformConfig } = await this.getPlatform(platform);
-    buildFiles(dictionary, platformConfig);
-    performActions(dictionary, platformConfig);
+    buildFiles(dictionary, platformConfig, this.options);
+    performActions(dictionary, platformConfig, this.options);
     // For chaining
     return this;
   }
@@ -400,7 +434,7 @@ export default class StyleDictionary extends Register {
     const { dictionary, platformConfig } = await this.getPlatform(platform);
     // We clean files first, then actions, ...and then directories?
     cleanFiles(platformConfig);
-    cleanActions(dictionary, platformConfig);
+    cleanActions(dictionary, platformConfig, this.options);
     cleanDirs(platformConfig);
     // For chaining
     return this;

--- a/lib/StyleDictionary.js
+++ b/lib/StyleDictionary.js
@@ -26,7 +26,7 @@ import resolveObject from './utils/resolveObject.js';
 import getName from './utils/references/getName.js';
 import GroupMessages from './utils/groupMessages.js';
 import flattenTokens from './utils/flattenTokens.js';
-import { detectW3CSyntax } from './utils/detectW3CSyntax.js';
+import { detectDtcgSyntax } from './utils/detectDtcgSyntax.js';
 import { preprocess } from './utils/preprocess.js';
 
 import transformObject from './transform/object.js';
@@ -178,11 +178,11 @@ export default class StyleDictionary extends Register {
     });
     this.options = options;
 
-    let { usesW3C } = this.options;
+    let { usesDtcg } = this.options;
 
-    // Try to detect W3C if not specified by user in options
-    if (this.tokens && usesW3C === undefined) {
-      usesW3C = detectW3CSyntax(this.tokens);
+    // Try to detect DTCG if not specified by user in options
+    if (Object.entries(this.tokens).length > 0 && usesDtcg === undefined) {
+      usesDtcg = detectDtcgSyntax(this.tokens);
     }
     // grab the inline tokens, ones either defined in the configuration object
     // or that already exist from extending another style dictionary instance
@@ -199,13 +199,13 @@ export default class StyleDictionary extends Register {
         undefined,
         false,
         this.parsers,
-        this.options.usesW3C,
+        this.options.usesDtcg,
       );
 
       includeTokens = result.tokens;
-      // If it wasn't known yet whether W3C is used, combineJSON util will have auto-detected it
-      if (usesW3C === undefined) {
-        usesW3C = result.usesW3C;
+      // If it wasn't known yet whether DTCG is used, combineJSON util will have auto-detected it
+      if (usesDtcg === undefined) {
+        usesDtcg = result.usesDtcg;
       }
     }
 
@@ -228,13 +228,13 @@ export default class StyleDictionary extends Register {
         },
         true,
         this.parsers,
-        this.options.usesW3C,
+        this.options.usesDtcg,
       );
 
       sourceTokens = result.tokens;
-      // If it wasn't known yet whether W3C is used, combineJSON util will have auto-detected it
-      if (usesW3C === undefined) {
-        usesW3C = result.usesW3C;
+      // If it wasn't known yet whether DTCG is used, combineJSON util will have auto-detected it
+      if (usesDtcg === undefined) {
+        usesDtcg = result.usesDtcg;
       }
 
       if (GroupMessages.count(PROPERTY_VALUE_COLLISIONS) > 0) {
@@ -252,7 +252,7 @@ export default class StyleDictionary extends Register {
     // Merge inline, include, and source tokens
     const unprocessedTokens = deepExtend([{}, inlineTokens, includeTokens, sourceTokens]);
     this.tokens = await preprocess(unprocessedTokens, this.preprocessors);
-    this.options = { ...this.options, usesW3C };
+    this.options = { ...this.options, usesDtcg };
     this.hasInitializedResolve(null);
 
     // For chaining
@@ -398,7 +398,7 @@ export default class StyleDictionary extends Register {
     // replacing that value in the string.
     const tokens = await this.exportPlatform(platform);
     this.allTokens = /** @type {TransformedToken[]} */ (
-      flattenTokens(tokens, this.options.usesW3C)
+      flattenTokens(tokens, this.options.usesDtcg)
     );
     // This is the dictionary object we pass to the file
     // building and action methods.

--- a/lib/buildFile.js
+++ b/lib/buildFile.js
@@ -100,7 +100,7 @@ export default function buildFile(file, platform = {}, dictionary, options) {
       let collisions = nameCollisionObj[tokenName]
         .map((token) => {
           let tokenPathText = chalk.rgb(255, 69, 0)(token.path.join('.'));
-          let valueText = chalk.rgb(255, 140, 0)(options.usesW3C ? token.$value : token.value);
+          let valueText = chalk.rgb(255, 140, 0)(options.usesDtcg ? token.$value : token.value);
           return tokenPathText + '   ' + valueText;
         })
         .join('\n        ');

--- a/lib/buildFile.js
+++ b/lib/buildFile.js
@@ -23,6 +23,7 @@ import createFormatArgs from './utils/createFormatArgs.js';
  * @typedef {import('../types/DesignToken.d.ts').Dictionary} Dictionary
  * @typedef {import('../types/DesignToken.d.ts').TransformedToken} TransformedToken
  * @typedef {import('../types/Config.d.ts').PlatformConfig} PlatformConfig
+ * @typedef {import('../types/Config.d.ts').Config} Config
  * @typedef {import('../types/File.d.ts').File} File
  */
 
@@ -33,8 +34,9 @@ import createFormatArgs from './utils/createFormatArgs.js';
  * @param {File} file
  * @param {PlatformConfig} platform
  * @param {Dictionary} dictionary
+ * @param {Config} options
  */
-export default function buildFile(file, platform = {}, dictionary) {
+export default function buildFile(file, platform = {}, dictionary, options) {
   const { destination, filter } = file || {};
   let { format } = file || {};
 
@@ -56,7 +58,7 @@ export default function buildFile(file, platform = {}, dictionary) {
   const dir = dirname(fullDestination);
   if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
 
-  const filteredTokens = filterTokens(dictionary, filter);
+  const filteredTokens = filterTokens(dictionary, filter, options);
   const filteredDictionary = Object.assign({}, dictionary, {
     tokens: filteredTokens.tokens,
     allTokens: filteredTokens.allTokens,
@@ -98,7 +100,7 @@ export default function buildFile(file, platform = {}, dictionary) {
       let collisions = nameCollisionObj[tokenName]
         .map((token) => {
           let tokenPathText = chalk.rgb(255, 69, 0)(token.path.join('.'));
-          let valueText = chalk.rgb(255, 140, 0)(token.$value ?? token.value);
+          let valueText = chalk.rgb(255, 140, 0)(options.usesW3C ? token.$value : token.value);
           return tokenPathText + '   ' + valueText;
         })
         .join('\n        ');
@@ -118,6 +120,7 @@ export default function buildFile(file, platform = {}, dictionary) {
       createFormatArgs({
         dictionary: filteredDictionary,
         platform,
+        options,
         file,
       }),
     ),

--- a/lib/buildFiles.js
+++ b/lib/buildFiles.js
@@ -15,7 +15,8 @@ import buildFile from './buildFile.js';
 
 /**
  * @typedef {import('../types/DesignToken.d.ts').Dictionary} Dictionary
- * @typedef {import('../types/Config.d.ts').PlatformConfig} Config
+ * @typedef {import('../types/Config.d.ts').PlatformConfig} PlatformConfig
+ * @typedef {import('../types/Config.d.ts').Config} Config
  */
 
 /**
@@ -25,9 +26,10 @@ import buildFile from './buildFile.js';
  * point.
  * @memberOf StyleDictionary
  * @param {Dictionary} dictionary
- * @param {Config} platform
+ * @param {PlatformConfig} platform
+ * @param {Config} options
  */
-export default function buildFiles(dictionary, platform) {
+export default function buildFiles(dictionary, platform, options) {
   if (
     platform.buildPath &&
     platform.buildPath.slice(-1) !== '/' &&
@@ -38,7 +40,7 @@ export default function buildFiles(dictionary, platform) {
 
   platform.files?.forEach(function (file) {
     if (file.format) {
-      buildFile(file, platform, dictionary);
+      buildFile(file, platform, dictionary, options);
     } else {
       throw new Error('Please supply a format');
     }

--- a/lib/cleanActions.js
+++ b/lib/cleanActions.js
@@ -13,7 +13,8 @@
 
 /**
  * @typedef {import('../types/DesignToken.d.ts').Dictionary} Dictionary
- * @typedef {import('../types/Config.d.ts').PlatformConfig} Config
+ * @typedef {import('../types/Config.d.ts').PlatformConfig} PlatformConfig
+ * @typedef {import('../types/Config.d.ts').Config} Config
  */
 
 /**
@@ -24,14 +25,15 @@
  * @private
  * @memberof module:style-dictionary
  * @param {Dictionary} dictionary
- * @param {Config} platform
+ * @param {PlatformConfig} platform
+ * @param {Config} options
  */
-export default function cleanActions(dictionary, platform) {
+export default function cleanActions(dictionary, platform, options) {
   if (platform.actions) {
     platform.actions.forEach(function (action) {
       // ensure we've augmented action with the do/undo functions and that undo exists
       if (typeof action !== 'string' && typeof action.undo === 'function') {
-        action.undo(dictionary, platform);
+        action.undo(dictionary, platform, options);
       }
     });
   }

--- a/lib/common/actions.js
+++ b/lib/common/actions.js
@@ -42,7 +42,7 @@ export default {
           const dir = `${imagesDir}${token.attributes.state}`;
           const path = `${dir}/${name}.png`;
           fs.mkdirSync(dir, { recursive: true });
-          fs.copyFileSync(options.usesW3C ? token.$value : token.value, path);
+          fs.copyFileSync(options.usesDtcg ? token.$value : token.value, path);
         }
       });
     },

--- a/lib/common/actions.js
+++ b/lib/common/actions.js
@@ -31,7 +31,7 @@ export default {
    * @memberof Actions
    */
   'android/copyImages': {
-    do: function (dictionary, config) {
+    do: function (dictionary, config, options) {
       const imagesDir = `${config.buildPath}android/main/res/drawable-`;
       /**
        * @param {Token} token
@@ -42,7 +42,7 @@ export default {
           const dir = `${imagesDir}${token.attributes.state}`;
           const path = `${dir}/${name}.png`;
           fs.mkdirSync(dir, { recursive: true });
-          fs.copyFileSync(token.$value ?? token.value, path);
+          fs.copyFileSync(options.usesW3C ? token.$value : token.value, path);
         }
       });
     },

--- a/lib/common/formatHelpers/createPropertyFormatter.js
+++ b/lib/common/formatHelpers/createPropertyFormatter.js
@@ -10,7 +10,7 @@
  * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
  * and limitations under the License.
  */
-import getReferences from '../../utils/references/getReferences.js';
+import { _getReferences } from '../../utils/references/getReferences.js';
 import usesReferences from '../../utils/references/usesReferences.js';
 
 /**
@@ -113,6 +113,7 @@ function addComment(to_ret_token, comment, options) {
  * @param {string} [options.format] - Available formats are: 'css', 'sass', 'less', and 'stylus'. If you want to customize the format and can't use one of those predefined formats, use the `formatting` option
  * @param {Formatting} [options.formatting] - Custom formatting properties that define parts of a declaration line in code. The configurable strings are: prefix, indentation, separator, suffix, and commentStyle. Those are used to generate a line like this: `${indentation}${prefix}${token.name}${separator} ${token.value}${suffix}`
  * @param {boolean} [options.themeable] [false] - Whether tokens should default to being themeable.
+ * @param {boolean} [options.usesW3C] [false] - Whether W3C token syntax should be uses.
  * @returns {(token: import('../../../types/DesignToken.d.ts').TransformedToken) => string}
  */
 export default function createPropertyFormatter({
@@ -122,6 +123,7 @@ export default function createPropertyFormatter({
   format,
   formatting = {},
   themeable = false,
+  usesW3C = false,
 }) {
   /** @type {Formatting} */
   const formatDefaults = {};
@@ -159,7 +161,7 @@ export default function createPropertyFormatter({
   const { tokens, unfilteredTokens } = dictionary;
   return function (token) {
     let to_ret_token = `${indentation}${prefix}${token.name}${separator} `;
-    let value = token.$value ?? token.value;
+    let value = usesW3C ? token.$value : token.value;
 
     /**
      * A single value can have multiple references either by interpolation:
@@ -176,7 +178,7 @@ export default function createPropertyFormatter({
     if (outputReferences && usesReferences(token.original.value)) {
       // Formats that use this function expect `value` to be a string
       // or else you will get '[object Object]' in the output
-      const refs = getReferences(token.original.value, tokens, { unfilteredTokens }, []);
+      const refs = _getReferences(token.original.value, tokens, { unfilteredTokens }, []);
 
       // original can either be an object value, which requires transitive value transformation in web CSS formats
       // or a different (primitive) type, meaning it can be stringified.
@@ -198,11 +200,8 @@ export default function createPropertyFormatter({
         // because Style Dictionary resolved this in the resolution step.
         // Here we are undoing that by replacing the value with
         // the reference's name
-        if (
-          (Object.hasOwn(ref, 'value') || Object.hasOwn(ref, '$value')) &&
-          Object.hasOwn(ref, 'name')
-        ) {
-          const refVal = ref.$value ?? ref.value;
+        if (Object.hasOwn(ref, `${usesW3C ? '$' : ''}value`) && Object.hasOwn(ref, 'name')) {
+          const refVal = usesW3C ? ref.$value : ref.value;
           const replaceFunc = function () {
             if (format === 'css') {
               if (outputReferenceFallbacks) {

--- a/lib/common/formatHelpers/createPropertyFormatter.js
+++ b/lib/common/formatHelpers/createPropertyFormatter.js
@@ -113,7 +113,7 @@ function addComment(to_ret_token, comment, options) {
  * @param {string} [options.format] - Available formats are: 'css', 'sass', 'less', and 'stylus'. If you want to customize the format and can't use one of those predefined formats, use the `formatting` option
  * @param {Formatting} [options.formatting] - Custom formatting properties that define parts of a declaration line in code. The configurable strings are: prefix, indentation, separator, suffix, and commentStyle. Those are used to generate a line like this: `${indentation}${prefix}${token.name}${separator} ${token.value}${suffix}`
  * @param {boolean} [options.themeable] [false] - Whether tokens should default to being themeable.
- * @param {boolean} [options.usesW3C] [false] - Whether W3C token syntax should be uses.
+ * @param {boolean} [options.usesDtcg] [false] - Whether DTCG token syntax should be uses.
  * @returns {(token: import('../../../types/DesignToken.d.ts').TransformedToken) => string}
  */
 export default function createPropertyFormatter({
@@ -123,7 +123,7 @@ export default function createPropertyFormatter({
   format,
   formatting = {},
   themeable = false,
-  usesW3C = false,
+  usesDtcg = false,
 }) {
   /** @type {Formatting} */
   const formatDefaults = {};
@@ -161,7 +161,7 @@ export default function createPropertyFormatter({
   const { tokens, unfilteredTokens } = dictionary;
   return function (token) {
     let to_ret_token = `${indentation}${prefix}${token.name}${separator} `;
-    let value = usesW3C ? token.$value : token.value;
+    let value = usesDtcg ? token.$value : token.value;
 
     /**
      * A single value can have multiple references either by interpolation:
@@ -200,8 +200,8 @@ export default function createPropertyFormatter({
         // because Style Dictionary resolved this in the resolution step.
         // Here we are undoing that by replacing the value with
         // the reference's name
-        if (Object.hasOwn(ref, `${usesW3C ? '$' : ''}value`) && Object.hasOwn(ref, 'name')) {
-          const refVal = usesW3C ? ref.$value : ref.value;
+        if (Object.hasOwn(ref, `${usesDtcg ? '$' : ''}value`) && Object.hasOwn(ref, 'name')) {
+          const refVal = usesDtcg ? ref.$value : ref.value;
           const replaceFunc = function () {
             if (format === 'css') {
               if (outputReferenceFallbacks) {

--- a/lib/common/formatHelpers/formattedVariables.js
+++ b/lib/common/formatHelpers/formattedVariables.js
@@ -36,6 +36,7 @@ const defaultFormatting = {
  * @param {Boolean} [options.outputReferences] - Whether or not to output references
  * @param {Formatting} [options.formatting] - Custom formatting properties that define parts of a declaration line in code. This will get passed to `formatHelpers.createPropertyFormatter` and used for the `lineSeparator` between lines of code.
  * @param {Boolean} [options.themeable] [false] - Whether tokens should default to being themeable.
+ * @param {boolean} [options.usesW3C] [false] - Whether W3C token syntax should be uses.
  * @returns {String}
  * @example
  * ```js
@@ -57,6 +58,7 @@ export default function formattedVariables({
   outputReferences = false,
   formatting = {},
   themeable = false,
+  usesW3C = false,
 }) {
   // typecast, we know that by know the tokens have been transformed
   let allTokens = /** @type {Token[]} */ (dictionary.allTokens);
@@ -87,6 +89,7 @@ export default function formattedVariables({
         format,
         formatting,
         themeable,
+        usesW3C,
       }),
     )
     .filter(function (strVal) {

--- a/lib/common/formatHelpers/formattedVariables.js
+++ b/lib/common/formatHelpers/formattedVariables.js
@@ -36,7 +36,7 @@ const defaultFormatting = {
  * @param {Boolean} [options.outputReferences] - Whether or not to output references
  * @param {Formatting} [options.formatting] - Custom formatting properties that define parts of a declaration line in code. This will get passed to `formatHelpers.createPropertyFormatter` and used for the `lineSeparator` between lines of code.
  * @param {Boolean} [options.themeable] [false] - Whether tokens should default to being themeable.
- * @param {boolean} [options.usesW3C] [false] - Whether W3C token syntax should be uses.
+ * @param {boolean} [options.usesDtcg] [false] - Whether DTCG token syntax should be uses.
  * @returns {String}
  * @example
  * ```js
@@ -58,7 +58,7 @@ export default function formattedVariables({
   outputReferences = false,
   formatting = {},
   themeable = false,
-  usesW3C = false,
+  usesDtcg = false,
 }) {
   // typecast, we know that by know the tokens have been transformed
   let allTokens = /** @type {Token[]} */ (dictionary.allTokens);
@@ -89,7 +89,7 @@ export default function formattedVariables({
         format,
         formatting,
         themeable,
-        usesW3C,
+        usesDtcg,
       }),
     )
     .filter(function (strVal) {

--- a/lib/common/formatHelpers/getTypeScriptType.js
+++ b/lib/common/formatHelpers/getTypeScriptType.js
@@ -13,6 +13,7 @@
 
 /**
  * @typedef {import('../../../types/Config.d.ts').LocalOptions} Options
+ * @typedef {import('../../../types/Config.d.ts').Config} Config
  */
 
 /**
@@ -36,7 +37,7 @@
  * });
  *```
  * @param {any} value A value to check the type of.
- * @param {Options & {outputStringLiterals?: boolean}} [options]
+ * @param {Options & Config & {outputStringLiterals?: boolean}} [options]
  * @return {String} A valid name for a TypeScript type.
  *
  */

--- a/lib/common/formatHelpers/iconsWithPrefix.js
+++ b/lib/common/formatHelpers/iconsWithPrefix.js
@@ -14,6 +14,7 @@
 /**
  * @typedef {import('../../../types/DesignToken.d.ts').TransformedToken} Token
  * @typedef {import('../../../types/Config.d.ts').LocalOptions} Options
+ * @typedef {import('../../../types/Config.d.ts').PlatformConfig} PlatformConfig
  */
 
 /**
@@ -27,6 +28,7 @@
  * @param {String} prefix - Character to prefix variable names, like '$' for Sass
  * @param {Token[]} allTokens - allTokens array on the dictionary object passed to the formatter function.
  * @param {Options} options - options object passed to the formatter function.
+ * @param {PlatformConfig} platform - platform specific options
  * @returns {String}
  * @example
  * ```js
@@ -38,14 +40,15 @@
  * });
  * ```
  */
-export default function iconsWithPrefix(prefix, allTokens, options) {
+export default function iconsWithPrefix(prefix, allTokens, options, platform) {
   return allTokens
     .filter(function (token) {
       return token.attributes?.category === 'content' && token.attributes.type === 'icon';
     })
     .map(function (token) {
-      const varName = prefix + token.name + ': ' + (token.$value ?? token.value) + ';';
-      const className = '.' + options.prefix + '-icon.' + token.attributes?.item + ':before ';
+      const varName =
+        prefix + token.name + ': ' + (options.usesW3C ? token.$value : token.value) + ';';
+      const className = '.' + platform.prefix + '-icon.' + token.attributes?.item + ':before ';
       const declaration = '{ content: ' + prefix + token.name + '; }';
       return varName + '\n' + className + declaration;
     })

--- a/lib/common/formatHelpers/iconsWithPrefix.js
+++ b/lib/common/formatHelpers/iconsWithPrefix.js
@@ -47,7 +47,7 @@ export default function iconsWithPrefix(prefix, allTokens, options, platform) {
     })
     .map(function (token) {
       const varName =
-        prefix + token.name + ': ' + (options.usesW3C ? token.$value : token.value) + ';';
+        prefix + token.name + ': ' + (options.usesDtcg ? token.$value : token.value) + ';';
       const className = '.' + platform.prefix + '-icon.' + token.attributes?.item + ':before ';
       const declaration = '{ content: ' + prefix + token.name + '; }';
       return varName + '\n' + className + declaration;

--- a/lib/common/formatHelpers/minifyDictionary.js
+++ b/lib/common/formatHelpers/minifyDictionary.js
@@ -20,7 +20,7 @@
  * @memberof module:formatHelpers
  * @name minifyDictionary
  * @param {Tokens} obj - The object to minify. You will most likely pass `dictionary.tokens` to it.
- * @param {boolean} [usesW3C] - Whether or not tokens are using W3C syntax.
+ * @param {boolean} [usesDtcg] - Whether or not tokens are using DTCG syntax.
  * @returns {Tokens}
  * @example
  * ```js
@@ -32,7 +32,7 @@
  * });
  * ```
  */
-export default function minifyDictionary(obj, usesW3C = false) {
+export default function minifyDictionary(obj, usesDtcg = false) {
   if (typeof obj !== 'object' || Array.isArray(obj)) {
     return obj;
   }
@@ -40,12 +40,12 @@ export default function minifyDictionary(obj, usesW3C = false) {
   /** @type {Tokens} */
   const toRet = {};
 
-  if (Object.hasOwn(obj, `${usesW3C ? '$' : ''}value`)) {
-    return usesW3C ? obj.$value : obj.value;
+  if (Object.hasOwn(obj, `${usesDtcg ? '$' : ''}value`)) {
+    return usesDtcg ? obj.$value : obj.value;
   } else {
     for (const name in obj) {
       if (Object.hasOwn(obj, name)) {
-        toRet[name] = minifyDictionary(obj[name], usesW3C);
+        toRet[name] = minifyDictionary(obj[name], usesDtcg);
       }
     }
   }

--- a/lib/common/formatHelpers/minifyDictionary.js
+++ b/lib/common/formatHelpers/minifyDictionary.js
@@ -20,6 +20,7 @@
  * @memberof module:formatHelpers
  * @name minifyDictionary
  * @param {Tokens} obj - The object to minify. You will most likely pass `dictionary.tokens` to it.
+ * @param {boolean} [usesW3C] - Whether or not tokens are using W3C syntax.
  * @returns {Tokens}
  * @example
  * ```js
@@ -31,7 +32,7 @@
  * });
  * ```
  */
-export default function minifyDictionary(obj) {
+export default function minifyDictionary(obj, usesW3C = false) {
   if (typeof obj !== 'object' || Array.isArray(obj)) {
     return obj;
   }
@@ -39,12 +40,12 @@ export default function minifyDictionary(obj) {
   /** @type {Tokens} */
   const toRet = {};
 
-  if (Object.hasOwn(obj, '$value') || Object.hasOwn(obj, 'value')) {
-    return obj.$value ?? obj.value;
+  if (Object.hasOwn(obj, `${usesW3C ? '$' : ''}value`)) {
+    return usesW3C ? obj.$value : obj.value;
   } else {
     for (const name in obj) {
       if (Object.hasOwn(obj, name)) {
-        toRet[name] = minifyDictionary(obj[name]);
+        toRet[name] = minifyDictionary(obj[name], usesW3C);
       }
     }
   }

--- a/lib/common/formatHelpers/sortByReference.js
+++ b/lib/common/formatHelpers/sortByReference.js
@@ -12,7 +12,7 @@
  */
 
 import usesReferences from '../../utils/references/usesReferences.js';
-import getReferences from '../../utils/references/getReferences.js';
+import { _getReferences } from '../../utils/references/getReferences.js';
 
 /**
  * @typedef {import('../../../types/DesignToken.d.ts').TransformedTokens} Tokens
@@ -57,10 +57,10 @@ export default function sortByReference(tokens, opts) {
     if (a.original && usesReferences(a.original.value)) {
       // Both a and b have references, we need to see if they reference each other
       if (b.original && usesReferences(b.original.value)) {
-        const aRefs = getReferences(a.original.value, tokens, {
+        const aRefs = _getReferences(a.original.value, tokens, {
           unfilteredTokens: opts?.unfilteredTokens,
         });
-        const bRefs = getReferences(b.original.value, tokens, {
+        const bRefs = _getReferences(b.original.value, tokens, {
           unfilteredTokens: opts?.unfilteredTokens,
         });
 

--- a/lib/common/formats.js
+++ b/lib/common/formats.js
@@ -83,11 +83,11 @@ const formats = {
    */
   'css/variables': function ({ dictionary, options = {}, file }) {
     const selector = options.selector ? options.selector : `:root`;
-    const { outputReferences } = options;
+    const { outputReferences, usesW3C } = options;
     return (
       fileHeader({ file }) +
       `${selector} {\n` +
-      formattedVariables({ format: 'css', dictionary, outputReferences }) +
+      formattedVariables({ format: 'css', dictionary, outputReferences, usesW3C }) +
       `\n}\n`
     );
   },
@@ -144,13 +144,13 @@ const formats = {
     const mapTemplate = _template(scssMapDeep);
 
     // Default the "themeable" option to true for backward compatibility.
-    const { outputReferences, themeable = true } = options;
+    const { outputReferences, themeable = true, usesW3C } = options;
     return (
       '\n' +
       fileHeader({ file, commentStyle: 'long' }) +
-      formattedVariables({ format: 'sass', dictionary, outputReferences, themeable }) +
+      formattedVariables({ format: 'sass', dictionary, outputReferences, themeable, usesW3C }) +
       '\n' +
-      mapTemplate({ dictionary, file })
+      mapTemplate({ dictionary, file, options })
     );
   },
 
@@ -173,10 +173,10 @@ const formats = {
    * ```
    */
   'scss/variables': function ({ dictionary, options, file }) {
-    const { outputReferences, themeable = false } = options;
+    const { outputReferences, themeable = false, usesW3C } = options;
     return (
       fileHeader({ file, commentStyle: 'short' }) +
-      formattedVariables({ format: 'sass', dictionary, outputReferences, themeable }) +
+      formattedVariables({ format: 'sass', dictionary, outputReferences, themeable, usesW3C }) +
       '\n'
     );
   },
@@ -193,10 +193,10 @@ const formats = {
    * .icon.email:before { content:$content-icon-email; }
    * ```
    */
-  'scss/icons': function ({ dictionary, options, file }) {
+  'scss/icons': function ({ dictionary, options, file, platform }) {
     return (
       fileHeader({ file, commentStyle: 'short' }) +
-      iconsWithPrefix('$', dictionary.allTokens, options)
+      iconsWithPrefix('$', dictionary.allTokens, options, platform)
     );
   },
 
@@ -216,10 +216,10 @@ const formats = {
    * ```
    */
   'less/variables': function ({ dictionary, options, file }) {
-    const { outputReferences } = options;
+    const { outputReferences, usesW3C } = options;
     return (
       fileHeader({ file, commentStyle: 'short' }) +
-      formattedVariables({ format: 'less', dictionary, outputReferences }) +
+      formattedVariables({ format: 'less', dictionary, outputReferences, usesW3C }) +
       '\n'
     );
   },
@@ -236,10 +236,10 @@ const formats = {
    * .icon.email:before { content:\@content-icon-email; }
    * ```
    */
-  'less/icons': function ({ dictionary, options, file }) {
+  'less/icons': function ({ dictionary, options, file, platform }) {
     return (
       fileHeader({ file, commentStyle: 'short' }) +
-      iconsWithPrefix('@', dictionary.allTokens, options)
+      iconsWithPrefix('@', dictionary.allTokens, options, platform)
     );
   },
 
@@ -256,10 +256,10 @@ const formats = {
    * ```
    */
   'stylus/variables': function ({ dictionary, options, file }) {
-    const { outputReferences } = options;
+    const { outputReferences, usesW3C } = options;
     return (
       fileHeader({ file, commentStyle: 'short' }) +
-      formattedVariables({ format: 'stylus', dictionary, outputReferences }) +
+      formattedVariables({ format: 'stylus', dictionary, outputReferences, usesW3C }) +
       '\n'
     );
   },
@@ -305,14 +305,16 @@ const formats = {
    *}
    *```
    */
-  'javascript/module-flat': function ({ dictionary, file }) {
+  'javascript/module-flat': function ({ dictionary, file, options }) {
     return (
       fileHeader({ file }) +
       'module.exports = ' +
       '{\n' +
       dictionary.allTokens
         .map(function (token) {
-          return `  "${token.name}": ${JSON.stringify(token.$value ?? token.value)}`;
+          return `  "${token.name}": ${JSON.stringify(
+            options.usesW3C ? token.$value : token.value,
+          )}`;
         })
         .join(',\n') +
       '\n}' +
@@ -441,7 +443,7 @@ const formats = {
    * export const ColorBackgroundAlt = '#fcfcfcfc';
    * ```
    */
-  'javascript/es6': function ({ dictionary, file }) {
+  'javascript/es6': function ({ dictionary, file, options }) {
     return (
       fileHeader({ file }) +
       dictionary.allTokens
@@ -450,7 +452,7 @@ const formats = {
             'export const ' +
             token.name +
             ' = ' +
-            JSON.stringify(token.$value ?? token.value) +
+            JSON.stringify(options.usesW3C ? token.$value : token.value) +
             ';';
           if (token.comment) to_ret = to_ret.concat(' // ' + token.comment);
           return to_ret;
@@ -486,9 +488,7 @@ const formats = {
    *
    * @memberof Formats
    * @kind member
-   * @typedef {Object} typescriptEs6DeclarationsOpts
-   * @property {Boolean} [options.outputStringLiterals=false] - Whether or not to output literal types for string values
-   * @param {FormatOpts & { options?: typescriptEs6DeclarationsOpts }} options
+   * @param {FormatOpts} options
    * @example
    * ```typescript
    * export const ColorBackgroundBase : string;
@@ -506,7 +506,7 @@ const formats = {
             'export const ' +
             token.name +
             ' : ' +
-            getTypeScriptType(token.$value ?? token.value, options) +
+            getTypeScriptType(options.usesW3C ? token.$value : token.value, options) +
             ';';
           return to_ret_token;
         })
@@ -577,7 +577,8 @@ const formats = {
      */
     function treeWalker(obj) {
       let type = Object.create(null);
-      if (Object.hasOwn(obj, '$value') || Object.hasOwn(obj, 'value')) {
+      const propToCheck = options.usesW3C ? '$value' : 'value';
+      if (Object.hasOwn(obj, propToCheck)) {
         type = 'DesignToken';
       } else {
         for (let k in obj)
@@ -593,8 +594,7 @@ const formats = {
 
     // TODO: find a browser+node compatible way to read from '../../types/DesignToken.d.ts'
     const designTokenInterface = `interface DesignToken {
-      value?: any;
-      $value?: any;
+      ${options.usesW3C ? '$' : ''}value?: any;
       name?: string;
       comment?: string;
       themeable?: boolean;
@@ -650,8 +650,8 @@ declare const ${moduleName}: ${JSON.stringify(treeWalker(dictionary.tokens), nul
    *  <dimen name="size_font_base">14sp</color>
    * ```
    */
-  'android/resources': function ({ dictionary, file }) {
-    return androidResources({ dictionary, file, fileHeader });
+  'android/resources': function ({ dictionary, file, options }) {
+    return androidResources({ dictionary, file, fileHeader, options });
   },
 
   /**
@@ -834,7 +834,7 @@ declare const ${moduleName}: ${JSON.stringify(treeWalker(dictionary.tokens), nul
   'compose/object': function ({ dictionary, options, file }) {
     const { allTokens, tokens, unfilteredTokens } = dictionary;
     const template = _template(composeObject);
-    const { outputReferences } = options;
+    const { outputReferences, usesW3C } = options;
     const formatProperty = createPropertyFormatter({
       outputReferences,
       dictionary,
@@ -842,6 +842,7 @@ declare const ${moduleName}: ${JSON.stringify(treeWalker(dictionary.tokens), nul
         suffix: '',
         commentStyle: 'none', // We will add the comment in the format template
       },
+      usesW3C,
     });
 
     let sortedTokens;
@@ -1027,7 +1028,7 @@ declare const ${moduleName}: ${JSON.stringify(treeWalker(dictionary.tokens), nul
   'ios-swift/class.swift': function ({ dictionary, options, file, platform }) {
     const { allTokens, tokens, unfilteredTokens } = dictionary;
     const template = _template(iosSwiftAny);
-    const { outputReferences } = options;
+    const { outputReferences, usesW3C } = options;
     options = setSwiftFileProperties(options, 'class', platform.transformGroup);
     const formatProperty = createPropertyFormatter({
       outputReferences,
@@ -1035,6 +1036,7 @@ declare const ${moduleName}: ${JSON.stringify(treeWalker(dictionary.tokens), nul
       formatting: {
         suffix: '',
       },
+      usesW3C,
     });
 
     let sortedTokens;
@@ -1068,7 +1070,7 @@ declare const ${moduleName}: ${JSON.stringify(treeWalker(dictionary.tokens), nul
   'ios-swift/enum.swift': function ({ dictionary, options, file, platform }) {
     const { allTokens, tokens, unfilteredTokens } = dictionary;
     const template = _template(iosSwiftAny);
-    const { outputReferences } = options;
+    const { outputReferences, usesW3C } = options;
     options = setSwiftFileProperties(options, 'enum', platform.transformGroup);
     const formatProperty = createPropertyFormatter({
       outputReferences,
@@ -1076,6 +1078,7 @@ declare const ${moduleName}: ${JSON.stringify(treeWalker(dictionary.tokens), nul
       formatting: {
         suffix: '',
       },
+      usesW3C,
     });
 
     let sortedTokens;
@@ -1119,7 +1122,7 @@ declare const ${moduleName}: ${JSON.stringify(treeWalker(dictionary.tokens), nul
   'ios-swift/any.swift': function ({ dictionary, options, file, platform }) {
     const { allTokens, tokens, unfilteredTokens } = dictionary;
     const template = _template(iosSwiftAny);
-    const { outputReferences } = options;
+    const { outputReferences, usesW3C } = options;
     options = setSwiftFileProperties(options, options.objectType, platform.transformGroup);
     const formatProperty = createPropertyFormatter({
       outputReferences,
@@ -1127,6 +1130,7 @@ declare const ${moduleName}: ${JSON.stringify(treeWalker(dictionary.tokens), nul
       formatting: {
         suffix: '',
       },
+      usesW3C,
     });
 
     let sortedTokens;
@@ -1214,8 +1218,8 @@ declare const ${moduleName}: ${JSON.stringify(treeWalker(dictionary.tokens), nul
    * }
    * ```
    */
-  'json/nested': function ({ dictionary }) {
-    return JSON.stringify(minifyDictionary(dictionary.tokens), null, 2) + '\n';
+  'json/nested': function ({ dictionary, options }) {
+    return JSON.stringify(minifyDictionary(dictionary.tokens, options.usesW3C), null, 2) + '\n';
   },
 
   /**
@@ -1231,12 +1235,14 @@ declare const ${moduleName}: ${JSON.stringify(treeWalker(dictionary.tokens), nul
    * }
    * ```
    */
-  'json/flat': function ({ dictionary }) {
+  'json/flat': function ({ dictionary, options }) {
     return (
       '{\n' +
       dictionary.allTokens
         .map(function (token) {
-          return `  "${token.name}": ${JSON.stringify(token.$value ?? token.value)}`;
+          return `  "${token.name}": ${JSON.stringify(
+            options.usesW3C ? token.$value : token.value,
+          )}`;
         })
         .join(',\n') +
       '\n}' +
@@ -1263,7 +1269,7 @@ declare const ${moduleName}: ${JSON.stringify(treeWalker(dictionary.tokens), nul
    * }
    * ```
    */
-  'sketch/palette': function ({ dictionary }) {
+  'sketch/palette': function ({ dictionary, options }) {
     const to_ret = {
       compatibleVersion: '1.0',
       pluginVersion: '1.1',
@@ -1275,7 +1281,7 @@ declare const ${moduleName}: ${JSON.stringify(treeWalker(dictionary.tokens), nul
         return token.attributes?.category === 'color' && token.attributes.type === 'base';
       })
       .map(function (token) {
-        return token.$value ?? token.value;
+        return options.usesW3C ? token.$value : token.value;
       });
     return JSON.stringify(to_ret, null, 2) + '\n';
   },
@@ -1301,7 +1307,7 @@ declare const ${moduleName}: ${JSON.stringify(treeWalker(dictionary.tokens), nul
    * }
    * ```
    */
-  'sketch/palette/v2': function ({ dictionary }) {
+  'sketch/palette/v2': function ({ dictionary, options }) {
     const to_ret = {
       compatibleVersion: '2.0',
       pluginVersion: '2.2',
@@ -1311,7 +1317,7 @@ declare const ${moduleName}: ${JSON.stringify(treeWalker(dictionary.tokens), nul
           {
             name: token.name,
           },
-          token.$value ?? token.value,
+          options.usesW3C ? token.$value : token.value,
         );
       }),
     };
@@ -1343,10 +1349,11 @@ declare const ${moduleName}: ${JSON.stringify(treeWalker(dictionary.tokens), nul
   'flutter/class.dart': function ({ dictionary, options, file }) {
     const { allTokens, tokens, unfilteredTokens } = dictionary;
     const template = _template(flutterClassDart);
-    const { outputReferences } = options;
+    const { outputReferences, usesW3C } = options;
     const formatProperty = createPropertyFormatter({
       outputReferences,
       dictionary,
+      usesW3C,
     });
 
     let sortedTokens;

--- a/lib/common/formats.js
+++ b/lib/common/formats.js
@@ -83,11 +83,11 @@ const formats = {
    */
   'css/variables': function ({ dictionary, options = {}, file }) {
     const selector = options.selector ? options.selector : `:root`;
-    const { outputReferences, usesW3C } = options;
+    const { outputReferences, usesDtcg } = options;
     return (
       fileHeader({ file }) +
       `${selector} {\n` +
-      formattedVariables({ format: 'css', dictionary, outputReferences, usesW3C }) +
+      formattedVariables({ format: 'css', dictionary, outputReferences, usesDtcg }) +
       `\n}\n`
     );
   },
@@ -144,11 +144,11 @@ const formats = {
     const mapTemplate = _template(scssMapDeep);
 
     // Default the "themeable" option to true for backward compatibility.
-    const { outputReferences, themeable = true, usesW3C } = options;
+    const { outputReferences, themeable = true, usesDtcg } = options;
     return (
       '\n' +
       fileHeader({ file, commentStyle: 'long' }) +
-      formattedVariables({ format: 'sass', dictionary, outputReferences, themeable, usesW3C }) +
+      formattedVariables({ format: 'sass', dictionary, outputReferences, themeable, usesDtcg }) +
       '\n' +
       mapTemplate({ dictionary, file, options })
     );
@@ -173,10 +173,10 @@ const formats = {
    * ```
    */
   'scss/variables': function ({ dictionary, options, file }) {
-    const { outputReferences, themeable = false, usesW3C } = options;
+    const { outputReferences, themeable = false, usesDtcg } = options;
     return (
       fileHeader({ file, commentStyle: 'short' }) +
-      formattedVariables({ format: 'sass', dictionary, outputReferences, themeable, usesW3C }) +
+      formattedVariables({ format: 'sass', dictionary, outputReferences, themeable, usesDtcg }) +
       '\n'
     );
   },
@@ -216,10 +216,10 @@ const formats = {
    * ```
    */
   'less/variables': function ({ dictionary, options, file }) {
-    const { outputReferences, usesW3C } = options;
+    const { outputReferences, usesDtcg } = options;
     return (
       fileHeader({ file, commentStyle: 'short' }) +
-      formattedVariables({ format: 'less', dictionary, outputReferences, usesW3C }) +
+      formattedVariables({ format: 'less', dictionary, outputReferences, usesDtcg }) +
       '\n'
     );
   },
@@ -256,10 +256,10 @@ const formats = {
    * ```
    */
   'stylus/variables': function ({ dictionary, options, file }) {
-    const { outputReferences, usesW3C } = options;
+    const { outputReferences, usesDtcg } = options;
     return (
       fileHeader({ file, commentStyle: 'short' }) +
-      formattedVariables({ format: 'stylus', dictionary, outputReferences, usesW3C }) +
+      formattedVariables({ format: 'stylus', dictionary, outputReferences, usesDtcg }) +
       '\n'
     );
   },
@@ -313,7 +313,7 @@ const formats = {
       dictionary.allTokens
         .map(function (token) {
           return `  "${token.name}": ${JSON.stringify(
-            options.usesW3C ? token.$value : token.value,
+            options.usesDtcg ? token.$value : token.value,
           )}`;
         })
         .join(',\n') +
@@ -452,7 +452,7 @@ const formats = {
             'export const ' +
             token.name +
             ' = ' +
-            JSON.stringify(options.usesW3C ? token.$value : token.value) +
+            JSON.stringify(options.usesDtcg ? token.$value : token.value) +
             ';';
           if (token.comment) to_ret = to_ret.concat(' // ' + token.comment);
           return to_ret;
@@ -506,7 +506,7 @@ const formats = {
             'export const ' +
             token.name +
             ' : ' +
-            getTypeScriptType(options.usesW3C ? token.$value : token.value, options) +
+            getTypeScriptType(options.usesDtcg ? token.$value : token.value, options) +
             ';';
           return to_ret_token;
         })
@@ -577,7 +577,7 @@ const formats = {
      */
     function treeWalker(obj) {
       let type = Object.create(null);
-      const propToCheck = options.usesW3C ? '$value' : 'value';
+      const propToCheck = options.usesDtcg ? '$value' : 'value';
       if (Object.hasOwn(obj, propToCheck)) {
         type = 'DesignToken';
       } else {
@@ -594,7 +594,7 @@ const formats = {
 
     // TODO: find a browser+node compatible way to read from '../../types/DesignToken.d.ts'
     const designTokenInterface = `interface DesignToken {
-      ${options.usesW3C ? '$' : ''}value?: any;
+      ${options.usesDtcg ? '$' : ''}value?: any;
       name?: string;
       comment?: string;
       themeable?: boolean;
@@ -834,7 +834,7 @@ declare const ${moduleName}: ${JSON.stringify(treeWalker(dictionary.tokens), nul
   'compose/object': function ({ dictionary, options, file }) {
     const { allTokens, tokens, unfilteredTokens } = dictionary;
     const template = _template(composeObject);
-    const { outputReferences, usesW3C } = options;
+    const { outputReferences, usesDtcg } = options;
     const formatProperty = createPropertyFormatter({
       outputReferences,
       dictionary,
@@ -842,7 +842,7 @@ declare const ${moduleName}: ${JSON.stringify(treeWalker(dictionary.tokens), nul
         suffix: '',
         commentStyle: 'none', // We will add the comment in the format template
       },
-      usesW3C,
+      usesDtcg,
     });
 
     let sortedTokens;
@@ -1028,7 +1028,7 @@ declare const ${moduleName}: ${JSON.stringify(treeWalker(dictionary.tokens), nul
   'ios-swift/class.swift': function ({ dictionary, options, file, platform }) {
     const { allTokens, tokens, unfilteredTokens } = dictionary;
     const template = _template(iosSwiftAny);
-    const { outputReferences, usesW3C } = options;
+    const { outputReferences, usesDtcg } = options;
     options = setSwiftFileProperties(options, 'class', platform.transformGroup);
     const formatProperty = createPropertyFormatter({
       outputReferences,
@@ -1036,7 +1036,7 @@ declare const ${moduleName}: ${JSON.stringify(treeWalker(dictionary.tokens), nul
       formatting: {
         suffix: '',
       },
-      usesW3C,
+      usesDtcg,
     });
 
     let sortedTokens;
@@ -1070,7 +1070,7 @@ declare const ${moduleName}: ${JSON.stringify(treeWalker(dictionary.tokens), nul
   'ios-swift/enum.swift': function ({ dictionary, options, file, platform }) {
     const { allTokens, tokens, unfilteredTokens } = dictionary;
     const template = _template(iosSwiftAny);
-    const { outputReferences, usesW3C } = options;
+    const { outputReferences, usesDtcg } = options;
     options = setSwiftFileProperties(options, 'enum', platform.transformGroup);
     const formatProperty = createPropertyFormatter({
       outputReferences,
@@ -1078,7 +1078,7 @@ declare const ${moduleName}: ${JSON.stringify(treeWalker(dictionary.tokens), nul
       formatting: {
         suffix: '',
       },
-      usesW3C,
+      usesDtcg,
     });
 
     let sortedTokens;
@@ -1122,7 +1122,7 @@ declare const ${moduleName}: ${JSON.stringify(treeWalker(dictionary.tokens), nul
   'ios-swift/any.swift': function ({ dictionary, options, file, platform }) {
     const { allTokens, tokens, unfilteredTokens } = dictionary;
     const template = _template(iosSwiftAny);
-    const { outputReferences, usesW3C } = options;
+    const { outputReferences, usesDtcg } = options;
     options = setSwiftFileProperties(options, options.objectType, platform.transformGroup);
     const formatProperty = createPropertyFormatter({
       outputReferences,
@@ -1130,7 +1130,7 @@ declare const ${moduleName}: ${JSON.stringify(treeWalker(dictionary.tokens), nul
       formatting: {
         suffix: '',
       },
-      usesW3C,
+      usesDtcg,
     });
 
     let sortedTokens;
@@ -1219,7 +1219,7 @@ declare const ${moduleName}: ${JSON.stringify(treeWalker(dictionary.tokens), nul
    * ```
    */
   'json/nested': function ({ dictionary, options }) {
-    return JSON.stringify(minifyDictionary(dictionary.tokens, options.usesW3C), null, 2) + '\n';
+    return JSON.stringify(minifyDictionary(dictionary.tokens, options.usesDtcg), null, 2) + '\n';
   },
 
   /**
@@ -1241,7 +1241,7 @@ declare const ${moduleName}: ${JSON.stringify(treeWalker(dictionary.tokens), nul
       dictionary.allTokens
         .map(function (token) {
           return `  "${token.name}": ${JSON.stringify(
-            options.usesW3C ? token.$value : token.value,
+            options.usesDtcg ? token.$value : token.value,
           )}`;
         })
         .join(',\n') +
@@ -1281,7 +1281,7 @@ declare const ${moduleName}: ${JSON.stringify(treeWalker(dictionary.tokens), nul
         return token.attributes?.category === 'color' && token.attributes.type === 'base';
       })
       .map(function (token) {
-        return options.usesW3C ? token.$value : token.value;
+        return options.usesDtcg ? token.$value : token.value;
       });
     return JSON.stringify(to_ret, null, 2) + '\n';
   },
@@ -1317,7 +1317,7 @@ declare const ${moduleName}: ${JSON.stringify(treeWalker(dictionary.tokens), nul
           {
             name: token.name,
           },
-          options.usesW3C ? token.$value : token.value,
+          options.usesDtcg ? token.$value : token.value,
         );
       }),
     };
@@ -1349,11 +1349,11 @@ declare const ${moduleName}: ${JSON.stringify(treeWalker(dictionary.tokens), nul
   'flutter/class.dart': function ({ dictionary, options, file }) {
     const { allTokens, tokens, unfilteredTokens } = dictionary;
     const template = _template(flutterClassDart);
-    const { outputReferences, usesW3C } = options;
+    const { outputReferences, usesDtcg } = options;
     const formatProperty = createPropertyFormatter({
       outputReferences,
       dictionary,
-      usesW3C,
+      usesDtcg,
     });
 
     let sortedTokens;

--- a/lib/common/templates/android/colors.template.js
+++ b/lib/common/templates/android/colors.template.js
@@ -21,6 +21,6 @@ const tokens = dictionary.allTokens.filter(function(token) {
 <%= fileHeader({file, commentStyle: 'xml'}) %>
 <resources>
   <% tokens.forEach(function(token) {
-  %><color name="<%= token.name %>"><%= token.$value ?? token.value %></color><% if (token.comment) { %><!-- <%= token.comment %> --><% } %>
+  %><color name="<%= token.name %>"><%= options.usesW3C ? token.$value : token.value %></color><% if (token.comment) { %><!-- <%= token.comment %> --><% } %>
   <% }); %>
 </resources>`;

--- a/lib/common/templates/android/colors.template.js
+++ b/lib/common/templates/android/colors.template.js
@@ -21,6 +21,6 @@ const tokens = dictionary.allTokens.filter(function(token) {
 <%= fileHeader({file, commentStyle: 'xml'}) %>
 <resources>
   <% tokens.forEach(function(token) {
-  %><color name="<%= token.name %>"><%= options.usesW3C ? token.$value : token.value %></color><% if (token.comment) { %><!-- <%= token.comment %> --><% } %>
+  %><color name="<%= token.name %>"><%= options.usesDtcg ? token.$value : token.value %></color><% if (token.comment) { %><!-- <%= token.comment %> --><% } %>
   <% }); %>
 </resources>`;

--- a/lib/common/templates/android/dimens.template.js
+++ b/lib/common/templates/android/dimens.template.js
@@ -20,6 +20,6 @@ const tokens = dictionary.allTokens.filter(function(token) {
 <%= fileHeader({file, commentStyle: 'xml'}) %>
 <resources>
   <% tokens.forEach(function(token) {
-  %><dimen name="<%= token.name %>"><%= token.$value ?? token.value %></dimen><% if (token.comment) { %><!-- <%= token.comment %> --><% } %>
+  %><dimen name="<%= token.name %>"><%= options.usesW3C ? token.$value : token.value %></dimen><% if (token.comment) { %><!-- <%= token.comment %> --><% } %>
   <% }); %>
 </resources>`;

--- a/lib/common/templates/android/dimens.template.js
+++ b/lib/common/templates/android/dimens.template.js
@@ -20,6 +20,6 @@ const tokens = dictionary.allTokens.filter(function(token) {
 <%= fileHeader({file, commentStyle: 'xml'}) %>
 <resources>
   <% tokens.forEach(function(token) {
-  %><dimen name="<%= token.name %>"><%= options.usesW3C ? token.$value : token.value %></dimen><% if (token.comment) { %><!-- <%= token.comment %> --><% } %>
+  %><dimen name="<%= token.name %>"><%= options.usesDtcg ? token.$value : token.value %></dimen><% if (token.comment) { %><!-- <%= token.comment %> --><% } %>
   <% }); %>
 </resources>`;

--- a/lib/common/templates/android/fontDimens.template.js
+++ b/lib/common/templates/android/fontDimens.template.js
@@ -20,6 +20,6 @@ const tokens = dictionary.allTokens.filter(function(token) {
 <%= fileHeader({file, commentStyle: 'xml'}) %>
 <resources>
   <% tokens.forEach(function(token) {
-  %><dimen name="<%= token.name %>"><%= token.$value ?? token.value %></dimen><% if (token.comment) { %><!-- <%= token.comment %> --><% } %>
+  %><dimen name="<%= token.name %>"><%= options.usesW3C ? token.$value : token.value %></dimen><% if (token.comment) { %><!-- <%= token.comment %> --><% } %>
   <% }); %>
 </resources>`;

--- a/lib/common/templates/android/fontDimens.template.js
+++ b/lib/common/templates/android/fontDimens.template.js
@@ -20,6 +20,6 @@ const tokens = dictionary.allTokens.filter(function(token) {
 <%= fileHeader({file, commentStyle: 'xml'}) %>
 <resources>
   <% tokens.forEach(function(token) {
-  %><dimen name="<%= token.name %>"><%= options.usesW3C ? token.$value : token.value %></dimen><% if (token.comment) { %><!-- <%= token.comment %> --><% } %>
+  %><dimen name="<%= token.name %>"><%= options.usesDtcg ? token.$value : token.value %></dimen><% if (token.comment) { %><!-- <%= token.comment %> --><% } %>
   <% }); %>
 </resources>`;

--- a/lib/common/templates/android/integers.template.js
+++ b/lib/common/templates/android/integers.template.js
@@ -20,6 +20,6 @@ var tokens = dictionary.allTokens.filter(function(token) {
 <%= fileHeader({file, commentStyle: 'xml'}) %>
 <resources>
   <% tokens.forEach(function(token) {
-  %><integer name="<%= token.name %>"><%= token.$value ?? token.value %></integer><% if (token.comment) { %><!-- <%= token.comment %> --><% } %>
+  %><integer name="<%= token.name %>"><%= options.usesW3C ? token.$value : token.value %></integer><% if (token.comment) { %><!-- <%= token.comment %> --><% } %>
   <% }); %>
 </resources>`;

--- a/lib/common/templates/android/integers.template.js
+++ b/lib/common/templates/android/integers.template.js
@@ -20,6 +20,6 @@ var tokens = dictionary.allTokens.filter(function(token) {
 <%= fileHeader({file, commentStyle: 'xml'}) %>
 <resources>
   <% tokens.forEach(function(token) {
-  %><integer name="<%= token.name %>"><%= options.usesW3C ? token.$value : token.value %></integer><% if (token.comment) { %><!-- <%= token.comment %> --><% } %>
+  %><integer name="<%= token.name %>"><%= options.usesDtcg ? token.$value : token.value %></integer><% if (token.comment) { %><!-- <%= token.comment %> --><% } %>
   <% }); %>
 </resources>`;

--- a/lib/common/templates/android/resources.template.js
+++ b/lib/common/templates/android/resources.template.js
@@ -18,6 +18,7 @@ import { usesReferences, getReferences } from 'style-dictionary/utils';
  * @typedef {import('../../../../types/DesignToken.d.ts').TransformedToken} Token
  * @typedef {import('../../../../types/DesignToken.d.ts').TransformedTokens} Tokens
  * @typedef {import('../../../../types/File.d.ts').File} File
+ * @typedef {import('../../../../types/Config.d.ts').Config} Config
  * @typedef {import('../../formatHelpers/fileHeader.js').default} FileHeader
  */
 
@@ -26,10 +27,11 @@ import { usesReferences, getReferences } from 'style-dictionary/utils';
  *   dictionary: Dictionary;
  *   file?: File;
  *   fileHeader?: FileHeader;
+ *   options: Config
  * }} opts
  */
 export default (opts) => {
-  const { file, fileHeader, dictionary } = opts;
+  const { file, fileHeader, dictionary, options } = opts;
 
   const resourceType = file?.resourceType || null;
 
@@ -65,7 +67,7 @@ export default (opts) => {
     if (file?.options && file.options.outputReferences && usesReferences(token.original.value)) {
       return `@${tokenToType(token)}/${getReferences(token.original.value, tokens)[0].name}`;
     } else {
-      return token.$value ?? token.value;
+      return options.usesW3C ? token.$value : token.value;
     }
   }
 

--- a/lib/common/templates/android/resources.template.js
+++ b/lib/common/templates/android/resources.template.js
@@ -67,7 +67,7 @@ export default (opts) => {
     if (file?.options && file.options.outputReferences && usesReferences(token.original.value)) {
       return `@${tokenToType(token)}/${getReferences(token.original.value, tokens)[0].name}`;
     } else {
-      return options.usesW3C ? token.$value : token.value;
+      return options.usesDtcg ? token.$value : token.value;
     }
   }
 

--- a/lib/common/templates/android/strings.template.js
+++ b/lib/common/templates/android/strings.template.js
@@ -20,6 +20,6 @@ const tokens = dictionary.allTokens.filter(function(token) {
 <%= fileHeader({file, commentStyle: 'xml'}) %>
 <resources>
   <% tokens.forEach(function(token) {
-  %><string name="<%= token.name %>"><%= options.usesW3C ? token.$value : token.value %></string><% if (token.comment) { %><!-- <%= token.comment %> --><% } %>
+  %><string name="<%= token.name %>"><%= options.usesDtcg ? token.$value : token.value %></string><% if (token.comment) { %><!-- <%= token.comment %> --><% } %>
   <% }); %>
 </resources>`;

--- a/lib/common/templates/android/strings.template.js
+++ b/lib/common/templates/android/strings.template.js
@@ -20,6 +20,6 @@ const tokens = dictionary.allTokens.filter(function(token) {
 <%= fileHeader({file, commentStyle: 'xml'}) %>
 <resources>
   <% tokens.forEach(function(token) {
-  %><string name="<%= token.name %>"><%= token.$value ?? token.value %></string><% if (token.comment) { %><!-- <%= token.comment %> --><% } %>
+  %><string name="<%= token.name %>"><%= options.usesW3C ? token.$value : token.value %></string><% if (token.comment) { %><!-- <%= token.comment %> --><% } %>
   <% }); %>
 </resources>`;

--- a/lib/common/templates/ios/colors.m.template.js
+++ b/lib/common/templates/ios/colors.m.template.js
@@ -31,7 +31,7 @@ export default `<%
 
   dispatch_once(&onceToken, ^{
     colorArray = @[
-<%= dictionary.allTokens.map(function(token){ return token.$value ?? token.value; }).join(',\\n') %>
+<%= dictionary.allTokens.map(function(token){ return options.usesW3C ? token.$value : token.value; }).join(',\\n') %>
     ];
   });
 

--- a/lib/common/templates/ios/colors.m.template.js
+++ b/lib/common/templates/ios/colors.m.template.js
@@ -31,7 +31,7 @@ export default `<%
 
   dispatch_once(&onceToken, ^{
     colorArray = @[
-<%= dictionary.allTokens.map(function(token){ return options.usesW3C ? token.$value : token.value; }).join(',\\n') %>
+<%= dictionary.allTokens.map(function(token){ return options.usesDtcg ? token.$value : token.value; }).join(',\\n') %>
     ];
   });
 

--- a/lib/common/templates/ios/macros.template.js
+++ b/lib/common/templates/ios/macros.template.js
@@ -21,5 +21,5 @@ export default `<%
 #import <UIKit/UIKit.h>
 
 <% dictionary.allTokens.forEach(function(token) {
-  %>#define <%= token.name %> <%= token.$value ?? token.value %>
+  %>#define <%= token.name %> <%= options.usesW3C ? token.$value : token.value %>
 <% }); %>`;

--- a/lib/common/templates/ios/macros.template.js
+++ b/lib/common/templates/ios/macros.template.js
@@ -21,5 +21,5 @@ export default `<%
 #import <UIKit/UIKit.h>
 
 <% dictionary.allTokens.forEach(function(token) {
-  %>#define <%= token.name %> <%= options.usesW3C ? token.$value : token.value %>
+  %>#define <%= token.name %> <%= options.usesDtcg ? token.$value : token.value %>
 <% }); %>`;

--- a/lib/common/templates/ios/plist.template.js
+++ b/lib/common/templates/ios/plist.template.js
@@ -28,18 +28,18 @@ const tokens = dictionary.allTokens.filter(function(token) {
     %><key><%= token.name %></key>
     <% if (token.attributes.category === 'color') { %><dict>
       <key>r</key>
-      <real><%= (token.$value ?? token.value)[0]/255 %></real>
+      <real><%= (options.usesW3C ? token.$value : token.value)[0]/255 %></real>
       <key>g</key>
-      <real><%= (token.$value ?? token.value)[1]/255 %></real>
+      <real><%= (options.usesW3C ? token.$value : token.value)[1]/255 %></real>
       <key>b</key>
-      <real><%= (token.$value ?? token.value)[2]/255 %></real>
+      <real><%= (options.usesW3C ? token.$value : token.value)[2]/255 %></real>
       <key>a</key>
       <real>1</real>
       </dict>
     <% } else if (token.attributes.category === 'size') { %></dict>
-      <integer><%= token.$value ?? token.value %></integer>
+      <integer><%= options.usesW3C ? token.$value : token.value %></integer>
     <% } else { %></dict>
-      <string><%= token.$value ?? token.value %></string>
+      <string><%= options.usesW3C ? token.$value : token.value %></string>
     <% } %><% if (token.comment) { %><!-- <%= token.comment %> --><% } %><% }); %>
   </dict>
 </plist>`;

--- a/lib/common/templates/ios/plist.template.js
+++ b/lib/common/templates/ios/plist.template.js
@@ -28,18 +28,18 @@ const tokens = dictionary.allTokens.filter(function(token) {
     %><key><%= token.name %></key>
     <% if (token.attributes.category === 'color') { %><dict>
       <key>r</key>
-      <real><%= (options.usesW3C ? token.$value : token.value)[0]/255 %></real>
+      <real><%= (options.usesDtcg ? token.$value : token.value)[0]/255 %></real>
       <key>g</key>
-      <real><%= (options.usesW3C ? token.$value : token.value)[1]/255 %></real>
+      <real><%= (options.usesDtcg ? token.$value : token.value)[1]/255 %></real>
       <key>b</key>
-      <real><%= (options.usesW3C ? token.$value : token.value)[2]/255 %></real>
+      <real><%= (options.usesDtcg ? token.$value : token.value)[2]/255 %></real>
       <key>a</key>
       <real>1</real>
       </dict>
     <% } else if (token.attributes.category === 'size') { %></dict>
-      <integer><%= options.usesW3C ? token.$value : token.value %></integer>
+      <integer><%= options.usesDtcg ? token.$value : token.value %></integer>
     <% } else { %></dict>
-      <string><%= options.usesW3C ? token.$value : token.value %></string>
+      <string><%= options.usesDtcg ? token.$value : token.value %></string>
     <% } %><% if (token.comment) { %><!-- <%= token.comment %> --><% } %><% }); %>
   </dict>
 </plist>`;

--- a/lib/common/templates/ios/singleton.m.template.js
+++ b/lib/common/templates/ios/singleton.m.template.js
@@ -45,8 +45,8 @@ export default `<%
 <% function buildDictionary(token, indent) {
   indent = indent || '  ';
   var to_ret = '@{\\n';
-  if (Object.hasOwn(token, \`\${options.usesW3C ? '$' : ''}value\`)) {
-    let value = options.usesW3C ? token.$value : token.value;
+  if (Object.hasOwn(token, \`\${options.usesDtcg ? '$' : ''}value\`)) {
+    let value = options.usesDtcg ? token.$value : token.value;
     if (token.attributes.category === 'size' || token.attributes.category === 'time') {
       value = '@' + value;
     }

--- a/lib/common/templates/ios/singleton.m.template.js
+++ b/lib/common/templates/ios/singleton.m.template.js
@@ -45,8 +45,8 @@ export default `<%
 <% function buildDictionary(token, indent) {
   indent = indent || '  ';
   var to_ret = '@{\\n';
-  if (Object.hasOwn(token, '$value') || Object.hasOwn(token, 'value')) {
-    let value = token.$value ?? token.value;
+  if (Object.hasOwn(token, \`\${options.usesW3C ? '$' : ''}value\`)) {
+    let value = options.usesW3C ? token.$value : token.value;
     if (token.attributes.category === 'size' || token.attributes.category === 'time') {
       value = '@' + value;
     }

--- a/lib/common/templates/ios/static.m.template.js
+++ b/lib/common/templates/ios/static.m.template.js
@@ -20,4 +20,4 @@ export default `<%
 #import "<%= file.className %>.h"
 
 <% dictionary.allTokens.forEach(function(token) {  %>
-<%= file.type %> const <%= token.name %> = <%= options.usesW3C ? token.$value : token.value %>;<% }); %>`;
+<%= file.type %> const <%= token.name %> = <%= options.usesDtcg ? token.$value : token.value %>;<% }); %>`;

--- a/lib/common/templates/ios/static.m.template.js
+++ b/lib/common/templates/ios/static.m.template.js
@@ -20,4 +20,4 @@ export default `<%
 #import "<%= file.className %>.h"
 
 <% dictionary.allTokens.forEach(function(token) {  %>
-<%= file.type %> const <%= token.name %> = <%= token.$value ?? token.value %>;<% }); %>`;
+<%= file.type %> const <%= token.name %> = <%= options.usesW3C ? token.$value : token.value %>;<% }); %>`;

--- a/lib/common/templates/ios/strings.m.template.js
+++ b/lib/common/templates/ios/strings.m.template.js
@@ -20,7 +20,7 @@ export default `<%
 #import "<%= file.className %>.h"
 
 <% dictionary.allTokens.forEach(function(token) {  %>
-NSString * const <%= token.name %> = <%= options.usesW3C ? token.$value : token.value %>;<% }); %>
+NSString * const <%= token.name %> = <%= options.usesDtcg ? token.$value : token.value %>;<% }); %>
 
 @implementation <%= file.className %>
 
@@ -41,7 +41,7 @@ NSString * const <%= token.name %> = <%= options.usesW3C ? token.$value : token.
 
 <% function buildProperty(token) {
   let to_ret = '@{\\n';
-  to_ret += '  ' + '@"value": ' + (options.usesW3C ? token.$value : token.value) + ',\\n';
+  to_ret += '  ' + '@"value": ' + (options.usesDtcg ? token.$value : token.value) + ',\\n';
   to_ret += '  ' + '@"name": @"' + token.name + '",\\n';
 
   for(const name in token.attributes) {

--- a/lib/common/templates/ios/strings.m.template.js
+++ b/lib/common/templates/ios/strings.m.template.js
@@ -20,7 +20,7 @@ export default `<%
 #import "<%= file.className %>.h"
 
 <% dictionary.allTokens.forEach(function(token) {  %>
-NSString * const <%= token.name %> = <%= token.$value ?? token.value %>;<% }); %>
+NSString * const <%= token.name %> = <%= options.usesW3C ? token.$value : token.value %>;<% }); %>
 
 @implementation <%= file.className %>
 
@@ -41,7 +41,7 @@ NSString * const <%= token.name %> = <%= token.$value ?? token.value %>;<% }); %
 
 <% function buildProperty(token) {
   let to_ret = '@{\\n';
-  to_ret += '  ' + '@"value": ' + (token.$value ?? token.value) + ',\\n';
+  to_ret += '  ' + '@"value": ' + (options.usesW3C ? token.$value : token.value) + ',\\n';
   to_ret += '  ' + '@"name": @"' + token.name + '",\\n';
 
   for(const name in token.attributes) {

--- a/lib/common/templates/scss/map-deep.template.js
+++ b/lib/common/templates/scss/map-deep.template.js
@@ -27,7 +27,7 @@ export default `<%
             output += \`''\`
         } else if (typeof obj === "string") {
             output += \`'\${obj}'\`
-        } else if (Object.hasOwn(obj, '$value') || Object.hasOwn(obj, 'value')) {
+        } else if (Object.hasOwn(obj, \`\${options.usesW3C ? '$' : ''}value\`)) {
             // if we have found a leaf (a property with a value) append the value
             output += \`$\${obj.name}\`;
         } else {

--- a/lib/common/templates/scss/map-deep.template.js
+++ b/lib/common/templates/scss/map-deep.template.js
@@ -27,7 +27,7 @@ export default `<%
             output += \`''\`
         } else if (typeof obj === "string") {
             output += \`'\${obj}'\`
-        } else if (Object.hasOwn(obj, \`\${options.usesW3C ? '$' : ''}value\`)) {
+        } else if (Object.hasOwn(obj, \`\${options.usesDtcg ? '$' : ''}value\`)) {
             // if we have found a leaf (a property with a value) append the value
             output += \`$\${obj.name}\`;
         } else {

--- a/lib/common/templates/scss/map-flat.template.js
+++ b/lib/common/templates/scss/map-flat.template.js
@@ -22,7 +22,7 @@ export default `<%
         if(token.comment) {
             line += '  // ' + token.comment + '\\n';
         }
-        const value = token.$value ?? token.value;
+        const value = options.usesW3C ? token.$value : token.value;
         line += '  \\'' + token.name + '\\': ' + (token.attributes.category==='asset' ? '"' + value + '"' : value)
         return line;
     }).join(',\\n');

--- a/lib/common/templates/scss/map-flat.template.js
+++ b/lib/common/templates/scss/map-flat.template.js
@@ -22,7 +22,7 @@ export default `<%
         if(token.comment) {
             line += '  // ' + token.comment + '\\n';
         }
-        const value = options.usesW3C ? token.$value : token.value;
+        const value = options.usesDtcg ? token.$value : token.value;
         line += '  \\'' + token.name + '\\': ' + (token.attributes.category==='asset' ? '"' + value + '"' : value)
         return line;
     }).join(',\\n');

--- a/lib/common/templates/static-style-guide/index.html.template.js
+++ b/lib/common/templates/static-style-guide/index.html.template.js
@@ -17,7 +17,7 @@ export default `<%
 
   const checkForStyle = function(token) {
     let toStyle = "";
-    const value = token.$value ?? token.value;
+    const value = options.usesW3C ? token.$value : token.value;
     if(value.match(colorRegex)) {
       if(token.path.indexOf('font')>-1) {
         toStyle += "color:" + value + ";";
@@ -66,7 +66,7 @@ export default `<%
         <% if(token.attributes && JSON.stringify(token.attributes)!=="{}") { %>
           <div class="style-guide-token-attributes-control"></div>
         <% } %>
-        <div class="style-guide-token-value"><%= token.$value ?? token.value %><% if(token.attributes.category === 'content' && token.attributes.type === 'icon') { %><i class="icon-font"><%= token.$value ?? token.value %></i><% } %></div>
+        <div class="style-guide-token-value"><%= options.usesW3C ? token.$value : token.value %><% if(token.attributes.category === 'content' && token.attributes.type === 'icon') { %><i class="icon-font"><%= options.usesW3C ? token.$value : token.value %></i><% } %></div>
         <% if(token.attributes && JSON.stringify(token.attributes)!=="{}") { %>
           <div class="style-guide-token-attributes"><%= JSON.stringify(token.attributes) %></div>
         <% } %>

--- a/lib/common/templates/static-style-guide/index.html.template.js
+++ b/lib/common/templates/static-style-guide/index.html.template.js
@@ -17,7 +17,7 @@ export default `<%
 
   const checkForStyle = function(token) {
     let toStyle = "";
-    const value = options.usesW3C ? token.$value : token.value;
+    const value = options.usesDtcg ? token.$value : token.value;
     if(value.match(colorRegex)) {
       if(token.path.indexOf('font')>-1) {
         toStyle += "color:" + value + ";";
@@ -66,7 +66,7 @@ export default `<%
         <% if(token.attributes && JSON.stringify(token.attributes)!=="{}") { %>
           <div class="style-guide-token-attributes-control"></div>
         <% } %>
-        <div class="style-guide-token-value"><%= options.usesW3C ? token.$value : token.value %><% if(token.attributes.category === 'content' && token.attributes.type === 'icon') { %><i class="icon-font"><%= options.usesW3C ? token.$value : token.value %></i><% } %></div>
+        <div class="style-guide-token-value"><%= options.usesDtcg ? token.$value : token.value %><% if(token.attributes.category === 'content' && token.attributes.type === 'icon') { %><i class="icon-font"><%= options.usesDtcg ? token.$value : token.value %></i><% } %></div>
         <% if(token.attributes && JSON.stringify(token.attributes)!=="{}") { %>
           <div class="style-guide-token-attributes"><%= JSON.stringify(token.attributes) %></div>
         <% } %>

--- a/lib/common/transforms.js
+++ b/lib/common/transforms.js
@@ -95,7 +95,7 @@ function isContent(token) {
  * @returns {string}
  */
 function wrapValueWith(character, token, options) {
-  return `${character}${options.usesW3C ? token.$value : token.value}${character}`;
+  return `${character}${options.usesDtcg ? token.$value : token.value}${character}`;
 }
 
 /**
@@ -183,7 +183,7 @@ export default {
     type: 'attribute',
     matcher: isColor,
     transformer: function (token, _, options) {
-      const color = Color(options.usesW3C ? token.$value : token.value);
+      const color = Color(options.usesDtcg ? token.$value : token.value);
       return {
         hex: color.toHex(),
         rgb: color.toRgb(),
@@ -369,7 +369,7 @@ export default {
     type: 'value',
     matcher: isColor,
     transformer: function (token, _, options) {
-      return Color(options.usesW3C ? token.$value : token.value).toRgbString();
+      return Color(options.usesDtcg ? token.$value : token.value).toRgbString();
     },
   },
 
@@ -389,7 +389,7 @@ export default {
     type: 'value',
     matcher: isColor,
     transformer: function (token, _, options) {
-      return Color(options.usesW3C ? token.$value : token.value).toHslString();
+      return Color(options.usesDtcg ? token.$value : token.value).toHslString();
     },
   },
 
@@ -409,7 +409,7 @@ export default {
     type: 'value',
     matcher: isColor,
     transformer: function (token, _, options) {
-      const color = Color(options.usesW3C ? token.$value : token.value);
+      const color = Color(options.usesDtcg ? token.$value : token.value);
       const o = color.toHsl();
       const vals = `${Math.round(o.h)} ${Math.round(o.s * 100)}% ${Math.round(o.l * 100)}%`;
       if (color.getAlpha() === 1) {
@@ -435,7 +435,7 @@ export default {
     type: 'value',
     matcher: isColor,
     transformer: function (token, _, options) {
-      return Color(options.usesW3C ? token.$value : token.value).toHexString();
+      return Color(options.usesDtcg ? token.$value : token.value).toHexString();
     },
   },
 
@@ -454,7 +454,7 @@ export default {
     type: 'value',
     matcher: isColor,
     transformer: function (token, _, options) {
-      return Color(options.usesW3C ? token.$value : token.value).toHex8String();
+      return Color(options.usesDtcg ? token.$value : token.value).toHex8String();
     },
   },
 
@@ -473,7 +473,7 @@ export default {
     type: 'value',
     matcher: isColor,
     transformer: function (token, _, options) {
-      const str = Color(options.usesW3C ? token.$value : token.value).toHex8();
+      const str = Color(options.usesDtcg ? token.$value : token.value).toHex8();
       return '#' + str.slice(6) + str.slice(0, 6);
     },
   },
@@ -493,7 +493,7 @@ export default {
     type: 'value',
     matcher: isColor,
     transformer: function (token, _, options) {
-      const str = Color(options.usesW3C ? token.$value : token.value).toHex8();
+      const str = Color(options.usesDtcg ? token.$value : token.value).toHex8();
       return 'Color(0x' + str.slice(6) + str.slice(0, 6) + ')';
     },
   },
@@ -513,7 +513,7 @@ export default {
     type: 'value',
     matcher: isColor,
     transformer: function (token, _, options) {
-      const rgb = Color(options.usesW3C ? token.$value : token.value).toRgb();
+      const rgb = Color(options.usesDtcg ? token.$value : token.value).toRgb();
       return (
         '[UIColor colorWithRed:' +
         (rgb.r / 255).toFixed(3) +
@@ -546,7 +546,7 @@ export default {
     type: 'value',
     matcher: isColor,
     transformer: function (token, _, options) {
-      const { r, g, b, a } = Color(options.usesW3C ? token.$value : token.value).toRgb();
+      const { r, g, b, a } = Color(options.usesDtcg ? token.$value : token.value).toRgb();
       const rFixed = (r / 255.0).toFixed(3);
       const gFixed = (g / 255.0).toFixed(3);
       const bFixed = (b / 255.0).toFixed(3);
@@ -569,7 +569,7 @@ export default {
     type: 'value',
     matcher: isColor,
     transformer: function (token, _, options) {
-      const { r, g, b, a } = Color(options.usesW3C ? token.$value : token.value).toRgb();
+      const { r, g, b, a } = Color(options.usesDtcg ? token.$value : token.value).toRgb();
       const rFixed = (r / 255.0).toFixed(3);
       const gFixed = (g / 255.0).toFixed(3);
       const bFixed = (b / 255.0).toFixed(3);
@@ -593,7 +593,7 @@ export default {
     type: 'value',
     matcher: isColor,
     transformer: function (token, _, options) {
-      const color = Color(options.usesW3C ? token.$value : token.value);
+      const color = Color(options.usesDtcg ? token.$value : token.value);
       if (color.getAlpha() === 1) {
         return color.toHexString();
       } else {
@@ -624,7 +624,7 @@ export default {
     type: 'value',
     matcher: /** @param {Token} token */ (token) => token.attributes?.category === 'color',
     transformer: function (token, _, options) {
-      let color = Color(options.usesW3C ? token.$value : token.value).toRgb();
+      let color = Color(options.usesDtcg ? token.$value : token.value).toRgb();
       return {
         red: (color.r / 255).toFixed(5),
         green: (color.g / 255).toFixed(5),
@@ -649,7 +649,7 @@ export default {
     type: 'value',
     matcher: isFontSize,
     transformer: function (token, _, options) {
-      const nonParsedVal = options.usesW3C ? token.$value : token.value;
+      const nonParsedVal = options.usesDtcg ? token.$value : token.value;
       const val = parseFloat(nonParsedVal);
       if (isNaN(val)) throwSizeError(token.name, nonParsedVal, 'sp');
       return val.toFixed(2) + 'sp';
@@ -671,7 +671,7 @@ export default {
     type: 'value',
     matcher: isNotFontSize,
     transformer: function (token, _, options) {
-      const nonParsedVal = options.usesW3C ? token.$value : token.value;
+      const nonParsedVal = options.usesDtcg ? token.$value : token.value;
       const val = parseFloat(nonParsedVal);
       if (isNaN(val)) throwSizeError(token.name, nonParsedVal, 'dp');
       return val.toFixed(2) + 'dp';
@@ -698,7 +698,7 @@ export default {
     type: 'value',
     matcher: isSize,
     transformer: function (token, config, options) {
-      const value = options.usesW3C ? token.$value : token.value;
+      const value = options.usesDtcg ? token.$value : token.value;
       const parsedVal = parseFloat(value);
       if (isNaN(parsedVal)) throwSizeError(token.name, value, 'object');
 
@@ -726,7 +726,7 @@ export default {
     type: 'value',
     matcher: isFontSize,
     transformer: function (token, config, options) {
-      const value = options.usesW3C ? token.$value : token.value;
+      const value = options.usesDtcg ? token.$value : token.value;
       const parsedVal = parseFloat(value);
       const baseFont = getBasePxFontSize(config);
       if (isNaN(parsedVal)) throwSizeError(token.name, value, 'sp');
@@ -749,7 +749,7 @@ export default {
     type: 'value',
     matcher: isNotFontSize,
     transformer: function (token, config, options) {
-      const value = options.usesW3C ? token.$value : token.value;
+      const value = options.usesDtcg ? token.$value : token.value;
       const parsedVal = parseFloat(value);
       const baseFont = getBasePxFontSize(config);
       if (isNaN(parsedVal)) throwSizeError(token.name, value, 'dp');
@@ -772,7 +772,7 @@ export default {
     type: 'value',
     matcher: isSize,
     transformer: function (token, _, options) {
-      const value = options.usesW3C ? token.$value : token.value;
+      const value = options.usesDtcg ? token.$value : token.value;
       const parsedVal = parseFloat(value);
       if (isNaN(parsedVal)) throwSizeError(token.name, value, 'px');
       return parsedVal + 'px';
@@ -794,7 +794,7 @@ export default {
     type: 'value',
     matcher: isSize,
     transformer: function (token, _, options) {
-      const nonParsed = options.usesW3C ? token.$value : token.value;
+      const nonParsed = options.usesDtcg ? token.$value : token.value;
       const parsedVal = parseFloat(nonParsed);
       if (isNaN(parsedVal)) throwSizeError(token.name, nonParsed, 'rem');
       return parsedVal + 'rem';
@@ -816,7 +816,7 @@ export default {
     type: 'value',
     matcher: isSize,
     transformer: function (token, config, options) {
-      const value = options.usesW3C ? token.$value : token.value;
+      const value = options.usesDtcg ? token.$value : token.value;
       const parsedVal = parseFloat(value);
       const baseFont = getBasePxFontSize(config);
       if (isNaN(parsedVal)) throwSizeError(token.name, value, 'pt');
@@ -839,7 +839,7 @@ export default {
     type: 'value',
     matcher: isFontSize,
     transformer: function (token, config, options) {
-      const value = options.usesW3C ? token.$value : token.value;
+      const value = options.usesDtcg ? token.$value : token.value;
       const parsedVal = parseFloat(value);
       const baseFont = getBasePxFontSize(config);
       if (isNaN(parsedVal)) throwSizeError(token.name, value, 'sp');
@@ -862,7 +862,7 @@ export default {
     type: 'value',
     matcher: isNotFontSize,
     transformer: function (token, config, options) {
-      const value = options.usesW3C ? token.$value : token.value;
+      const value = options.usesDtcg ? token.$value : token.value;
       const parsedVal = parseFloat(value);
       const baseFont = getBasePxFontSize(config);
       if (isNaN(parsedVal)) throwSizeError(token.name, value, 'dp');
@@ -885,7 +885,7 @@ export default {
     type: 'value',
     matcher: isFontSize,
     transformer: function (token, _, options) {
-      const value = options.usesW3C ? token.$value : token.value;
+      const value = options.usesDtcg ? token.$value : token.value;
       const parsedVal = parseFloat(value);
       if (isNaN(parsedVal)) throwSizeError(token.name, value, 'em');
       return parsedVal + '.em';
@@ -906,7 +906,7 @@ export default {
     type: 'value',
     matcher: isSize,
     transformer: function (token, config, options) {
-      const value = options.usesW3C ? token.$value : token.value;
+      const value = options.usesDtcg ? token.$value : token.value;
       const parsedVal = parseFloat(value);
       const baseFont = getBasePxFontSize(config);
       if (isNaN(parsedVal)) throwSizeError(token.name, value, 'CGFloat');
@@ -929,7 +929,7 @@ export default {
     type: 'value',
     matcher: isSize,
     transformer: function (token, config, options) {
-      const value = options.usesW3C ? token.$value : token.value;
+      const value = options.usesDtcg ? token.$value : token.value;
       const parsedVal = parseFloat(value);
       const baseFont = getBasePxFontSize(config);
       if (isNaN(parsedVal)) throwSizeError(token.name, value, 'px');
@@ -953,7 +953,7 @@ export default {
     type: 'value',
     matcher: isSize,
     transformer: (token, config, options) => {
-      const value = options.usesW3C ? token.$value : token.value;
+      const value = options.usesDtcg ? token.$value : token.value;
       const parsedVal = parseFloat(value);
       const baseFont = getBasePxFontSize(config);
 
@@ -986,7 +986,7 @@ export default {
       return token.attributes?.category === 'content' && token.attributes.type === 'icon';
     },
     transformer: function (token, _, options) {
-      return (options.usesW3C ? token.$value : token.value).replace(
+      return (options.usesDtcg ? token.$value : token.value).replace(
         UNICODE_PATTERN,
         /**
          * @param {string} match
@@ -1108,7 +1108,7 @@ export default {
       return token.attributes?.category === 'time';
     },
     transformer: function (token, _, options) {
-      return (parseFloat(options.usesW3C ? token.$value : token.value) / 1000).toFixed(2) + 's';
+      return (parseFloat(options.usesDtcg ? token.$value : token.value) / 1000).toFixed(2) + 's';
     },
   },
 
@@ -1127,7 +1127,7 @@ export default {
     type: 'value',
     matcher: isAsset,
     transformer: function (token, _, options) {
-      return convertToBase64(options.usesW3C ? token.$value : token.value);
+      return convertToBase64(options.usesDtcg ? token.$value : token.value);
     },
   },
 
@@ -1146,7 +1146,7 @@ export default {
     type: 'value',
     matcher: isAsset,
     transformer: function (token, _, options) {
-      return join(process?.cwd() ?? '/', options.usesW3C ? token.$value : token.value);
+      return join(process?.cwd() ?? '/', options.usesDtcg ? token.$value : token.value);
     },
   },
 
@@ -1198,7 +1198,7 @@ export default {
     type: 'value',
     matcher: isColor,
     transformer: function (token, _, options) {
-      const str = Color(options.usesW3C ? token.$value : token.value)
+      const str = Color(options.usesDtcg ? token.$value : token.value)
         .toHex8()
         .toUpperCase();
       return `Color(0x${str.slice(6)}${str.slice(0, 6)})`;
@@ -1270,7 +1270,7 @@ export default {
     matcher: isSize,
     transformer: function (token, config, options) {
       const baseFont = getBasePxFontSize(config);
-      return (parseFloat(options.usesW3C ? token.$value : token.value) * baseFont).toFixed(2);
+      return (parseFloat(options.usesDtcg ? token.$value : token.value) * baseFont).toFixed(2);
     },
   },
 };

--- a/lib/common/transforms.js
+++ b/lib/common/transforms.js
@@ -19,7 +19,8 @@ import convertToBase64 from '../utils/convertToBase64.js';
 /**
  * @typedef {import('../../types/Transform.d.ts').Transform} Transform
  * @typedef {import('../../types/DesignToken.d.ts').TransformedToken} Token
- * @typedef {import('../../types/Config.d.ts').PlatformConfig} Options
+ * @typedef {import('../../types/Config.d.ts').PlatformConfig} PlatformConfig
+ * @typedef {import('../../types/Config.d.ts').Config} Config
  */
 
 /**
@@ -90,18 +91,20 @@ function isContent(token) {
 /**
  * @param {string} character
  * @param {Token} token
+ * @param {Config} options
  * @returns {string}
  */
-function wrapValueWith(character, token) {
-  return `${character}${token.$value ?? token.value}${character}`;
+function wrapValueWith(character, token, options) {
+  return `${character}${options.usesW3C ? token.$value : token.value}${character}`;
 }
 
 /**
  * @param {Token} token
+ * @param {Config} options
  * @returns {string}
  */
-function wrapValueWithDoubleQuote(token) {
-  return wrapValueWith('"', token);
+function wrapValueWithDoubleQuote(token, options) {
+  return wrapValueWith('"', token, options);
 }
 
 /**
@@ -115,11 +118,11 @@ function throwSizeError(name, value, unitType) {
 }
 
 /**
- * @param {Options} options
+ * @param {PlatformConfig} config
  * @returns {number}
  */
-function getBasePxFontSize(options) {
-  return (options && options.basePxFontSize) || 16;
+function getBasePxFontSize(config) {
+  return (config && config.basePxFontSize) || 16;
 }
 
 /**
@@ -179,8 +182,8 @@ export default {
   'attribute/color': {
     type: 'attribute',
     matcher: isColor,
-    transformer: function (token) {
-      const color = Color(token.$value ?? token.value);
+    transformer: function (token, _, options) {
+      const color = Color(options.usesW3C ? token.$value : token.value);
       return {
         hex: color.toHex(),
         rgb: color.toRgb(),
@@ -222,8 +225,8 @@ export default {
    */
   'name/cti/camel': {
     type: 'name',
-    transformer: function (token, options) {
-      return camelCase([options.prefix].concat(token.path).join(' '), camelOpts);
+    transformer: function (token, config) {
+      return camelCase([config.prefix].concat(token.path).join(' '), camelOpts);
     },
   },
 
@@ -243,9 +246,9 @@ export default {
    */
   'name/ti/camel': {
     type: 'name',
-    transformer: function (token, options) {
+    transformer: function (token, config) {
       return camelCase(
-        [options.prefix].concat(token.path.slice(1, token.path.length)).join(' '),
+        [config.prefix].concat(token.path.slice(1, token.path.length)).join(' '),
         camelOpts,
       );
     },
@@ -265,8 +268,8 @@ export default {
    */
   'name/cti/kebab': {
     type: 'name',
-    transformer: function (token, options) {
-      return kebabCase([options.prefix].concat(token.path).join(' '));
+    transformer: function (token, config) {
+      return kebabCase([config.prefix].concat(token.path).join(' '));
     },
   },
 
@@ -284,8 +287,8 @@ export default {
    */
   'name/cti/snake': {
     type: 'name',
-    transformer: function (token, options) {
-      return snakeCase([options.prefix].concat(token.path).join(' '));
+    transformer: function (token, config) {
+      return snakeCase([config.prefix].concat(token.path).join(' '));
     },
   },
 
@@ -303,8 +306,8 @@ export default {
    */
   'name/cti/constant': {
     type: 'name',
-    transformer: function (token, options) {
-      return snakeCase([options.prefix].concat(token.path).join(' ')).toUpperCase();
+    transformer: function (token, config) {
+      return snakeCase([config.prefix].concat(token.path).join(' ')).toUpperCase();
     },
   },
 
@@ -322,9 +325,9 @@ export default {
    */
   'name/ti/constant': {
     type: 'name',
-    transformer: function (token, options) {
+    transformer: function (token, config) {
       const path = token.path.slice(1);
-      return snakeCase([options.prefix].concat(path).join(' ')).toUpperCase();
+      return snakeCase([config.prefix].concat(path).join(' ')).toUpperCase();
     },
   },
 
@@ -342,12 +345,12 @@ export default {
    */
   'name/cti/pascal': {
     type: 'name',
-    transformer: function (token, options) {
+    transformer: function (token, config) {
       /** @param {string} str */
       const upperFirst = function (str) {
         return str ? str[0].toUpperCase() + str.slice(1) : '';
       };
-      return upperFirst(camelCase([options.prefix].concat(token.path).join(' '), camelOpts));
+      return upperFirst(camelCase([config.prefix].concat(token.path).join(' '), camelOpts));
     },
   },
 
@@ -365,8 +368,8 @@ export default {
   'color/rgb': {
     type: 'value',
     matcher: isColor,
-    transformer: function (token) {
-      return Color(token.$value ?? token.value).toRgbString();
+    transformer: function (token, _, options) {
+      return Color(options.usesW3C ? token.$value : token.value).toRgbString();
     },
   },
 
@@ -385,8 +388,8 @@ export default {
   'color/hsl': {
     type: 'value',
     matcher: isColor,
-    transformer: function (token) {
-      return Color(token.$value ?? token.value).toHslString();
+    transformer: function (token, _, options) {
+      return Color(options.usesW3C ? token.$value : token.value).toHslString();
     },
   },
 
@@ -405,8 +408,8 @@ export default {
   'color/hsl-4': {
     type: 'value',
     matcher: isColor,
-    transformer: function (token) {
-      const color = Color(token.$value ?? token.value);
+    transformer: function (token, _, options) {
+      const color = Color(options.usesW3C ? token.$value : token.value);
       const o = color.toHsl();
       const vals = `${Math.round(o.h)} ${Math.round(o.s * 100)}% ${Math.round(o.l * 100)}%`;
       if (color.getAlpha() === 1) {
@@ -431,8 +434,8 @@ export default {
   'color/hex': {
     type: 'value',
     matcher: isColor,
-    transformer: function (token) {
-      return Color(token.$value ?? token.value).toHexString();
+    transformer: function (token, _, options) {
+      return Color(options.usesW3C ? token.$value : token.value).toHexString();
     },
   },
 
@@ -450,8 +453,8 @@ export default {
   'color/hex8': {
     type: 'value',
     matcher: isColor,
-    transformer: function (token) {
-      return Color(token.$value ?? token.value).toHex8String();
+    transformer: function (token, _, options) {
+      return Color(options.usesW3C ? token.$value : token.value).toHex8String();
     },
   },
 
@@ -469,8 +472,8 @@ export default {
   'color/hex8android': {
     type: 'value',
     matcher: isColor,
-    transformer: function (token) {
-      const str = Color(token.$value ?? token.value).toHex8();
+    transformer: function (token, _, options) {
+      const str = Color(options.usesW3C ? token.$value : token.value).toHex8();
       return '#' + str.slice(6) + str.slice(0, 6);
     },
   },
@@ -489,8 +492,8 @@ export default {
   'color/composeColor': {
     type: 'value',
     matcher: isColor,
-    transformer: function (token) {
-      const str = Color(token.$value ?? token.value).toHex8();
+    transformer: function (token, _, options) {
+      const str = Color(options.usesW3C ? token.$value : token.value).toHex8();
       return 'Color(0x' + str.slice(6) + str.slice(0, 6) + ')';
     },
   },
@@ -509,8 +512,8 @@ export default {
   'color/UIColor': {
     type: 'value',
     matcher: isColor,
-    transformer: function (token) {
-      const rgb = Color(token.$value ?? token.value).toRgb();
+    transformer: function (token, _, options) {
+      const rgb = Color(options.usesW3C ? token.$value : token.value).toRgb();
       return (
         '[UIColor colorWithRed:' +
         (rgb.r / 255).toFixed(3) +
@@ -542,8 +545,8 @@ export default {
   'color/UIColorSwift': {
     type: 'value',
     matcher: isColor,
-    transformer: function (token) {
-      const { r, g, b, a } = Color(token.$value ?? token.value).toRgb();
+    transformer: function (token, _, options) {
+      const { r, g, b, a } = Color(options.usesW3C ? token.$value : token.value).toRgb();
       const rFixed = (r / 255.0).toFixed(3);
       const gFixed = (g / 255.0).toFixed(3);
       const bFixed = (b / 255.0).toFixed(3);
@@ -565,8 +568,8 @@ export default {
   'color/ColorSwiftUI': {
     type: 'value',
     matcher: isColor,
-    transformer: function (token) {
-      const { r, g, b, a } = Color(token.$value ?? token.value).toRgb();
+    transformer: function (token, _, options) {
+      const { r, g, b, a } = Color(options.usesW3C ? token.$value : token.value).toRgb();
       const rFixed = (r / 255.0).toFixed(3);
       const gFixed = (g / 255.0).toFixed(3);
       const bFixed = (b / 255.0).toFixed(3);
@@ -589,8 +592,8 @@ export default {
   'color/css': {
     type: 'value',
     matcher: isColor,
-    transformer: function (token) {
-      const color = Color(token.$value ?? token.value);
+    transformer: function (token, _, options) {
+      const color = Color(options.usesW3C ? token.$value : token.value);
       if (color.getAlpha() === 1) {
         return color.toHexString();
       } else {
@@ -620,8 +623,8 @@ export default {
   'color/sketch': {
     type: 'value',
     matcher: /** @param {Token} token */ (token) => token.attributes?.category === 'color',
-    transformer: function (token) {
-      let color = Color(token.original.value).toRgb();
+    transformer: function (token, _, options) {
+      let color = Color(options.usesW3C ? token.$value : token.value).toRgb();
       return {
         red: (color.r / 255).toFixed(5),
         green: (color.g / 255).toFixed(5),
@@ -645,9 +648,10 @@ export default {
   'size/sp': {
     type: 'value',
     matcher: isFontSize,
-    transformer: function (token) {
-      const val = parseFloat(token.$value ?? token.value);
-      if (isNaN(val)) throwSizeError(token.name, token.$value ?? token.value, 'sp');
+    transformer: function (token, _, options) {
+      const nonParsedVal = options.usesW3C ? token.$value : token.value;
+      const val = parseFloat(nonParsedVal);
+      if (isNaN(val)) throwSizeError(token.name, nonParsedVal, 'sp');
       return val.toFixed(2) + 'sp';
     },
   },
@@ -666,9 +670,10 @@ export default {
   'size/dp': {
     type: 'value',
     matcher: isNotFontSize,
-    transformer: function (token) {
-      const val = parseFloat(token.$value ?? token.value);
-      if (isNaN(val)) throwSizeError(token.name, token.$value ?? token.value, 'dp');
+    transformer: function (token, _, options) {
+      const nonParsedVal = options.usesW3C ? token.$value : token.value;
+      const val = parseFloat(nonParsedVal);
+      if (isNaN(val)) throwSizeError(token.name, nonParsedVal, 'dp');
       return val.toFixed(2) + 'dp';
     },
   },
@@ -692,8 +697,8 @@ export default {
   'size/object': {
     type: 'value',
     matcher: isSize,
-    transformer: function (token, options) {
-      const value = token.$value ?? token.value;
+    transformer: function (token, config, options) {
+      const value = options.usesW3C ? token.$value : token.value;
       const parsedVal = parseFloat(value);
       if (isNaN(parsedVal)) throwSizeError(token.name, value, 'object');
 
@@ -701,7 +706,7 @@ export default {
         original: value,
         number: parsedVal,
         decimal: parsedVal / 100,
-        scale: parsedVal * getBasePxFontSize(options),
+        scale: parsedVal * getBasePxFontSize(config),
       };
     },
   },
@@ -720,10 +725,10 @@ export default {
   'size/remToSp': {
     type: 'value',
     matcher: isFontSize,
-    transformer: function (token, options) {
-      const value = token.$value ?? token.value;
+    transformer: function (token, config, options) {
+      const value = options.usesW3C ? token.$value : token.value;
       const parsedVal = parseFloat(value);
-      const baseFont = getBasePxFontSize(options);
+      const baseFont = getBasePxFontSize(config);
       if (isNaN(parsedVal)) throwSizeError(token.name, value, 'sp');
       return (parsedVal * baseFont).toFixed(2) + 'sp';
     },
@@ -743,10 +748,10 @@ export default {
   'size/remToDp': {
     type: 'value',
     matcher: isNotFontSize,
-    transformer: function (token, options) {
-      const value = token.$value ?? token.value;
+    transformer: function (token, config, options) {
+      const value = options.usesW3C ? token.$value : token.value;
       const parsedVal = parseFloat(value);
-      const baseFont = getBasePxFontSize(options);
+      const baseFont = getBasePxFontSize(config);
       if (isNaN(parsedVal)) throwSizeError(token.name, value, 'dp');
       return (parsedVal * baseFont).toFixed(2) + 'dp';
     },
@@ -766,8 +771,8 @@ export default {
   'size/px': {
     type: 'value',
     matcher: isSize,
-    transformer: function (token) {
-      const value = token.$value ?? token.value;
+    transformer: function (token, _, options) {
+      const value = options.usesW3C ? token.$value : token.value;
       const parsedVal = parseFloat(value);
       if (isNaN(parsedVal)) throwSizeError(token.name, value, 'px');
       return parsedVal + 'px';
@@ -788,9 +793,10 @@ export default {
   'size/rem': {
     type: 'value',
     matcher: isSize,
-    transformer: function (token) {
-      const parsedVal = parseFloat(token.$value ?? token.value);
-      if (isNaN(parsedVal)) throwSizeError(token.name, token.$value ?? token.value, 'rem');
+    transformer: function (token, _, options) {
+      const nonParsed = options.usesW3C ? token.$value : token.value;
+      const parsedVal = parseFloat(nonParsed);
+      if (isNaN(parsedVal)) throwSizeError(token.name, nonParsed, 'rem');
       return parsedVal + 'rem';
     },
   },
@@ -809,10 +815,10 @@ export default {
   'size/remToPt': {
     type: 'value',
     matcher: isSize,
-    transformer: function (token, options) {
-      const value = token.$value ?? token.value;
+    transformer: function (token, config, options) {
+      const value = options.usesW3C ? token.$value : token.value;
       const parsedVal = parseFloat(value);
-      const baseFont = getBasePxFontSize(options);
+      const baseFont = getBasePxFontSize(config);
       if (isNaN(parsedVal)) throwSizeError(token.name, value, 'pt');
       return (parsedVal * baseFont).toFixed(2) + 'f';
     },
@@ -832,10 +838,10 @@ export default {
   'size/compose/remToSp': {
     type: 'value',
     matcher: isFontSize,
-    transformer: function (token, options) {
-      const value = token.$value ?? token.value;
+    transformer: function (token, config, options) {
+      const value = options.usesW3C ? token.$value : token.value;
       const parsedVal = parseFloat(value);
-      const baseFont = getBasePxFontSize(options);
+      const baseFont = getBasePxFontSize(config);
       if (isNaN(parsedVal)) throwSizeError(token.name, value, 'sp');
       return (parsedVal * baseFont).toFixed(2) + '.sp';
     },
@@ -855,10 +861,10 @@ export default {
   'size/compose/remToDp': {
     type: 'value',
     matcher: isNotFontSize,
-    transformer: function (token, options) {
-      const value = token.$value ?? token.value;
+    transformer: function (token, config, options) {
+      const value = options.usesW3C ? token.$value : token.value;
       const parsedVal = parseFloat(value);
-      const baseFont = getBasePxFontSize(options);
+      const baseFont = getBasePxFontSize(config);
       if (isNaN(parsedVal)) throwSizeError(token.name, value, 'dp');
       return (parsedVal * baseFont).toFixed(2) + '.dp';
     },
@@ -878,8 +884,8 @@ export default {
   'size/compose/em': {
     type: 'value',
     matcher: isFontSize,
-    transformer: function (token) {
-      const value = token.$value ?? token.value;
+    transformer: function (token, _, options) {
+      const value = options.usesW3C ? token.$value : token.value;
       const parsedVal = parseFloat(value);
       if (isNaN(parsedVal)) throwSizeError(token.name, value, 'em');
       return parsedVal + '.em';
@@ -899,10 +905,10 @@ export default {
   'size/swift/remToCGFloat': {
     type: 'value',
     matcher: isSize,
-    transformer: function (token, options) {
-      const value = token.$value ?? token.value;
+    transformer: function (token, config, options) {
+      const value = options.usesW3C ? token.$value : token.value;
       const parsedVal = parseFloat(value);
-      const baseFont = getBasePxFontSize(options);
+      const baseFont = getBasePxFontSize(config);
       if (isNaN(parsedVal)) throwSizeError(token.name, value, 'CGFloat');
       return `CGFloat(${(parsedVal * baseFont).toFixed(2)})`;
     },
@@ -922,10 +928,10 @@ export default {
   'size/remToPx': {
     type: 'value',
     matcher: isSize,
-    transformer: function (token, options) {
-      const value = token.$value ?? token.value;
+    transformer: function (token, config, options) {
+      const value = options.usesW3C ? token.$value : token.value;
       const parsedVal = parseFloat(value);
-      const baseFont = getBasePxFontSize(options);
+      const baseFont = getBasePxFontSize(config);
       if (isNaN(parsedVal)) throwSizeError(token.name, value, 'px');
       return (parsedVal * baseFont).toFixed(0) + 'px';
     },
@@ -946,10 +952,10 @@ export default {
   'size/pxToRem': {
     type: 'value',
     matcher: isSize,
-    transformer: (token, options) => {
-      const baseFont = getBasePxFontSize(options);
-      const value = token.$value ?? token.value;
+    transformer: (token, config, options) => {
+      const value = options.usesW3C ? token.$value : token.value;
       const parsedVal = parseFloat(value);
+      const baseFont = getBasePxFontSize(config);
 
       if (isNaN(parsedVal)) {
         throwSizeError(token.name, value, 'rem');
@@ -976,11 +982,11 @@ export default {
    */
   'content/icon': {
     type: 'value',
-    matcher: /** @param {Token} token */ function (token) {
+    matcher: function (token) {
       return token.attributes?.category === 'content' && token.attributes.type === 'icon';
     },
-    transformer: function (token) {
-      return (token.$value ?? token.value).replace(
+    transformer: function (token, _, options) {
+      return (options.usesW3C ? token.$value : token.value).replace(
         UNICODE_PATTERN,
         /**
          * @param {string} match
@@ -1006,8 +1012,8 @@ export default {
   'content/quote': {
     type: 'value',
     matcher: isContent,
-    transformer: function (token) {
-      return wrapValueWith("'", token);
+    transformer: function (token, _, options) {
+      return wrapValueWith("'", token, options);
     },
   },
 
@@ -1025,8 +1031,8 @@ export default {
   'content/objC/literal': {
     type: 'value',
     matcher: isContent,
-    transformer: function (token) {
-      return '@' + wrapValueWithDoubleQuote(token);
+    transformer: function (token, _, options) {
+      return '@' + wrapValueWithDoubleQuote(token, options);
     },
   },
 
@@ -1044,7 +1050,7 @@ export default {
   'content/swift/literal': {
     type: 'value',
     matcher: isContent,
-    transformer: wrapValueWithDoubleQuote,
+    transformer: (token, _, options) => wrapValueWithDoubleQuote(token, options),
   },
 
   /**
@@ -1059,11 +1065,11 @@ export default {
    */
   'font/objC/literal': {
     type: 'value',
-    matcher: /** @param {Token} token */ function (token) {
+    matcher: function (token) {
       return token.attributes?.category === 'font';
     },
-    transformer: function (token) {
-      return '@' + wrapValueWithDoubleQuote(token);
+    transformer: function (token, _, options) {
+      return '@' + wrapValueWithDoubleQuote(token, options);
     },
   },
 
@@ -1079,10 +1085,10 @@ export default {
    */
   'font/swift/literal': {
     type: 'value',
-    matcher: /** @param {Token} token */ function (token) {
+    matcher: function (token) {
       return token.attributes?.category === 'font';
     },
-    transformer: wrapValueWithDoubleQuote,
+    transformer: (token, _, options) => wrapValueWithDoubleQuote(token, options),
   },
 
   /**
@@ -1098,11 +1104,11 @@ export default {
    */
   'time/seconds': {
     type: 'value',
-    matcher: /** @param {Token} token */ function (token) {
+    matcher: function (token) {
       return token.attributes?.category === 'time';
     },
-    transformer: function (token) {
-      return (parseFloat(token.$value ?? token.value) / 1000).toFixed(2) + 's';
+    transformer: function (token, _, options) {
+      return (parseFloat(options.usesW3C ? token.$value : token.value) / 1000).toFixed(2) + 's';
     },
   },
 
@@ -1120,8 +1126,8 @@ export default {
   'asset/base64': {
     type: 'value',
     matcher: isAsset,
-    transformer: function (token) {
-      return convertToBase64(token.$value ?? token.value);
+    transformer: function (token, _, options) {
+      return convertToBase64(options.usesW3C ? token.$value : token.value);
     },
   },
 
@@ -1139,8 +1145,8 @@ export default {
   'asset/path': {
     type: 'value',
     matcher: isAsset,
-    transformer: function (token) {
-      return join(process?.cwd() ?? '/', token.$value ?? token.value);
+    transformer: function (token, _, options) {
+      return join(process?.cwd() ?? '/', options.usesW3C ? token.$value : token.value);
     },
   },
 
@@ -1157,8 +1163,8 @@ export default {
   'asset/objC/literal': {
     type: 'value',
     matcher: isAsset,
-    transformer: function (token) {
-      return '@' + wrapValueWithDoubleQuote(token);
+    transformer: function (token, _, options) {
+      return '@' + wrapValueWithDoubleQuote(token, options);
     },
   },
 
@@ -1175,7 +1181,7 @@ export default {
   'asset/swift/literal': {
     type: 'value',
     matcher: isAsset,
-    transformer: wrapValueWithDoubleQuote,
+    transformer: (token, _, options) => wrapValueWithDoubleQuote(token, options),
   },
 
   /**
@@ -1191,8 +1197,8 @@ export default {
   'color/hex8flutter': {
     type: 'value',
     matcher: isColor,
-    transformer: function (token) {
-      const str = Color(token.$value ?? token.value)
+    transformer: function (token, _, options) {
+      const str = Color(options.usesW3C ? token.$value : token.value)
         .toHex8()
         .toUpperCase();
       return `Color(0x${str.slice(6)}${str.slice(0, 6)})`;
@@ -1212,7 +1218,7 @@ export default {
   'content/flutter/literal': {
     type: 'value',
     matcher: isContent,
-    transformer: wrapValueWithDoubleQuote,
+    transformer: (token, _, options) => wrapValueWithDoubleQuote(token, options),
   },
 
   /**
@@ -1228,7 +1234,7 @@ export default {
   'asset/flutter/literal': {
     type: 'value',
     matcher: isAsset,
-    transformer: wrapValueWithDoubleQuote,
+    transformer: (token, _, options) => wrapValueWithDoubleQuote(token, options),
   },
 
   /**
@@ -1246,7 +1252,7 @@ export default {
     matcher: /** @param {Token} token */ function (token) {
       return token.attributes?.category === 'font';
     },
-    transformer: wrapValueWithDoubleQuote,
+    transformer: (token, _, options) => wrapValueWithDoubleQuote(token, options),
   },
 
   /**
@@ -1262,9 +1268,9 @@ export default {
   'size/flutter/remToDouble': {
     type: 'value',
     matcher: isSize,
-    transformer: function (token, options) {
-      const baseFont = getBasePxFontSize(options);
-      return (parseFloat(token.$value ?? token.value) * baseFont).toFixed(2);
+    transformer: function (token, config, options) {
+      const baseFont = getBasePxFontSize(config);
+      return (parseFloat(options.usesW3C ? token.$value : token.value) * baseFont).toFixed(2);
     },
   },
 };

--- a/lib/filterTokens.js
+++ b/lib/filterTokens.js
@@ -17,6 +17,7 @@ import isPlainObject from 'is-plain-obj';
  * @typedef {import('../types/DesignToken.d.ts').TransformedTokens} Tokens
  * @typedef {import('../types/DesignToken.d.ts').TransformedToken} Token
  * @typedef {import('../types/Filter.d.ts').Matcher} Matcher
+ * @typedef {import('../types/Config.d.ts').Config} Config
  */
 
 /**
@@ -27,14 +28,15 @@ import isPlainObject from 'is-plain-obj';
  * @param {Matcher} filter - A function that receives a property object and
  *   returns `true` if the property should be included in the output or `false`
  *   if the property should be excluded from the output.
+ * @param {Config} options
  * @returns {Tokens} tokens - A new object containing only the tokens
  *   that matched the filter.
  */
-function filterTokenObject(tokens, filter) {
+function filterTokenObject(tokens, filter, options) {
   // Use reduce to generate a new object with the unwanted tokens filtered
   // out
   return Object.entries(tokens ?? []).reduce((acc, [key, token]) => {
-    const tokenValue = token.$value ?? token.value;
+    const tokenValue = options.usesW3C ? token.$value : token.value;
     // If the token is not an object, we don't know what it is. We return it as-is.
     if (!isPlainObject(token)) {
       return acc;
@@ -47,7 +49,7 @@ function filterTokenObject(tokens, filter) {
       // it's an object containing multiple tokens and recursively filter it
       // using the `filterTokenObject` function.
     } else {
-      const filtered = filterTokenObject(token, filter);
+      const filtered = filterTokenObject(token, filter, options);
       // If the filtered object is not empty then add it to the final `acc`
       // object. If it is empty then every property inside of it was filtered
       // out, then exclude it entirely from the final `acc` object.
@@ -64,11 +66,12 @@ function filterTokenObject(tokens, filter) {
  * @param {Matcher} filter - A function that receives a token object
  *   and returns `true` if the token should be included in the output
  *   or `false` if the token should be excluded from the output
+ * @param {Config} [options]
  * @returns {Dictionary} dictionary - A new dictionary containing only the
  *   tokens that matched the filter (or the original dictionary if no filter
  *   function was provided).
  */
-export default function filterTokens(dictionary, filter) {
+export default function filterTokens(dictionary, filter, options = {}) {
   if (!filter) {
     return dictionary;
   } else {
@@ -77,7 +80,7 @@ export default function filterTokens(dictionary, filter) {
     } else {
       return {
         allTokens: (dictionary.allTokens ?? []).filter(filter),
-        tokens: filterTokenObject(dictionary.tokens, filter),
+        tokens: filterTokenObject(dictionary.tokens, filter, options),
       };
     }
   }

--- a/lib/filterTokens.js
+++ b/lib/filterTokens.js
@@ -36,7 +36,7 @@ function filterTokenObject(tokens, filter, options) {
   // Use reduce to generate a new object with the unwanted tokens filtered
   // out
   return Object.entries(tokens ?? []).reduce((acc, [key, token]) => {
-    const tokenValue = options.usesW3C ? token.$value : token.value;
+    const tokenValue = options.usesDtcg ? token.$value : token.value;
     // If the token is not an object, we don't know what it is. We return it as-is.
     if (!isPlainObject(token)) {
       return acc;

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -12,6 +12,7 @@ export let fs = /** @type {memfs|nodefs} */ ((await import('@bundled-es-modules/
  * since ES modules exports are read-only, use a setter
  * @param {memfs|nodefs} _fs
  */
+/* c8 ignore next 3 */
 export const setFs = (_fs) => {
   fs = _fs;
 };

--- a/lib/performActions.js
+++ b/lib/performActions.js
@@ -13,7 +13,8 @@
 
 /**
  * @typedef {import('../types/DesignToken.d.ts').Dictionary} Dictionary
- * @typedef {import('../types/Config.d.ts').PlatformConfig} Config
+ * @typedef {import('../types/Config.d.ts').PlatformConfig} PlatformConfig
+ *  @typedef {import('../types/Config.d.ts').Config} Config
  */
 
 /**
@@ -23,15 +24,16 @@
  * @private
  * @memberof module:style-dictionary
  * @param {Dictionary} dictionary
- * @param {Config} platform
+ * @param {PlatformConfig} platform
+ * @param {Config} options
  * @returns
  */
-export default function performActions(dictionary, platform) {
+export default function performActions(dictionary, platform, options) {
   if (platform.actions) {
     platform.actions.forEach(function (action) {
       // ensure we've augmented action with the do/undo functions
       if (typeof action !== 'string') {
-        action.do(dictionary, platform);
+        action.do(dictionary, platform, options);
       }
     });
   }

--- a/lib/transform/object.js
+++ b/lib/transform/object.js
@@ -63,7 +63,7 @@ export default function transformObject(
     //   value: "#ababab"
     //   ...
     // }
-    if (isObj && Object.hasOwn(objProp, `${options.usesW3C ? '$' : ''}value`)) {
+    if (isObj && Object.hasOwn(objProp, `${options.usesDtcg ? '$' : ''}value`)) {
       const pathName = getName(path);
       const alreadyTransformed = transformedPropRefs.indexOf(pathName) !== -1;
 
@@ -89,7 +89,7 @@ export default function transformObject(
       };
 
       // If property has a reference, defer its transformations until later
-      if (usesReferences(options.usesW3C ? token.$value : token.value, config)) {
+      if (usesReferences(options.usesDtcg ? token.$value : token.value, config)) {
         deferProp();
         continue;
       }

--- a/lib/transform/object.js
+++ b/lib/transform/object.js
@@ -23,6 +23,7 @@ import tokenSetup from './tokenSetup.js';
  * @typedef {import('../../types/DesignToken.d.ts').DesignToken} Token
  * @typedef {import('../../types/DesignToken.d.ts').TransformedToken} TransformedToken
  * @typedef {import('../../types/Config.d.ts').PlatformConfig} PlatformConfig
+ * @typedef {import('../../types/Config.d.ts').Config} Config
  */
 
 /**
@@ -33,7 +34,8 @@ import tokenSetup from './tokenSetup.js';
  * on the same style dictionary.
  * @private
  * @param {Tokens|TransformedTokens} obj
- * @param {PlatformConfig} options
+ * @param {PlatformConfig} config
+ * @param {Config} options
  * @param {{ transformedPropRefs?: string[], deferredPropValueTransforms?: string[] }} [ctx]
  * @param {string[]} [path]
  * @param {Record<string, Tokens|TransformedTokens|Token|TransformedToken>} [transformedObj]
@@ -41,6 +43,7 @@ import tokenSetup from './tokenSetup.js';
  */
 export default function transformObject(
   obj,
+  config,
   options,
   { transformedPropRefs = [], deferredPropValueTransforms = [] } = {},
   path = [],
@@ -60,7 +63,7 @@ export default function transformObject(
     //   value: "#ababab"
     //   ...
     // }
-    if (isObj && (Object.hasOwn(objProp, '$value') || Object.hasOwn(objProp, 'value'))) {
+    if (isObj && Object.hasOwn(objProp, `${options.usesW3C ? '$' : ''}value`)) {
       const pathName = getName(path);
       const alreadyTransformed = transformedPropRefs.indexOf(pathName) !== -1;
 
@@ -86,14 +89,14 @@ export default function transformObject(
       };
 
       // If property has a reference, defer its transformations until later
-      if (usesReferences(token.$value ?? token.value, options)) {
+      if (usesReferences(options.usesW3C ? token.$value : token.value, config)) {
         deferProp();
         continue;
       }
 
       // If we got here, the property hasn't been transformed yet and
       // does not use a value reference. Transform the property now and assign it.
-      const transformedToken = transformToken(token, options);
+      const transformedToken = transformToken(token, config, options);
       // If a value transform returns undefined, it means the transform wants it to be deferred
       // e.g. due to a ref existing in a sibling prop that the transform relies on.
       // Example: { value: "#fff", darken: "{darken-amount}" }
@@ -118,6 +121,7 @@ export default function transformObject(
       // objProp is not a token -> go deeper down the object tree
       transformedObj[name] = transformObject(
         objProp,
+        config,
         options,
         { transformedPropRefs, deferredPropValueTransforms },
         path,

--- a/lib/transform/token.js
+++ b/lib/transform/token.js
@@ -50,7 +50,7 @@ export default function transformProperty(token, config, options) {
       // Only try to transform if the value is not a string or if it has '{}'
       if (
         transform.type === 'value' &&
-        !usesReferences(options.usesW3C ? token.$value : token.value, config)
+        !usesReferences(options.usesDtcg ? token.$value : token.value, config)
       ) {
         // Only transform non-referenced values (from original)
         // and transitive transforms if the value has been resolved
@@ -59,7 +59,7 @@ export default function transformProperty(token, config, options) {
           if (transformedValue === undefined) {
             return undefined;
           }
-          to_ret[options.usesW3C ? '$value' : 'value'] = transformedValue;
+          to_ret[options.usesDtcg ? '$value' : 'value'] = transformedValue;
         }
       }
 

--- a/lib/transform/token.js
+++ b/lib/transform/token.js
@@ -16,6 +16,7 @@ import usesReferences from '../utils/references/usesReferences.js';
 /**
  * @typedef {import('../../types/DesignToken.d.ts').TransformedToken} Token
  * @typedef {import('../../types/Config.d.ts').PlatformConfig} PlatformConfig
+ * @typedef {import('../../types/Config.d.ts').Config} Config
  * @typedef {import('../../types/Transform.d.ts').Transform} Transform
  * @typedef {import('../../types/Transform.d.ts').NameTransform} NameTransform
  */
@@ -25,13 +26,14 @@ import usesReferences from '../utils/references/usesReferences.js';
  * it returns a new token object rather than mutating it inline.
  * @private
  * @param {Token} token
- * @param {PlatformConfig} options
+ * @param {PlatformConfig} config
+ * @param {Config} options
  * @returns {Token|undefined} - A new property object with transforms applied.
  */
-export default function transformProperty(token, options) {
+export default function transformProperty(token, config, options) {
   const to_ret = structuredClone(token);
 
-  const transforms = /** @type {Omit<Transform, "name">[]} */ (options.transforms) || [];
+  const transforms = /** @type {Omit<Transform, "name">[]} */ (config.transforms) || [];
 
   for (let i = 0; i < transforms.length; i++) {
     const transform = transforms[i];
@@ -40,24 +42,24 @@ export default function transformProperty(token, options) {
       if (transform.type === 'name') {
         to_ret.name = /** @type {Omit<NameTransform, "name">} */ (transform).transformer(
           to_ret,
+          config,
           options,
         );
       }
       // Don't try to transform the value if it is referencing another value
       // Only try to transform if the value is not a string or if it has '{}'
-      if (transform.type === 'value' && !usesReferences(token.$value ?? token.value, options)) {
+      if (
+        transform.type === 'value' &&
+        !usesReferences(options.usesW3C ? token.$value : token.value, config)
+      ) {
         // Only transform non-referenced values (from original)
         // and transitive transforms if the value has been resolved
-        if (!usesReferences(token.original.value, options) || transform.transitive) {
-          const transformedValue = transform.transformer(to_ret, options);
+        if (!usesReferences(token.original.value, config) || transform.transitive) {
+          const transformedValue = transform.transformer(to_ret, config, options);
           if (transformedValue === undefined) {
             return undefined;
           }
-          if (token.$value !== undefined) {
-            to_ret.$value = transformedValue;
-          } else {
-            to_ret.value = transformedValue;
-          }
+          to_ret[options.usesW3C ? '$value' : 'value'] = transformedValue;
         }
       }
 
@@ -65,7 +67,7 @@ export default function transformProperty(token, options) {
         to_ret.attributes = Object.assign(
           {},
           to_ret.attributes,
-          transform.transformer(to_ret, options),
+          transform.transformer(to_ret, config, options),
         );
     }
   }

--- a/lib/utils/combineJSON.js
+++ b/lib/utils/combineJSON.js
@@ -17,6 +17,7 @@ import { extname } from 'path-unified';
 import { fs } from 'style-dictionary/fs';
 import { resolve } from '../resolve.js';
 import deepExtend from './deepExtend.js';
+import { detectW3CSyntax } from './detectW3CSyntax.js';
 
 /**
  * @typedef {import('../../types/DesignToken.d.ts').DesignTokens} Tokens
@@ -46,7 +47,8 @@ function traverseObj(obj, fn) {
  * @param {Function} [collision] - A function to be called when a name collision happens that isn't a normal deep merge of objects
  * @param {boolean} [source] - If json files are "sources", tag tokens
  * @param {Parser[]} [parsers] - Custom file parsers
- * @returns {Promise<Tokens>}
+ * @param {boolean} [usesW3C] - Whether or not tokens are using W3C syntax.
+ * @returns {Promise<{tokens: Tokens, usesW3C: boolean|undefined }>}
  */
 export default async function combineJSON(
   arr,
@@ -54,6 +56,7 @@ export default async function combineJSON(
   collision,
   source = true,
   parsers = [],
+  usesW3C,
 ) {
   /** @type {Tokens} */
   const to_ret = {};
@@ -106,9 +109,12 @@ export default async function combineJSON(
     }
 
     if (file_content) {
+      if (usesW3C === undefined) {
+        usesW3C = detectW3CSyntax(file_content);
+      }
       // Add some side data on each property to make filtering easier
       traverseObj(file_content, (obj) => {
-        if ((Object.hasOwn(obj, '$value') || Object.hasOwn(obj, 'value')) && !obj.filePath) {
+        if (Object.hasOwn(obj, `${usesW3C ? '$' : ''}value`) && !obj.filePath) {
           obj.filePath = filePath;
 
           obj.isSource = source;
@@ -123,5 +129,5 @@ export default async function combineJSON(
     }
   }
 
-  return to_ret;
+  return { tokens: to_ret, usesW3C };
 }

--- a/lib/utils/combineJSON.js
+++ b/lib/utils/combineJSON.js
@@ -17,7 +17,7 @@ import { extname } from 'path-unified';
 import { fs } from 'style-dictionary/fs';
 import { resolve } from '../resolve.js';
 import deepExtend from './deepExtend.js';
-import { detectW3CSyntax } from './detectW3CSyntax.js';
+import { detectDtcgSyntax } from './detectDtcgSyntax.js';
 
 /**
  * @typedef {import('../../types/DesignToken.d.ts').DesignTokens} Tokens
@@ -47,8 +47,8 @@ function traverseObj(obj, fn) {
  * @param {Function} [collision] - A function to be called when a name collision happens that isn't a normal deep merge of objects
  * @param {boolean} [source] - If json files are "sources", tag tokens
  * @param {Parser[]} [parsers] - Custom file parsers
- * @param {boolean} [usesW3C] - Whether or not tokens are using W3C syntax.
- * @returns {Promise<{tokens: Tokens, usesW3C: boolean|undefined }>}
+ * @param {boolean} [usesDtcg] - Whether or not tokens are using DTCG syntax.
+ * @returns {Promise<{tokens: Tokens, usesDtcg: boolean|undefined }>}
  */
 export default async function combineJSON(
   arr,
@@ -56,7 +56,7 @@ export default async function combineJSON(
   collision,
   source = true,
   parsers = [],
-  usesW3C,
+  usesDtcg,
 ) {
   /** @type {Tokens} */
   const to_ret = {};
@@ -109,12 +109,12 @@ export default async function combineJSON(
     }
 
     if (file_content) {
-      if (usesW3C === undefined) {
-        usesW3C = detectW3CSyntax(file_content);
+      if (usesDtcg === undefined) {
+        usesDtcg = detectDtcgSyntax(file_content);
       }
       // Add some side data on each property to make filtering easier
       traverseObj(file_content, (obj) => {
-        if (Object.hasOwn(obj, `${usesW3C ? '$' : ''}value`) && !obj.filePath) {
+        if (Object.hasOwn(obj, `${usesDtcg ? '$' : ''}value`) && !obj.filePath) {
           obj.filePath = filePath;
 
           obj.isSource = source;
@@ -129,5 +129,5 @@ export default async function combineJSON(
     }
   }
 
-  return { tokens: to_ret, usesW3C };
+  return { tokens: to_ret, usesDtcg };
 }

--- a/lib/utils/createFormatArgs.js
+++ b/lib/utils/createFormatArgs.js
@@ -12,10 +12,12 @@
  */
 
 import deepExtend from './deepExtend.js';
+import { deepmerge } from './deepmerge.js';
 
 /**
  * @typedef {import('../../types/DesignToken.js').Dictionary} Dictionary
  * @typedef {import('../../types/Config.d.ts').PlatformConfig} PlatformConfig
+ * @typedef {import('../../types/Config.d.ts').Config} Config
  * @typedef {import('../../types/File.d.ts').File} File
  *
 
@@ -24,16 +26,17 @@ import deepExtend from './deepExtend.js';
  * @param {{
  *   dictionary: Dictionary;
  *   platform: PlatformConfig;
+ *   options: Config;
  *   file: File;
  * }} param0
  * @returns
  */
-export default function createFormatArgs({ dictionary, platform, file }) {
+export default function createFormatArgs({ dictionary, platform, options, file }) {
   const { allTokens, tokens } = dictionary;
   // This will merge platform and file-level configuration
   // where the file configuration takes precedence
-  const { options } = platform;
-  const fileOptsTakenFromPlatform = /** @type {Partial<File>} */ ({ options });
+  const { options: fileOpts } = platform;
+  const fileOptsTakenFromPlatform = /** @type {Partial<File>} */ ({ options: fileOpts });
 
   // we have to do some typecasting here. We assume that because deepExtends merges objects together, and "file"
   // always has the destination prop, then result will be File rather than Partial<File>, so we just typecast it.
@@ -45,6 +48,9 @@ export default function createFormatArgs({ dictionary, platform, file }) {
     tokens,
     platform,
     file,
-    options: file.options || {},
+    options: {
+      ...(file.options || {}),
+      usesW3C: options?.usesW3C ?? false,
+    },
   };
 }

--- a/lib/utils/createFormatArgs.js
+++ b/lib/utils/createFormatArgs.js
@@ -12,7 +12,6 @@
  */
 
 import deepExtend from './deepExtend.js';
-import { deepmerge } from './deepmerge.js';
 
 /**
  * @typedef {import('../../types/DesignToken.js').Dictionary} Dictionary
@@ -50,7 +49,7 @@ export default function createFormatArgs({ dictionary, platform, options, file }
     file,
     options: {
       ...(file.options || {}),
-      usesW3C: options?.usesW3C ?? false,
+      usesDtcg: options?.usesDtcg ?? false,
     },
   };
 }

--- a/lib/utils/detectDtcgSyntax.js
+++ b/lib/utils/detectDtcgSyntax.js
@@ -6,14 +6,14 @@ import isPlainObject from 'is-plain-obj';
  * @param {Tokens} tokens
  * @returns
  */
-export function detectW3CSyntax(tokens) {
-  let usesW3C = false;
+export function detectDtcgSyntax(tokens) {
+  let usesDtcg = false;
   // depth-first because more likely to be faster than breadth-first
   // due to amount of tokens usually being much larger than depth of token groups
   const recurse = /** @param {Tokens} slice */ (slice) => {
     Object.keys(slice).forEach((key) => {
       if (['$value', '$type'].includes(key)) {
-        usesW3C = true;
+        usesDtcg = true;
         return;
       }
       if (isPlainObject(slice[key])) {
@@ -22,5 +22,5 @@ export function detectW3CSyntax(tokens) {
     });
   };
   recurse(tokens);
-  return usesW3C;
+  return usesDtcg;
 }

--- a/lib/utils/detectW3CSyntax.js
+++ b/lib/utils/detectW3CSyntax.js
@@ -1,0 +1,26 @@
+import isPlainObject from 'is-plain-obj';
+
+/**
+ * @typedef {import('../../types/DesignToken.js').DesignTokens} Tokens
+ *
+ * @param {Tokens} tokens
+ * @returns
+ */
+export function detectW3CSyntax(tokens) {
+  let usesW3C = false;
+  // depth-first because more likely to be faster than breadth-first
+  // due to amount of tokens usually being much larger than depth of token groups
+  const recurse = /** @param {Tokens} slice */ (slice) => {
+    Object.keys(slice).forEach((key) => {
+      if (['$value', '$type'].includes(key)) {
+        usesW3C = true;
+        return;
+      }
+      if (isPlainObject(slice[key])) {
+        recurse(slice[key]);
+      }
+    });
+  };
+  recurse(tokens);
+  return usesW3C;
+}

--- a/lib/utils/flattenTokens.js
+++ b/lib/utils/flattenTokens.js
@@ -21,18 +21,18 @@ import isPlainObject from 'is-plain-obj';
 /**
  * @private
  * @param  {Tokens} slice - The plain object you want flattened into an array.
- * @param {boolean} [usesW3C] - Whether or not tokens are using W3C syntax.
+ * @param {boolean} [usesDtcg] - Whether or not tokens are using DTCG syntax.
  * @param  {Token[]} [to_ret] - Tokens array. This function is recursive therefore this is what gets passed along.
  * @return {Token[]}
  */
-function _flattenTokens(slice, usesW3C, to_ret = []) {
+function _flattenTokens(slice, usesDtcg, to_ret = []) {
   for (let name in slice) {
     if (Object.hasOwn(slice, name)) {
       // TODO: this is a bit fragile and arbitrary to stop when we get to a 'value' property.
-      if (isPlainObject(slice[name]) && Object.hasOwn(slice[name], `${usesW3C ? '$' : ''}value`)) {
+      if (isPlainObject(slice[name]) && Object.hasOwn(slice[name], `${usesDtcg ? '$' : ''}value`)) {
         to_ret.push(/** @type {Token} */ (slice[name]));
       } else if (isPlainObject(slice[name])) {
-        _flattenTokens(slice[name], usesW3C, to_ret);
+        _flattenTokens(slice[name], usesDtcg, to_ret);
       }
     }
   }
@@ -44,9 +44,9 @@ function _flattenTokens(slice, usesW3C, to_ret = []) {
  * A leaf node in this context has a 'value' property. Potentially refactor this to
  * be more generic.
  * @param  {Tokens} tokens - The plain object you want flattened into an array.
- * @param {boolean} [usesW3C] - Whether or not tokens are using W3C syntax.
+ * @param {boolean} [usesDtcg] - Whether or not tokens are using DTCG syntax.
  * @return {Token[]}
  */
-export default function flattenTokens(tokens, usesW3C = false) {
-  return _flattenTokens(tokens, usesW3C);
+export default function flattenTokens(tokens, usesDtcg = false) {
+  return _flattenTokens(tokens, usesDtcg);
 }

--- a/lib/utils/flattenTokens.js
+++ b/lib/utils/flattenTokens.js
@@ -19,27 +19,34 @@ import isPlainObject from 'is-plain-obj';
  */
 
 /**
- * Takes an plain javascript object and will make a flat array of all the leaf nodes.
- * A leaf node in this context has a 'value' property. Potentially refactor this to
- * be more generic.
  * @private
- * @param  {Tokens} tokens - The plain object you want flattened into an array.
+ * @param  {Tokens} slice - The plain object you want flattened into an array.
+ * @param {boolean} [usesW3C] - Whether or not tokens are using W3C syntax.
  * @param  {Token[]} [to_ret] - Tokens array. This function is recursive therefore this is what gets passed along.
  * @return {Token[]}
  */
-export default function flattenTokens(tokens, to_ret = []) {
-  for (let name in tokens) {
-    if (Object.hasOwn(tokens, name)) {
+function _flattenTokens(slice, usesW3C, to_ret = []) {
+  for (let name in slice) {
+    if (Object.hasOwn(slice, name)) {
       // TODO: this is a bit fragile and arbitrary to stop when we get to a 'value' property.
-      if (
-        isPlainObject(tokens[name]) &&
-        (Object.hasOwn(tokens[name], '$value') || Object.hasOwn(tokens[name], 'value'))
-      ) {
-        to_ret.push(/** @type {Token} */ (tokens[name]));
-      } else if (isPlainObject(tokens[name])) {
-        flattenTokens(tokens[name], to_ret);
+      if (isPlainObject(slice[name]) && Object.hasOwn(slice[name], `${usesW3C ? '$' : ''}value`)) {
+        to_ret.push(/** @type {Token} */ (slice[name]));
+      } else if (isPlainObject(slice[name])) {
+        _flattenTokens(slice[name], usesW3C, to_ret);
       }
     }
   }
   return to_ret;
+}
+
+/**
+ * Takes an plain javascript object and will make a flat array of all the leaf nodes.
+ * A leaf node in this context has a 'value' property. Potentially refactor this to
+ * be more generic.
+ * @param  {Tokens} tokens - The plain object you want flattened into an array.
+ * @param {boolean} [usesW3C] - Whether or not tokens are using W3C syntax.
+ * @return {Token[]}
+ */
+export default function flattenTokens(tokens, usesW3C = false) {
+  return _flattenTokens(tokens, usesW3C);
 }

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -15,7 +15,7 @@ import usesReferences from './references/usesReferences.js';
 import { getReferences } from './references/getReferences.js';
 import { resolveReferences } from './references/resolveReferences.js';
 import flattenTokens from './flattenTokens.js';
-import { typeW3CDelegate } from './preprocess.js';
+import { typeDtcgDelegate } from './preprocess.js';
 
 // Public style-dictionary/utils API
-export { usesReferences, getReferences, resolveReferences, flattenTokens, typeW3CDelegate };
+export { usesReferences, getReferences, resolveReferences, flattenTokens, typeDtcgDelegate };

--- a/lib/utils/preprocess.js
+++ b/lib/utils/preprocess.js
@@ -15,6 +15,7 @@ import isPlainObject from 'is-plain-obj';
 
 /**
  * @typedef {import('../../types/DesignToken.d.ts').DesignTokens} DesignTokens
+ * @typedef {import('../../types/DesignToken.d.ts').DesignToken} DesignToken
  * @typedef {import('../../types/Preprocessor.d.ts').Preprocessor} Preprocessor
  * @typedef {import('../../types/Preprocessor.d.ts').preprocessor} preprocessor
  */
@@ -27,22 +28,23 @@ export function typeW3CDelegate(tokens) {
   const clone = structuredClone(tokens);
 
   /**
-   * @param {DesignTokens} slice
+   * @param {DesignTokens | DesignToken} slice
    * @param {string} [_type]
    */
   const recurse = (slice, _type) => {
-    Object.values(slice).forEach((prop) => {
-      let type = _type; // keep track of type through the stack
-      if (isPlainObject(prop)) {
-        if (typeof prop.$type === 'string') {
-          type = prop.$type;
-        }
-        // prop is a design token, but no $type prop currently,
-        // so we add it if we know what the type is from our ancestor tree
-        if (prop.$value && !prop.$type && type) {
-          prop.$type = type;
-        }
-        recurse(prop, type);
+    let type = _type; // keep track of type through the stack
+    const keys = Object.keys(slice);
+    if (!keys.includes('$type') && type && keys.includes('$value')) {
+      slice.$type = type;
+    }
+
+    Object.entries(slice).forEach(([key, val]) => {
+      if (key === '$type') {
+        type = val;
+      }
+
+      if (isPlainObject(val)) {
+        recurse(val, type);
       }
     });
   };

--- a/lib/utils/preprocess.js
+++ b/lib/utils/preprocess.js
@@ -24,7 +24,7 @@ import isPlainObject from 'is-plain-obj';
  * @param {DesignTokens} tokens
  * @returns
  */
-export function typeW3CDelegate(tokens) {
+export function typeDtcgDelegate(tokens) {
   const clone = structuredClone(tokens);
 
   /**
@@ -62,7 +62,7 @@ export function typeW3CDelegate(tokens) {
  * @returns {Promise<DesignTokens>}
  */
 export async function preprocess(tokens, preprocessorObj = {}) {
-  let processedTokens = typeW3CDelegate(tokens);
+  let processedTokens = typeDtcgDelegate(tokens);
 
   const preprocessors = Object.values(preprocessorObj);
   if (preprocessors.length > 0) {

--- a/lib/utils/references/getReferences.js
+++ b/lib/utils/references/getReferences.js
@@ -61,7 +61,7 @@ export function _getReferences(
   references = [],
   throwImmediately = false,
 ) {
-  const { usesW3C } = opts;
+  const { usesDtcg } = opts;
   const regex = createReferenceRegex(opts);
 
   /**
@@ -71,7 +71,7 @@ export function _getReferences(
    */
   function findReference(match, variable) {
     // remove 'value' to access the whole token object
-    variable = variable.trim().replace(`.${usesW3C ? '$' : ''}value`, '');
+    variable = variable.trim().replace(`.${usesDtcg ? '$' : ''}value`, '');
 
     // Find what the value is referencing
     const pathName = getPathFromName(variable, opts.separator ?? defaults.separator);

--- a/lib/utils/references/getReferences.js
+++ b/lib/utils/references/getReferences.js
@@ -19,7 +19,7 @@ import defaults from './defaults.js';
 const FILTER_WARNINGS = GroupMessages.GROUP.FilteredOutputReferences;
 
 /**
- * @typedef {import('../../../types/Config.d.ts').RegexOptions} RegexOptions
+ * @typedef {import('../../../types/Config.d.ts').GetReferencesOptions} GetReferencesOptions
  * @typedef {import('../../StyleDictionary.js').default} Dictionary
  * @typedef {import('../../../types/DesignToken.d.ts').TransformedTokens} Tokens
  * @typedef {import('../../../types/DesignToken.d.ts').TransformedToken} Token
@@ -29,7 +29,7 @@ const FILTER_WARNINGS = GroupMessages.GROUP.FilteredOutputReferences;
  * @memberof Dictionary
  * @param {string|Object<string, string|any>} value the value that contains a reference
  * @param {Tokens} tokens the dictionary to search in
- * @param {RegexOptions & { unfilteredTokens?: Tokens }} [opts]
+ * @param {GetReferencesOptions} [opts]
  * @param {Token[]} [references] array of token's references because a token's value can contain multiple references due to string interpolation
  * @returns {Token[]}
  */
@@ -49,18 +49,19 @@ export function getReferences(value, tokens, opts = {}, references = []) {
  *
  * @param {string|Object<string, string|any>} value the value that contains a reference
  * @param {Tokens} tokens the dictionary to search in
- * @param {RegexOptions & { unfilteredTokens?: Tokens }} [opts]
+ * @param {GetReferencesOptions & { unfilteredTokens?: Tokens }} [opts]
  * @param {Token[]} [references] array of token's references because a token's value can contain multiple references due to string interpolation
  * @param {boolean} [throwImmediately]
  * @returns {Token[]}
  */
-export default function _getReferences(
+export function _getReferences(
   value,
   tokens,
   opts = {},
   references = [],
   throwImmediately = false,
 ) {
+  const { usesW3C } = opts;
   const regex = createReferenceRegex(opts);
 
   /**
@@ -70,7 +71,7 @@ export default function _getReferences(
    */
   function findReference(match, variable) {
     // remove 'value' to access the whole token object
-    variable = variable.trim().replace('.value', '').replace('.$value', '');
+    variable = variable.trim().replace(`.${usesW3C ? '$' : ''}value`, '');
 
     // Find what the value is referencing
     const pathName = getPathFromName(variable, opts.separator ?? defaults.separator);

--- a/lib/utils/references/resolveReferences.js
+++ b/lib/utils/references/resolveReferences.js
@@ -55,7 +55,7 @@ export function _resolveReferences(
     opening_character = defaults.opening_character,
     closing_character = defaults.closing_character,
     ignorePaths = [],
-    usesW3C = false,
+    usesDtcg = false,
     // for internal usage
     current_context = [],
     stack = [],
@@ -69,7 +69,7 @@ export function _resolveReferences(
   let to_ret = value;
   /** @type {DesignToken|string|number|undefined} */
   let ref;
-  const valProp = usesW3C ? '$value' : 'value';
+  const valProp = usesDtcg ? '$value' : 'value';
 
   // When we know the current context:
   // the key associated with the value that we are resolving the reference for
@@ -105,7 +105,7 @@ export function _resolveReferences(
     // and
     // the reference points to someplace that has a `value` attribute
     // we should take the '.value' of the reference
-    // per the W3C draft spec where references do not have .value
+    // per the DTCG draft spec where references do not have .value
     // https://design-tokens.github.io/community-group/format/#aliases-references
     if (!refHasValue && ref && Object.hasOwn(ref, valProp)) {
       ref = ref[valProp];
@@ -154,7 +154,7 @@ export function _resolveReferences(
             to_ret = _resolveReferences(to_ret, tokens, {
               regex: reg,
               ignorePaths,
-              usesW3C,
+              usesDtcg,
               current_context,
               separator,
               stack,

--- a/lib/utils/references/resolveReferences.js
+++ b/lib/utils/references/resolveReferences.js
@@ -22,8 +22,8 @@ import defaults from './defaults.js';
 const PROPERTY_REFERENCE_WARNINGS = GroupMessages.GROUP.PropertyReferenceWarnings;
 
 /**
- * @typedef {import('../../../types/Config.d.ts').ResolveReferenceOptions} RefOpts
- * @typedef {import('../../../types/Config.d.ts').ResolveReferenceOptionsInternal} RefOptsInternal
+ * @typedef {import('../../../types/Config.d.ts').ResolveReferencesOptions} RefOpts
+ * @typedef {import('../../../types/Config.d.ts').ResolveReferencesOptionsInternal} RefOptsInternal
  * @typedef {import('../../../types/DesignToken.d.ts').DesignTokens} DesignTokens
  * @typedef {import('../../../types/DesignToken.d.ts').DesignToken} DesignToken
  */
@@ -55,6 +55,7 @@ export function _resolveReferences(
     opening_character = defaults.opening_character,
     closing_character = defaults.closing_character,
     ignorePaths = [],
+    usesW3C = false,
     // for internal usage
     current_context = [],
     stack = [],
@@ -68,6 +69,7 @@ export function _resolveReferences(
   let to_ret = value;
   /** @type {DesignToken|string|number|undefined} */
   let ref;
+  const valProp = usesW3C ? '$value' : 'value';
 
   // When we know the current context:
   // the key associated with the value that we are resolving the reference for
@@ -87,16 +89,12 @@ export function _resolveReferences(
     // Find what the value is referencing
     const pathName = getPathFromName(variable, separator);
 
-    const refHasValue = ['value', '$value'].includes(pathName[pathName.length - 1]);
+    const refHasValue = valProp === pathName[pathName.length - 1];
 
     // FIXME: shouldn't these two "refHasValue" conditions be reversed??
     if (refHasValue && ignorePaths.indexOf(variable) !== -1) {
       return '';
-    } else if (
-      !refHasValue &&
-      (ignorePaths.indexOf(`${variable}.value`) !== -1 ||
-        ignorePaths.indexOf(`${variable}.$value`) !== -1)
-    ) {
+    } else if (!refHasValue && ignorePaths.indexOf(`${variable}.${valProp}`) !== -1) {
       return '';
     }
 
@@ -109,8 +107,8 @@ export function _resolveReferences(
     // we should take the '.value' of the reference
     // per the W3C draft spec where references do not have .value
     // https://design-tokens.github.io/community-group/format/#aliases-references
-    if (!refHasValue && ref && (Object.hasOwn(ref, '$value') || Object.hasOwn(ref, 'value'))) {
-      ref = ref.$value ?? ref.value;
+    if (!refHasValue && ref && Object.hasOwn(ref, valProp)) {
+      ref = ref[valProp];
     }
 
     if (typeof ref !== 'undefined') {
@@ -156,6 +154,7 @@ export function _resolveReferences(
             to_ret = _resolveReferences(to_ret, tokens, {
               regex: reg,
               ignorePaths,
+              usesW3C,
               current_context,
               separator,
               stack,

--- a/types/Action.d.ts
+++ b/types/Action.d.ts
@@ -12,13 +12,13 @@
  */
 
 import type { Dictionary } from './DesignToken.d.ts';
-import type { PlatformConfig } from './Config.d.ts';
+import type { PlatformConfig, Config } from './Config.d.ts';
 
 export interface Action {
   name: string;
   /** The action in the form of a function. */
-  do(dictionary: Dictionary, config: Platform): void;
+  do(dictionary: Dictionary, config: PlatformConfig, options: Config): void;
 
   /** A function that undoes the action. */
-  undo?(dictionary: Dictionary, config: Platform): void;
+  undo?(dictionary: Dictionary, config: PlatformConfig, options: Config): void;
 }

--- a/types/Config.d.ts
+++ b/types/Config.d.ts
@@ -35,13 +35,13 @@ export interface RegexOptions {
 }
 
 export interface GetReferencesOptions extends RegexOptions {
-  usesW3C?: boolean;
+  usesDtcg?: boolean;
   unfilteredTokens?: DesignTokens;
 }
 
 export interface ResolveReferencesOptions extends RegexOptions {
   ignorePaths?: string[];
-  usesW3C?: boolean;
+  usesDtcg?: boolean;
 }
 
 export interface ResolveReferencesOptionsInternal extends ResolveReferencesOptions {
@@ -78,5 +78,5 @@ export interface Config {
   filter?: Record<string, Filter['matcher']>;
   fileHeader?: Record<string, FileHeader>;
   action?: Record<string, Action>;
-  usesW3C?: boolean;
+  usesDtcg?: boolean;
 }

--- a/types/Config.d.ts
+++ b/types/Config.d.ts
@@ -34,11 +34,17 @@ export interface RegexOptions {
   separator?: string;
 }
 
-export interface ResolveReferenceOptions extends RegexOptions {
-  ignorePaths?: string[];
+export interface GetReferencesOptions extends RegexOptions {
+  usesW3C?: boolean;
+  unfilteredTokens?: DesignTokens;
 }
 
-export interface ResolveReferenceOptionsInternal extends ResolveReferenceOptions {
+export interface ResolveReferencesOptions extends RegexOptions {
+  ignorePaths?: string[];
+  usesW3C?: boolean;
+}
+
+export interface ResolveReferencesOptionsInternal extends ResolveReferencesOptions {
   current_context?: string[];
   stack?: string[];
   foundCirc?: Record<string, boolean>;
@@ -72,4 +78,5 @@ export interface Config {
   filter?: Record<string, Filter['matcher']>;
   fileHeader?: Record<string, FileHeader>;
   action?: Record<string, Action>;
+  usesW3C?: boolean;
 }

--- a/types/Format.d.ts
+++ b/types/Format.d.ts
@@ -13,7 +13,7 @@
 
 import type { Dictionary } from './DesignToken.d.ts';
 import type { File } from './File.d.ts';
-import type { LocalOptions } from './Config.d.ts';
+import type { LocalOptions, Config } from './Config.d.ts';
 import type { PlatformConfig } from './Platform.d.ts';
 
 export interface FormatterArguments {
@@ -28,7 +28,7 @@ export interface FormatterArguments {
   /**
    * The options object,
    */
-  options: LocalOptions;
+  options: LocalOptions & Config;
   /**
    * The platform configuration the format is called in
    */

--- a/types/Transform.d.ts
+++ b/types/Transform.d.ts
@@ -13,14 +13,14 @@
 
 import type { Matcher } from './Filter.d.ts';
 import type { TransformedToken } from './DesignToken.d.ts';
-import type { PlatformConfig } from './Config.d.ts';
+import type { PlatformConfig, Config } from './Config.d.ts';
 
 interface BaseTransform<Type, Value> {
   name: string;
   type: Type;
   matcher?: Matcher;
   transitive?: boolean;
-  transformer: (token: TransformedToken, options: PlatformConfig) => Value;
+  transformer: (token: TransformedToken, config: PlatformConfig, options: Config) => Value;
 }
 
 export type NameTransform = BaseTransform<'name', string>;

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -29,7 +29,7 @@ export default {
     threshold: {
       statements: 98,
       branches: 99,
-      functions: 96,
+      functions: 95,
       lines: 98,
     },
   },


### PR DESCRIPTION
*Description of changes:*

Allows the use of "value" and "type" as token names or groups.
The sacrifice is that you cannot combine W3C with non-W3C syntax, but that use-case seems less important to support.