### PR TITLE
fix: changing FormatHelpers.setSwiftFileProperties type function to return object

### DIFF
--- a/types/FormatHelpers.d.ts
+++ b/types/FormatHelpers.d.ts
@@ -73,5 +73,9 @@ export interface FormatHelpers {
     options: object,
     objectType: string,
     transformGroup: string,
-  ) => object;
+  ) =>  {
+    objectType?: string;
+    import?: string[];
+    accessControl?: string;
+};
 }

--- a/types/FormatHelpers.d.ts
+++ b/types/FormatHelpers.d.ts
@@ -73,5 +73,5 @@ export interface FormatHelpers {
     options: object,
     objectType: string,
     transformGroup: string,
-  ) => string;
+  ) => object;
 }


### PR DESCRIPTION
Docs specify that return type should be `Object` but it's `string` in [FormatHelpers.d.ts](https://github.com/amzn/style-dictionary/blob/17f4cb2f30bd002dfd55d6ef8c5bee4138de8d64/types/FormatHelpers.d.ts#L76) file.

*Description of changes:*
changing FormatHelpers.setSwiftFileProperties type function to return object

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
