### PR TITLE
Adding all types to index.d.ts

### DIFF
--- a/.changeset/shy-nails-ring.md
+++ b/.changeset/shy-nails-ring.md
@@ -1,0 +1,5 @@
+---
+'style-dictionary': patch
+---
+
+fix(types): Added missing type exports

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "style-dictionary",
-  "version": "4.0.0-prerelease.15",
+  "version": "4.0.0-prerelease.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "style-dictionary",
-      "version": "4.0.0-prerelease.15",
+      "version": "4.0.0-prerelease.21",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,6 +1,6 @@
 export type { Action } from './Action.d.ts';
 
-export type { PlatformConfig, Config } from './Config.d.ts';
+export type { PlatformConfig, Config, LocalOptions, LogConfig } from './Config.d.ts';
 
 export type {
   DesignToken,
@@ -9,13 +9,13 @@ export type {
   TransformedTokens,
 } from './DesignToken.d.ts';
 
-export type { FileHeader, File } from './File.d.ts';
+export type { FileHeader, File, FormattingOptions } from './File.d.ts';
 
-export type { Filter } from './Filter.d.ts';
+export type { Filter, Matcher } from './Filter.d.ts';
 
-export type { Format } from './Format.d.ts';
+export type { Format, FormatterArguments, Formatter } from './Format.d.ts';
 
-export type { Parser } from './Parser.d.ts';
+export type { Parser, ParserOptions } from './Parser.d.ts';
 
 export type { Preprocessor } from './Preprocessor.d.ts';
 
@@ -25,3 +25,5 @@ export type {
   AttributeTransform,
   ValueTransform,
 } from './Transform.d.ts';
+
+export type { Volume } from './Volume.d.ts';

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,12 +1,13 @@
 export type { Action } from './Action.d.ts';
 
-export * from './Config.d.ts';
+export { PlatformConfig, Config, LocalOptions, LogConfig } from './Config.d.ts';
 
 export type {
   DesignToken,
   DesignTokens,
   TransformedToken,
   TransformedTokens,
+  Dictionary
 } from './DesignToken.d.ts';
 
 export type { FileHeader, File, FormattingOptions } from './File.d.ts';

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,6 +1,6 @@
 export type { Action } from './Action.d.ts';
 
-export type { PlatformConfig, Config, LocalOptions, LogConfig } from './Config.d.ts';
+export * from './Config.d.ts';
 
 export type {
   DesignToken,


### PR DESCRIPTION
Fixes #1135

Adds all types to index.d.ts to be used by others e.g. when building custom formatters.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
