### PR TITLE
Output refs transformed

### DIFF
--- a/.changeset/mean-panthers-serve.md
+++ b/.changeset/mean-panthers-serve.md
@@ -1,0 +1,5 @@
+---
+'style-dictionary': minor
+---
+
+Added `outputReferencesTransformed` utility function to pass into outputReferences option, which will not output references for values that have been transitively transformed.

--- a/__integration__/__snapshots__/outputReferences.test.snap.js
+++ b/__integration__/__snapshots__/outputReferences.test.snap.js
@@ -28,3 +28,16 @@ css
 ✔︎ __integration__/build/filteredVariables.css`;
 /* end snapshot integration output references should not warn the user if filters out references is prevented with outputReferencesFilter */
 
+snapshots["integration output references should allow using outputReferencesTransformed to not output refs when value has been transitively transformed"] = 
+`/**
+ * Do not edit directly
+ * Generated on Sat, 01 Jan 2000 00:00:00 GMT
+ */
+
+:root {
+  --base: rgb(0,0,0);
+  --referred: rgba(0,0,0,0.12);
+}
+`;
+/* end snapshot integration output references should allow using outputReferencesTransformed to not output refs when value has been transitively transformed */
+

--- a/docs/src/components/sd-playground.ts
+++ b/docs/src/components/sd-playground.ts
@@ -185,8 +185,8 @@ class SdPlayground extends LitElement {
   }
 
   async init() {
-    await this.initData();
     await this.initMonaco();
+    await this.initData();
     this.hasInitializedResolve();
     this.currentFile = 'config';
   }

--- a/docs/src/content/docs/reference/Hooks/Formats/index.md
+++ b/docs/src/content/docs/reference/Hooks/Formats/index.md
@@ -185,6 +185,15 @@ You can create custom formats that output references as well. See the [Custom fo
 When combining [`filters`](/reference/hooks/filters) with `outputReferences`, it could happen that a token is referencing another token that is getting filtered out.
 When that happens, Style Dictionary will throw a warning. However, it is possible to configure `outputReferences` to use [our `outputReferencesFilter` utility function](/reference/utils/references/#outputreferencesfilter), which will prevent tokens that reference other tokens that are filtered out from outputting references, they will output the resolved values instead.
 
+### outputReferences with transitive transforms
+
+When combining [transitive value transforms](/reference/hooks/transforms/#transitive-transforms) with `outputReferences`,
+it could happen that a token that contains references has also been transitively transformed.
+What this means is that putting back the references in the output would mean we are undoing that work.
+In this scenario, it's often preferable not to output a reference.
+
+There is an [`outputReferencesTransformed`](/reference/utils/references/#outputreferencestransformed) utility function that takes care of checking if this happened and not outputting refs for tokens in this scenario.
+
 ## File headers
 
 By default Style Dictionary adds a file header comment in the top of files built using built-in formats like this:

--- a/docs/src/remark-playground.ts
+++ b/docs/src/remark-playground.ts
@@ -18,7 +18,7 @@ const paragraphVisitor = (
     let tokensData = serialize({});
     let configData = serialize({});
     let scriptData = serialize({});
-    let skipAmount = 2;
+    let skipAmount = 1;
 
     for (const child of parent.children.slice(index + 1, index + 4)) {
       if (child.type !== 'code') break;

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -15,6 +15,7 @@ import usesReferences from './references/usesReferences.js';
 import { getReferences } from './references/getReferences.js';
 import { resolveReferences } from './references/resolveReferences.js';
 import { outputReferencesFilter } from './references/outputReferencesFilter.js';
+import { outputReferencesTransformed } from './references/outputReferencesTransformed.js';
 import flattenTokens from './flattenTokens.js';
 import { typeDtcgDelegate } from './preprocess.js';
 
@@ -24,6 +25,7 @@ export {
   getReferences,
   resolveReferences,
   outputReferencesFilter,
+  outputReferencesTransformed,
   flattenTokens,
   typeDtcgDelegate,
 };

--- a/lib/utils/references/outputReferencesTransformed.js
+++ b/lib/utils/references/outputReferencesTransformed.js
@@ -1,0 +1,19 @@
+import { resolveReferences } from './resolveReferences.js';
+
+/**
+ * @typedef {import('../../../types/DesignToken.d.ts').TransformedToken} TransformedToken
+ * @typedef {import('../../../types/DesignToken.d.ts').Dictionary} Dictionary
+ *
+ * @param {TransformedToken} token
+ * @param {{ dictionary: Dictionary, usesDtcg?: boolean }} dictionary
+ * @returns
+ */
+export function outputReferencesTransformed(token, { dictionary, usesDtcg }) {
+  const originalValue = usesDtcg ? token.original.$value : token.original.value;
+  const value = usesDtcg ? token.$value : token.value;
+
+  // Check if the token's value is the same as if we were resolve references on the original value
+  // This checks whether the token's value has been transformed e.g. transitive transforms.
+  // If it has been, that means we should not be outputting refs because this would undo the work of those transforms.
+  return value === resolveReferences(originalValue, dictionary.tokens, { usesDtcg });
+}


### PR DESCRIPTION
*Issue #, if available:* 
https://github.com/amzn/style-dictionary/issues/1124

*Description of changes:*
Allows users to configure outputReferences to not output refs if the final value of the token doesn't match the original value assuming references are resolved in the original. This means the token's value is the result of a transitive transform being applied, and with this util you can prevent outputReferences from undoing that transform's work.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
