### PR TITLE
docs(quick_start): fix broken link to build process page

### DIFF
--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -249,7 +249,7 @@ $color-font-tertiary: #cccccc;
 ```
 
 That's it! There is a lot more you can do with your style dictionary than generating files with color values. Take a look
-at some [examples](examples.md) or take a deeper dive into [package structure](package_structure.md), [extending](extending.md), or how the [build process](build_process.md) works.
+at some [examples](examples.md) or take a deeper dive into [package structure](package_structure.md), [extending](extending.md), or how the [build process](architecture.md) works.
 
 ## Basic Usage
 ### Command Line Interface (CLI)


### PR DESCRIPTION
## Issue #, if available:

/

## Description of changes:

In the **"Quick Start"** page, the link to the **"Build process"** explanation page is broken.

Currently, the link goes to a "[/build_process](https://amzn.github.io/style-dictionary/#/build_process)" page that doesn't exist _(404)_.

On reading the documentation, it would appear that the relevant associated page is "[/architecture](https://amzn.github.io/style-dictionary/#/architecture)".

<hr/>

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
