### PR TITLE
Added missing type keyword

### DIFF
--- a/.changeset/tough-grapes-agree.md
+++ b/.changeset/tough-grapes-agree.md
@@ -1,0 +1,5 @@
+---
+'style-dictionary': patch
+---
+
+fix(types): add missing type keyword for type export from index.d.ts

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,6 +1,6 @@
 export type { Action } from './Action.d.ts';
 
-export { PlatformConfig, Config, LocalOptions, LogConfig } from './Config.d.ts';
+export type { PlatformConfig, Config, LocalOptions, LogConfig } from './Config.d.ts';
 
 export type {
   DesignToken,


### PR DESCRIPTION
Added missing type keyword when importing types into index.d.ts

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
