### PR TITLE
fix: check buildPath consistently

### DIFF
--- a/lib/buildFiles.js
+++ b/lib/buildFiles.js
@@ -12,6 +12,7 @@
  */
 
 const buildFile = require('./buildFile');
+const validBuildPath = require("./utils/validBuildPath");
 
 /**
  * Takes a platform config object and a dictionary
@@ -24,7 +25,7 @@ const buildFile = require('./buildFile');
  * @returns {null}
  */
 function buildFiles(dictionary, platform) {
-  if (platform.buildPath && (platform.buildPath.slice(-1) !== '/' && platform.buildPath.slice(-1) !== '\\')) {
+  if (!validBuildPath(platform.buildPath)) {
     throw new Error('Build path must end in a trailing slash or you will get weird file names.')
   }
 

--- a/lib/cleanDirs.js
+++ b/lib/cleanDirs.js
@@ -12,6 +12,7 @@
  */
 
 const cleanDir = require('./cleanDir');
+const validBuildPath = require("./utils/validBuildPath");
 
 /**
  * Takes a platform config object and a properties
@@ -24,7 +25,7 @@ const cleanDir = require('./cleanDir');
  * @returns {null}
  */
 function cleanDirs(dictionary, platform) {
-  if (platform.buildPath && platform.buildPath.slice(-1) !== '/') {
+  if (!validBuildPath(platform.buildPath)) {
     throw new Error('Build path must end in a trailing slash or you will get weird file names.')
   }
 

--- a/lib/cleanFiles.js
+++ b/lib/cleanFiles.js
@@ -12,6 +12,7 @@
  */
 
 const cleanFile = require('./cleanFile');
+const validBuildPath = require("./utils/validBuildPath");
 
 /**
  * Takes a platform config object and a dictionary
@@ -24,7 +25,7 @@ const cleanFile = require('./cleanFile');
  * @returns {null}
  */
 function cleanFiles(dictionary, platform) {
-  if (platform.buildPath && platform.buildPath.slice(-1) !== '/') {
+  if (!validBuildPath(platform.buildPath)) {
     throw new Error('Build path must end in a trailing slash or you will get weird file names.')
   }
 

--- a/lib/utils/validBuildPath.js
+++ b/lib/utils/validBuildPath.js
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+
+const path = require("path");
+
+/**
+ * Check if the build path is valid.
+ *
+ * @param buildPath
+ * @returns {boolean}
+ */
+function validBuildPath(buildPath) {
+  return !buildPath || (buildPath.slice(-1) === path.sep);
+}
+
+module.exports = validBuildPath;


### PR DESCRIPTION
*Issue #, if available:* #1144 

*Description of changes:*

Extracted `buildPath`-checking logic to its own util and ensure it uses the platform-specific separator.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
