### PR TITLE
feat: move transforms global prop to hooks.transforms, align api

### DIFF
--- a/.changeset/spicy-pears-work.md
+++ b/.changeset/spicy-pears-work.md
@@ -1,0 +1,50 @@
+---
+'style-dictionary': major
+---
+
+BREAKING: Transforms, when registered, are put inside the `hooks.transforms` property now, as opposed to `transform`.
+The `matcher` property has been renamed to `filter` (to align with the Filter hook change), and the `transformer` handler function has been renamed to `transform` for consistency.
+
+Before:
+
+```js
+export default {
+  // register it inline or by SD.registerTransform
+  transform: {
+    'color-transform': {
+      type: 'value',
+      matcher: (token) => token.type === 'color',
+      transformer: (token) => token.value,
+    },
+  },
+  platforms: {
+    css: {
+      // apply it per platform
+      transforms: ['color-transform'],
+    },
+  },
+};
+```
+
+After
+
+```js
+export default {
+  // register it inline or by SD.registerTransform
+  hooks: {
+    transforms: {
+      'color-transform': {
+        type: 'value',
+        filter: (token) => token.type === 'color',
+        transform: (token) => token.value,
+      },
+    },
+  },
+  platforms: {
+    css: {
+      // apply it per platform
+      transforms: ['color-transform'],
+    },
+  },
+};
+```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ We use ESLint on the code to ensure a consistent style. Any new code committed m
 
 ### Code Rules
 
-1. **Do not mutate token names or values in a format.** Mutations like this should happen in a transformer.
+1. **Do not mutate token names or values in a format.** Mutations like this should happen in a transform.
 1. **Be as generic as possible.** Do not hard-code any values or configuration in formats.
 1. **Fail loudly.** Users should be aware if something is missing or configurations aren't correct. This will help debug any issues instead of failing silently.
 1. **Rely on few dependencies.** This framework is meant to be extended and allows for customization. We don't want to bring a slew of dependencies that most people don't need.

--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ StyleDictionary.registerTransform({
   filter: function (token) {
     return token.type === 'time';
   },
-  transformer: function (token) {
+  transform: function (token) {
     return (parseInt(token.original.value) / 1000).toString() + 's';
   },
 });

--- a/__integration__/async.test.js
+++ b/__integration__/async.test.js
@@ -60,7 +60,7 @@ describe('integration', async function () {
       name: 'foo-value-transform',
       type: 'value',
       filter: (token) => token.value === 'foo',
-      transformer: async () => {
+      transform: async () => {
         await sleep(10);
         return 'bar';
       },

--- a/__integration__/objectValues.test.js
+++ b/__integration__/objectValues.test.js
@@ -78,37 +78,41 @@ describe('integration', async () => {
           },
         },
       },
-      transform: {
-        hsl: {
-          type: 'value',
-          transitive: true,
-          filter: (token) => token.original.value.h,
-          transformer: (token) => {
-            return `hsl(${token.value.h}, ${token.value.s}, ${token.value.l})`;
+      hooks: {
+        transforms: {
+          hsl: {
+            type: 'value',
+            transitive: true,
+            filter: (token) => token.original.value.h,
+            transform: (token) => {
+              return `hsl(${token.value.h}, ${token.value.s}, ${token.value.l})`;
+            },
           },
-        },
-        hslToHex: {
-          type: 'value',
-          transitive: true,
-          filter: (token) => token.original.value.h,
-          transformer: (token) => {
-            return Color(`hsl(${token.value.h}, ${token.value.s}, ${token.value.l})`).toHexString();
+          hslToHex: {
+            type: 'value',
+            transitive: true,
+            filter: (token) => token.original.value.h,
+            transform: (token) => {
+              return Color(
+                `hsl(${token.value.h}, ${token.value.s}, ${token.value.l})`,
+              ).toHexString();
+            },
           },
-        },
-        cssBorder: {
-          type: 'value',
-          transitive: true,
-          filter: (token) => token.path[0] === `border`,
-          transformer: (token) => {
-            return `${token.value.width} ${token.value.style} ${token.value.color}`;
+          cssBorder: {
+            type: 'value',
+            transitive: true,
+            filter: (token) => token.path[0] === `border`,
+            transform: (token) => {
+              return `${token.value.width} ${token.value.style} ${token.value.color}`;
+            },
           },
-        },
-        shadow: {
-          type: 'value',
-          transitive: true,
-          filter: (token) => token.type === 'shadow',
-          transformer: (token) => {
-            return token.value.map((obj) => obj.color).join(', ');
+          shadow: {
+            type: 'value',
+            transitive: true,
+            filter: (token) => token.type === 'shadow',
+            transform: (token) => {
+              return token.value.map((obj) => obj.color).join(', ');
+            },
           },
         },
       },

--- a/__integration__/outputReferences.test.js
+++ b/__integration__/outputReferences.test.js
@@ -45,19 +45,21 @@ describe('integration', async () => {
             type: 'color',
           },
         },
-        transform: {
-          'rgb-in-rgba': {
-            type: 'value',
-            transitive: true,
-            filter: (token) => token.type === 'color',
-            // quite naive transform to support rgb inside rgba
-            transformer: (token) => {
-              const reg = /rgba\((rgb\((\d,\d,\d)\)),((0\.)?\d+?)\)/g;
-              const match = reg.exec(token.value);
-              if (match && match[1] && match[2]) {
-                return token.value.replace(match[1], match[2]);
-              }
-              return token.value;
+        hooks: {
+          transforms: {
+            'rgb-in-rgba': {
+              type: 'value',
+              transitive: true,
+              filter: (token) => token.type === 'color',
+              // quite naive transform to support rgb inside rgba
+              transform: (token) => {
+                const reg = /rgba\((rgb\((\d,\d,\d)\)),((0\.)?\d+?)\)/g;
+                const match = reg.exec(token.value);
+                if (match && match[1] && match[2]) {
+                  return token.value.replace(match[1], match[2]);
+                }
+                return token.value;
+              },
             },
           },
         },

--- a/__integration__/w3c-forward-compat.test.js
+++ b/__integration__/w3c-forward-compat.test.js
@@ -43,19 +43,21 @@ describe('integration', async () => {
           },
         },
       },
-      transform: {
-        'custom/css/color': {
-          type: 'value',
-          filter: (token) => token.$type === 'color',
-          transformer: (token) => {
-            return Color(sd.usesDtcg ? token.$value : token.value).toRgbString();
+      hooks: {
+        transforms: {
+          'custom/css/color': {
+            type: 'value',
+            filter: (token) => token.$type === 'color',
+            transform: (token) => {
+              return Color(sd.usesDtcg ? token.$value : token.value).toRgbString();
+            },
           },
-        },
-        'custom/add/px': {
-          type: 'value',
-          filter: (token) => token.$type === 'dimension',
-          transformer: (token) => {
-            return `${sd.usesDtcg ? token.$value : token.value}px`;
+          'custom/add/px': {
+            type: 'value',
+            filter: (token) => token.$type === 'dimension',
+            transform: (token) => {
+              return `${sd.usesDtcg ? token.$value : token.value}px`;
+            },
           },
         },
       },

--- a/__tests__/common/transforms.test.js
+++ b/__tests__/common/transforms.test.js
@@ -20,7 +20,7 @@ describe('common', () => {
     describe('name/camel', () => {
       it('should handle prefix', () => {
         expect(
-          transforms['name/camel'].transformer(
+          transforms['name/camel'].transform(
             {
               path: ['one', 'two', 'three'],
             },
@@ -33,7 +33,7 @@ describe('common', () => {
 
       it('should handle no prefix', () => {
         expect(
-          transforms['name/camel'].transformer(
+          transforms['name/camel'].transform(
             {
               path: ['one', 'two', 'three'],
             },
@@ -46,7 +46,7 @@ describe('common', () => {
     describe('name/kebab', () => {
       it('should handle prefix', () => {
         expect(
-          transforms['name/kebab'].transformer(
+          transforms['name/kebab'].transform(
             {
               path: ['one', 'two', 'three'],
             },
@@ -59,7 +59,7 @@ describe('common', () => {
 
       it('should handle no prefix', () => {
         expect(
-          transforms['name/kebab'].transformer(
+          transforms['name/kebab'].transform(
             {
               path: ['one', 'two', 'three'],
             },
@@ -72,7 +72,7 @@ describe('common', () => {
     describe('name/snake', () => {
       it('should handle prefix', () => {
         expect(
-          transforms['name/snake'].transformer(
+          transforms['name/snake'].transform(
             {
               path: ['one', 'two', 'three'],
             },
@@ -85,7 +85,7 @@ describe('common', () => {
 
       it('should handle no prefix', () => {
         expect(
-          transforms['name/snake'].transformer(
+          transforms['name/snake'].transform(
             {
               path: ['one', 'two', 'three'],
             },
@@ -98,7 +98,7 @@ describe('common', () => {
     describe('name/constant', () => {
       it('should handle prefix', () => {
         expect(
-          transforms['name/constant'].transformer(
+          transforms['name/constant'].transform(
             {
               path: ['one', 'two', 'three'],
             },
@@ -111,7 +111,7 @@ describe('common', () => {
 
       it('should handle no prefix', () => {
         expect(
-          transforms['name/constant'].transformer(
+          transforms['name/constant'].transform(
             {
               path: ['one', 'two', 'three'],
             },
@@ -123,7 +123,7 @@ describe('common', () => {
 
     describe('attribute/color', () => {
       it('should handle normal colors', () => {
-        const attributes = transforms['attribute/color'].transformer(
+        const attributes = transforms['attribute/color'].transform(
           {
             value: '#aaaaaa',
           },
@@ -135,14 +135,14 @@ describe('common', () => {
         expect(attributes).to.have.nested.property('hsl.s', 0);
       });
       it('should handle colors with transparency', () => {
-        const attributes = transforms['attribute/color'].transformer(
+        const attributes = transforms['attribute/color'].transform(
           {
             value: '#aaaaaa99',
           },
           {},
           {},
         );
-        const attributes2 = transforms['attribute/color'].transformer(
+        const attributes2 = transforms['attribute/color'].transform(
           {
             value: 'rgba(170,170,170,0.6)',
           },
@@ -169,9 +169,9 @@ describe('common', () => {
           attributes: { category: 'size', component: 'button' },
         };
 
-        const attrs = transforms['attribute/cti'].transformer(prop, {}, {});
-        const attrsShort = transforms['attribute/cti'].transformer(propShort, {}, {});
-        const attrsOverride = transforms['attribute/cti'].transformer(propOverride, {}, {});
+        const attrs = transforms['attribute/cti'].transform(prop, {}, {});
+        const attrsShort = transforms['attribute/cti'].transform(propShort, {}, {});
+        const attrsOverride = transforms['attribute/cti'].transform(propOverride, {}, {});
 
         it('should assign attributes correctly', () => {
           expect(attrs).eql({
@@ -202,7 +202,7 @@ describe('common', () => {
 
     describe('color/hex', () => {
       it('should handle hex colors', () => {
-        const value = transforms['color/hex'].transformer(
+        const value = transforms['color/hex'].transform(
           {
             value: '#aaaaaa',
           },
@@ -213,7 +213,7 @@ describe('common', () => {
       });
 
       it('should handle hex8 colors', () => {
-        const value = transforms['color/hex'].transformer(
+        const value = transforms['color/hex'].transform(
           {
             value: '#aaaaaaaa',
           },
@@ -224,7 +224,7 @@ describe('common', () => {
       });
 
       it('should handle rgb colors', () => {
-        const value = transforms['color/hex'].transformer(
+        const value = transforms['color/hex'].transform(
           {
             value: 'rgb(170,170,170)',
           },
@@ -235,7 +235,7 @@ describe('common', () => {
       });
 
       it('should handle rgb (object) colors', () => {
-        const value = transforms['color/hex'].transformer(
+        const value = transforms['color/hex'].transform(
           {
             value: {
               r: '170',
@@ -246,7 +246,7 @@ describe('common', () => {
           {},
           {},
         );
-        const value2 = transforms['color/hex'].transformer(
+        const value2 = transforms['color/hex'].transform(
           {
             value: 'rgb(170,170,170)',
           },
@@ -258,7 +258,7 @@ describe('common', () => {
       });
 
       it('should handle hsl colors', () => {
-        const value = transforms['color/hex'].transformer(
+        const value = transforms['color/hex'].transform(
           {
             value: {
               h: '0',
@@ -269,7 +269,7 @@ describe('common', () => {
           {},
           {},
         );
-        const value2 = transforms['color/hex'].transformer(
+        const value2 = transforms['color/hex'].transform(
           {
             value: 'hsl(0,0,0.5)',
           },
@@ -283,7 +283,7 @@ describe('common', () => {
 
     describe('color/hex8', () => {
       it('should handle hex colors', () => {
-        const value = transforms['color/hex8'].transformer(
+        const value = transforms['color/hex8'].transform(
           {
             value: '#aaaaaa',
           },
@@ -294,7 +294,7 @@ describe('common', () => {
       });
 
       it('should handle rgb colors', () => {
-        const value = transforms['color/hex8'].transformer(
+        const value = transforms['color/hex8'].transform(
           {
             value: 'rgb(170,170,170)',
           },
@@ -305,7 +305,7 @@ describe('common', () => {
       });
 
       it('should handle rgba colors', () => {
-        const value = transforms['color/hex8'].transformer(
+        const value = transforms['color/hex8'].transform(
           {
             value: 'rgba(170,170,170,0.6)',
           },
@@ -318,7 +318,7 @@ describe('common', () => {
 
     describe('color/hex8android', () => {
       it('should handle colors without alpha', () => {
-        const value = transforms['color/hex8android'].transformer(
+        const value = transforms['color/hex8android'].transform(
           {
             value: '#aaaaaa',
           },
@@ -329,7 +329,7 @@ describe('common', () => {
       });
 
       it('should handle colors with alpha', () => {
-        const value = transforms['color/hex8android'].transformer(
+        const value = transforms['color/hex8android'].transform(
           {
             value: '#aaaaaa99',
           },
@@ -342,7 +342,7 @@ describe('common', () => {
 
     describe('color/rgb', () => {
       it('should handle normal colors', () => {
-        const value = transforms['color/rgb'].transformer(
+        const value = transforms['color/rgb'].transform(
           {
             value: '#aaaaaa',
           },
@@ -353,7 +353,7 @@ describe('common', () => {
       });
 
       it('should handle colors with transparency', () => {
-        const value = transforms['color/rgb'].transformer(
+        const value = transforms['color/rgb'].transform(
           {
             value: '#aaaaaa99',
           },
@@ -366,7 +366,7 @@ describe('common', () => {
 
     describe('color/hsl-4', () => {
       it('should handle normal colors', () => {
-        const value = transforms['color/hsl-4'].transformer(
+        const value = transforms['color/hsl-4'].transform(
           {
             value: '#009688',
           },
@@ -377,7 +377,7 @@ describe('common', () => {
       });
 
       it('should handle colors with transparency', () => {
-        const value = transforms['color/hsl-4'].transformer(
+        const value = transforms['color/hsl-4'].transform(
           {
             value: '#00968899',
           },
@@ -390,7 +390,7 @@ describe('common', () => {
 
     describe('color/hsl', () => {
       it('should handle normal colors', () => {
-        const value = transforms['color/hsl'].transformer(
+        const value = transforms['color/hsl'].transform(
           {
             value: '#009688',
           },
@@ -401,7 +401,7 @@ describe('common', () => {
       });
 
       it('should handle colors with transparency', () => {
-        const value = transforms['color/hsl'].transformer(
+        const value = transforms['color/hsl'].transform(
           {
             value: '#00968899',
           },
@@ -414,7 +414,7 @@ describe('common', () => {
 
     describe('color/composeColor', () => {
       it('should handle color without alpha', () => {
-        const value = transforms['color/composeColor'].transformer(
+        const value = transforms['color/composeColor'].transform(
           {
             value: '#aaaaaa',
           },
@@ -425,7 +425,7 @@ describe('common', () => {
       });
 
       it('should handle color with alpha', () => {
-        const value = transforms['color/composeColor'].transformer(
+        const value = transforms['color/composeColor'].transform(
           {
             value: '#aaaaaaff',
           },
@@ -438,7 +438,7 @@ describe('common', () => {
 
     describe('color/UIColor', () => {
       it('should handle normal colors', () => {
-        const value = transforms['color/UIColor'].transformer(
+        const value = transforms['color/UIColor'].transform(
           {
             value: '#aaaaaa',
           },
@@ -451,7 +451,7 @@ describe('common', () => {
       });
 
       it('should retain enough precision when converting to decimal', () => {
-        const value = transforms['color/UIColor'].transformer(
+        const value = transforms['color/UIColor'].transform(
           {
             value: '#1d1d1d',
           },
@@ -464,7 +464,7 @@ describe('common', () => {
       });
 
       it('should handle colors with transparency', () => {
-        const value = transforms['color/UIColor'].transformer(
+        const value = transforms['color/UIColor'].transform(
           {
             value: '#aaaaaa99',
           },
@@ -479,7 +479,7 @@ describe('common', () => {
 
     describe('color/UIColorSwift', () => {
       it('should handle normal colors', () => {
-        const value = transforms['color/UIColorSwift'].transformer(
+        const value = transforms['color/UIColorSwift'].transform(
           {
             value: '#aaaaaa',
           },
@@ -490,7 +490,7 @@ describe('common', () => {
       });
 
       it('should retain enough precision when converting to decimal', () => {
-        const value = transforms['color/UIColorSwift'].transformer(
+        const value = transforms['color/UIColorSwift'].transform(
           {
             value: '#1d1d1d',
           },
@@ -501,7 +501,7 @@ describe('common', () => {
       });
 
       it('should handle colors with transparency', () => {
-        const value = transforms['color/UIColorSwift'].transformer(
+        const value = transforms['color/UIColorSwift'].transform(
           {
             value: '#aaaaaa99',
           },
@@ -514,7 +514,7 @@ describe('common', () => {
 
     describe('color/ColorSwiftUI', () => {
       it('should handle normal colors', () => {
-        const value = transforms['color/ColorSwiftUI'].transformer(
+        const value = transforms['color/ColorSwiftUI'].transform(
           {
             value: '#aaaaaa',
           },
@@ -525,7 +525,7 @@ describe('common', () => {
       });
 
       it('should retain enough precision when converting to decimal', () => {
-        const value = transforms['color/ColorSwiftUI'].transformer(
+        const value = transforms['color/ColorSwiftUI'].transform(
           {
             value: '#1d1d1d',
           },
@@ -536,7 +536,7 @@ describe('common', () => {
       });
 
       it('should handle colors with transparency', () => {
-        const value = transforms['color/ColorSwiftUI'].transformer(
+        const value = transforms['color/ColorSwiftUI'].transform(
           {
             value: '#aaaaaa99',
           },
@@ -549,7 +549,7 @@ describe('common', () => {
 
     describe('color/hex8flutter', () => {
       it('should handle colors without alpha', () => {
-        const value = transforms['color/hex8flutter'].transformer(
+        const value = transforms['color/hex8flutter'].transform(
           {
             value: '#aaaaaa',
           },
@@ -560,7 +560,7 @@ describe('common', () => {
       });
 
       it('should handle colors with alpha', () => {
-        const value = transforms['color/hex8flutter'].transformer(
+        const value = transforms['color/hex8flutter'].transform(
           {
             value: '#aaaaaa99',
           },
@@ -573,7 +573,7 @@ describe('common', () => {
 
     describe('color/css', () => {
       it('should handle normal colors', () => {
-        const value = transforms['color/css'].transformer(
+        const value = transforms['color/css'].transform(
           {
             value: 'rgb(170, 170, 170)',
           },
@@ -584,7 +584,7 @@ describe('common', () => {
       });
 
       it('should handle colors with transparency', () => {
-        const value = transforms['color/css'].transformer(
+        const value = transforms['color/css'].transform(
           {
             value: '#aaaaaa99',
           },
@@ -598,7 +598,7 @@ describe('common', () => {
     describe('color/sketch', () => {
       it('should retain hex specificity', () => {
         const originalHex = '#0b7dbb';
-        const value = transforms['color/sketch'].transformer(
+        const value = transforms['color/sketch'].transform(
           {
             value: originalHex,
           },
@@ -616,14 +616,14 @@ describe('common', () => {
 
     describe('size/sp', () => {
       it('should work', () => {
-        const value = transforms['size/sp'].transformer(
+        const value = transforms['size/sp'].transform(
           {
             value: '12px',
           },
           {},
           {},
         );
-        const value2 = transforms['size/sp'].transformer(
+        const value2 = transforms['size/sp'].transform(
           {
             value: '12',
           },
@@ -634,20 +634,20 @@ describe('common', () => {
         expect(value2).to.equal('12.00sp');
       });
       it('should throw an error if prop value is Nan', () => {
-        expect(() => transforms['size/sp'].transformer({ value: 'a' }, {}, {})).to.throw();
+        expect(() => transforms['size/sp'].transform({ value: 'a' }, {}, {})).to.throw();
       });
     });
 
     describe('size/dp', () => {
       it('should work', () => {
-        const value = transforms['size/dp'].transformer(
+        const value = transforms['size/dp'].transform(
           {
             value: '12px',
           },
           {},
           {},
         );
-        const value2 = transforms['size/dp'].transformer(
+        const value2 = transforms['size/dp'].transform(
           {
             value: '12',
           },
@@ -658,13 +658,13 @@ describe('common', () => {
         expect(value2).to.equal('12.00dp');
       });
       it('should throw an error if prop value is Nan', () => {
-        expect(() => transforms['size/dp'].transformer({ value: 'a' })).to.throw();
+        expect(() => transforms['size/dp'].transform({ value: 'a' })).to.throw();
       });
     });
 
     describe('size/object', () => {
       it('should work', () => {
-        const value = transforms['size/object'].transformer(
+        const value = transforms['size/object'].transform(
           {
             value: '1px',
           },
@@ -677,7 +677,7 @@ describe('common', () => {
         expect(value.scale).to.equal(16);
       });
       it('should work with custom base font', () => {
-        const value = transforms['size/object'].transformer(
+        const value = transforms['size/object'].transform(
           { value: '1' },
           { basePxFontSize: 14 },
           {},
@@ -688,13 +688,13 @@ describe('common', () => {
         expect(value.scale).to.equal(14);
       });
       it('should throw an error if prop value is NaN', () => {
-        expect(() => transforms['size/object'].transformer({ value: 'a' }, {}, {})).to.throw();
+        expect(() => transforms['size/object'].transform({ value: 'a' }, {}, {})).to.throw();
       });
     });
 
     describe('size/remToSp', () => {
       it('should work', () => {
-        const value = transforms['size/remToSp'].transformer(
+        const value = transforms['size/remToSp'].transform(
           {
             value: '1',
           },
@@ -704,7 +704,7 @@ describe('common', () => {
         expect(value).to.equal('16.00sp');
       });
       it('converts rem to sp using custom base font', () => {
-        const value = transforms['size/remToSp'].transformer(
+        const value = transforms['size/remToSp'].transform(
           { value: '1' },
           { basePxFontSize: 14 },
           {},
@@ -712,13 +712,13 @@ describe('common', () => {
         expect(value).to.equal('14.00sp');
       });
       it('should throw an error if prop value is Nan', () => {
-        expect(() => transforms['size/dp'].transformer({ value: 'a' }, {}, {})).to.throw();
+        expect(() => transforms['size/dp'].transform({ value: 'a' }, {}, {})).to.throw();
       });
     });
 
     describe('size/remToDp', () => {
       it('should work', () => {
-        const value = transforms['size/remToDp'].transformer(
+        const value = transforms['size/remToDp'].transform(
           {
             value: '1',
           },
@@ -728,7 +728,7 @@ describe('common', () => {
         expect(value).to.equal('16.00dp');
       });
       it('converts rem to dp using custom base font', () => {
-        const value = transforms['size/remToDp'].transformer(
+        const value = transforms['size/remToDp'].transform(
           { value: '1' },
           { basePxFontSize: 14 },
           {},
@@ -736,13 +736,13 @@ describe('common', () => {
         expect(value).to.equal('14.00dp');
       });
       it('should throw an error if prop value is Nan', () => {
-        expect(() => transforms['size/dp'].transformer({ value: 'a' }, {}, {})).to.throw();
+        expect(() => transforms['size/dp'].transform({ value: 'a' }, {}, {})).to.throw();
       });
     });
 
     describe('size/px', () => {
       it('should work', () => {
-        const value = transforms['size/px'].transformer(
+        const value = transforms['size/px'].transform(
           {
             value: '10',
           },
@@ -752,13 +752,13 @@ describe('common', () => {
         expect(value).to.equal('10px');
       });
       it('should throw an error if prop value is Nan', () => {
-        expect(() => transforms['size/dp'].transformer({ value: 'a' }, {}, {})).to.throw();
+        expect(() => transforms['size/dp'].transform({ value: 'a' }, {}, {})).to.throw();
       });
     });
 
     describe('size/remToPt', () => {
       it('should work', () => {
-        const value = transforms['size/remToPt'].transformer(
+        const value = transforms['size/remToPt'].transform(
           {
             value: '1',
           },
@@ -768,7 +768,7 @@ describe('common', () => {
         expect(value).to.equal('16.00f');
       });
       it('converts rem to pt using custom base font', () => {
-        const value = transforms['size/remToPt'].transformer(
+        const value = transforms['size/remToPt'].transform(
           { value: '1' },
           { basePxFontSize: 14 },
           {},
@@ -776,13 +776,13 @@ describe('common', () => {
         expect(value).to.equal('14.00f');
       });
       it('should throw an error if prop value is Nan', () => {
-        expect(() => transforms['size/dp'].transformer({ value: 'a' }, {}, {})).to.throw();
+        expect(() => transforms['size/dp'].transform({ value: 'a' }, {}, {})).to.throw();
       });
     });
 
     describe('size/compose/remToSp', () => {
       it('should work', () => {
-        const value = transforms['size/compose/remToSp'].transformer(
+        const value = transforms['size/compose/remToSp'].transform(
           {
             value: '1',
           },
@@ -792,7 +792,7 @@ describe('common', () => {
         expect(value).to.equal('16.00.sp');
       });
       it('converts rem to sp using custom base font', () => {
-        const value = transforms['size/compose/remToSp'].transformer(
+        const value = transforms['size/compose/remToSp'].transform(
           { value: '1' },
           { basePxFontSize: 14 },
           {},
@@ -801,14 +801,14 @@ describe('common', () => {
       });
       it('should throw an error if prop value is Nan', () => {
         expect(() =>
-          transforms['size/compose/remToSp'].transformer({ value: 'a' }, {}, {}),
+          transforms['size/compose/remToSp'].transform({ value: 'a' }, {}, {}),
         ).to.throw();
       });
     });
 
     describe('size/compose/em', () => {
       it('should work', () => {
-        const value = transforms['size/compose/em'].transformer(
+        const value = transforms['size/compose/em'].transform(
           {
             value: '10',
           },
@@ -818,13 +818,13 @@ describe('common', () => {
         expect(value).to.equal('10.em');
       });
       it('should throw an error if prop value is Nan', () => {
-        expect(() => transforms['size/compose/em'].transformer({ value: 'a' }, {}, {})).to.throw();
+        expect(() => transforms['size/compose/em'].transform({ value: 'a' }, {}, {})).to.throw();
       });
     });
 
     describe('size/compose/remToDp', () => {
       it('should work', () => {
-        const value = transforms['size/compose/remToDp'].transformer(
+        const value = transforms['size/compose/remToDp'].transform(
           {
             value: '1',
           },
@@ -834,7 +834,7 @@ describe('common', () => {
         expect(value).to.equal('16.00.dp');
       });
       it('converts rem to dp using custom base font', () => {
-        const value = transforms['size/compose/remToDp'].transformer(
+        const value = transforms['size/compose/remToDp'].transform(
           { value: '1' },
           { basePxFontSize: 14 },
           {},
@@ -843,14 +843,14 @@ describe('common', () => {
       });
       it('should throw an error if prop value is Nan', () => {
         expect(() =>
-          transforms['size/compose/remToDp'].transformer({ value: 'a' }, {}, {}),
+          transforms['size/compose/remToDp'].transform({ value: 'a' }, {}, {}),
         ).to.throw();
       });
     });
 
     describe('size/swift/remToCGFloat', () => {
       it('should work', () => {
-        const value = transforms['size/swift/remToCGFloat'].transformer(
+        const value = transforms['size/swift/remToCGFloat'].transform(
           {
             value: '1',
           },
@@ -860,7 +860,7 @@ describe('common', () => {
         expect(value).to.equal('CGFloat(16.00)');
       });
       it('converts rem to CGFloat using custom base font', () => {
-        const value = transforms['size/swift/remToCGFloat'].transformer(
+        const value = transforms['size/swift/remToCGFloat'].transform(
           { value: '1' },
           { basePxFontSize: 14 },
           {},
@@ -869,14 +869,14 @@ describe('common', () => {
       });
       it('should throw an error if prop value is Nan', () => {
         expect(() =>
-          transforms['size/rem/remToCGFloat'].transformer({ value: 'a' }, {}, {}),
+          transforms['size/rem/remToCGFloat'].transform({ value: 'a' }, {}, {}),
         ).to.throw();
       });
     });
 
     describe('size/remToPx', () => {
       it('should work', () => {
-        const value = transforms['size/remToPx'].transformer(
+        const value = transforms['size/remToPx'].transform(
           {
             value: '1',
           },
@@ -886,7 +886,7 @@ describe('common', () => {
         expect(value).to.equal('16px');
       });
       it('converts rem to px using custom base font', () => {
-        const value = transforms['size/remToPx'].transformer(
+        const value = transforms['size/remToPx'].transform(
           { value: '1' },
           { basePxFontSize: 14 },
           {},
@@ -894,34 +894,34 @@ describe('common', () => {
         expect(value).to.equal('14px');
       });
       it('should throw an error if prop value is Nan', () => {
-        expect(() => transforms['size/dp'].transformer({ value: 'a' }, {}, {})).to.throw();
+        expect(() => transforms['size/dp'].transform({ value: 'a' }, {}, {})).to.throw();
       });
     });
 
     describe('size/pxToRem', () => {
-      const pxToRemTransformer = transforms['size/pxToRem'].transformer;
+      const pxToRemtransform = transforms['size/pxToRem'].transform;
 
       ['12', '12px', '12rem'].forEach((value) => {
         it(`ignoring unit, scales "${value}" to rem`, () => {
-          expect(pxToRemTransformer({ value }, {}, {})).to.equal('0.75rem');
+          expect(pxToRemtransform({ value }, {}, {})).to.equal('0.75rem');
         });
       });
       it('converts pixel to rem using custom base font', () => {
-        expect(pxToRemTransformer({ value: '14px' }, { basePxFontSize: 14 }, {})).to.equal('1rem');
+        expect(pxToRemtransform({ value: '14px' }, { basePxFontSize: 14 }, {})).to.equal('1rem');
       });
       ['0', '0px', '0rem'].forEach((value) => {
         it(`zero value "${value}" is returned without a unit`, () => {
-          expect(pxToRemTransformer({ value }, {}, {})).to.equal('0');
+          expect(pxToRemtransform({ value }, {}, {})).to.equal('0');
         });
       });
       it('should throw an error if prop value is Nan', () => {
-        expect(() => pxToRemTransformer({ value: 'a' }, {}, {})).to.throw();
+        expect(() => pxToRemtransform({ value: 'a' }, {}, {})).to.throw();
       });
     });
 
     describe('size/rem', () => {
       it('should work', () => {
-        const value = transforms['size/rem'].transformer(
+        const value = transforms['size/rem'].transform(
           {
             value: '1',
           },
@@ -931,13 +931,13 @@ describe('common', () => {
         expect(value).to.equal('1rem');
       });
       it('should throw an error if prop value is Nan', () => {
-        expect(() => transforms['size/dp'].transformer({ value: 'a' }, {}, {})).to.throw();
+        expect(() => transforms['size/dp'].transform({ value: 'a' }, {}, {})).to.throw();
       });
     });
 
     describe('size/flutter/remToDouble', () => {
       it('should work', () => {
-        const value = transforms['size/flutter/remToDouble'].transformer(
+        const value = transforms['size/flutter/remToDouble'].transform(
           {
             value: '1',
           },
@@ -947,7 +947,7 @@ describe('common', () => {
         expect(value).to.equal('16.00');
       });
       it('converts rem to double using custom base font', () => {
-        const value = transforms['size/flutter/remToDouble'].transformer(
+        const value = transforms['size/flutter/remToDouble'].transform(
           { value: '1' },
           { basePxFontSize: 14 },
           {},
@@ -958,7 +958,7 @@ describe('common', () => {
 
     describe('content/quote', () => {
       it('should work', () => {
-        const value = transforms['content/quote'].transformer(
+        const value = transforms['content/quote'].transform(
           {
             value: 'hello',
           },
@@ -971,7 +971,7 @@ describe('common', () => {
 
     describe('html/icon', () => {
       it('should work', () => {
-        const value = transforms['html/icon'].transformer(
+        const value = transforms['html/icon'].transform(
           {
             value: '&#xE001;',
           },
@@ -984,7 +984,7 @@ describe('common', () => {
 
     describe('content/objC/literal', () => {
       it('should work', () => {
-        const value = transforms['content/objC/literal'].transformer(
+        const value = transforms['content/objC/literal'].transform(
           {
             value: 'hello',
           },
@@ -997,7 +997,7 @@ describe('common', () => {
 
     describe('asset/url', () => {
       it('should work', () => {
-        const value = transforms['asset/url'].transformer(
+        const value = transforms['asset/url'].transform(
           {
             value: 'https://example.com',
           },
@@ -1008,7 +1008,7 @@ describe('common', () => {
       });
 
       it('should escape double quotes', () => {
-        const value = transforms['asset/url'].transformer(
+        const value = transforms['asset/url'].transform(
           {
             value:
               'data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="90" height="45"%3E%3Cpath d="M10 10h60" stroke="%2300F" stroke-width="5"/%3E%3Cpath d="M10 20h60" stroke="%230F0" stroke-width="5"/%3E%3Cpath d="M10 30h60" stroke="red" stroke-width="5"/%3E%3C/svg%3E"',
@@ -1024,7 +1024,7 @@ describe('common', () => {
 
     describe('asset/objC/literal', () => {
       it('should work', () => {
-        const value = transforms['asset/objC/literal'].transformer(
+        const value = transforms['asset/objC/literal'].transform(
           {
             value: 'hello',
           },
@@ -1037,7 +1037,7 @@ describe('common', () => {
 
     describe('time/seconds', () => {
       it('should work', () => {
-        const value = transforms['time/seconds'].transformer(
+        const value = transforms['time/seconds'].transform(
           {
             value: '1000',
           },
@@ -1053,7 +1053,7 @@ describe('common', () => {
     // the filePath of the token to determine where the asset is located relative to the token that refers to it
     describe.skip('asset/path', () => {
       it('should work', () => {
-        const value = transforms['asset/path'].transformer(
+        const value = transforms['asset/path'].transform(
           {
             value: 'foo.json',
           },

--- a/__tests__/exportPlatform.test.js
+++ b/__tests__/exportPlatform.test.js
@@ -19,8 +19,9 @@ const config = fileToJSON('__tests__/__configs/test.json');
 
 describe('exportPlatform', () => {
   let styleDictionary;
-  beforeEach(() => {
+  beforeEach(async () => {
     styleDictionary = new StyleDictionary(config);
+    await styleDictionary.hasInitialized;
   });
 
   it('should throw if not given a platform', async () => {
@@ -75,7 +76,7 @@ describe('exportPlatform', () => {
         filter: function (prop) {
           return !!prop.original.transformColor;
         },
-        transformer: function (prop) {
+        transform: function (prop) {
           return prop.value + '-darker';
         },
       });
@@ -97,11 +98,13 @@ describe('exportPlatform', () => {
           eight: { value: '{one.value}' },
           nine: { value: '{eight.value}' },
         },
-        transform: {
-          transitive: {
-            type: 'value',
-            transitive: true,
-            transformer: (token) => `${token.value}-bar`,
+        hooks: {
+          transforms: {
+            transitive: {
+              type: 'value',
+              transitive: true,
+              transform: (token) => `${token.value}-bar`,
+            },
           },
         },
         platforms: {
@@ -149,7 +152,7 @@ describe('exportPlatform', () => {
         name: 'color/darken',
         transitive: true,
         filter: (token) => token.type === 'color',
-        transformer: (token) => {
+        transform: (token) => {
           const darkenMod = token?.$extensions?.['bar.foo']?.darken;
           if (usesReferences(darkenMod)) {
             // defer this transform, because our darken value is a ref
@@ -353,14 +356,16 @@ describe('exportPlatform', () => {
     };
     // making the css/color transform transitive so we can be sure the references
     // get resolved properly and transformed.
-    const transitiveTransform = Object.assign({}, StyleDictionary.transform['color/css'], {
+    const transitiveTransform = Object.assign({}, StyleDictionary.hooks.transforms['color/css'], {
       transitive: true,
     });
 
     const sd = new StyleDictionary({
       tokens,
-      transform: {
-        transitiveTransform,
+      hooks: {
+        transforms: {
+          transitiveTransform,
+        },
       },
       platforms: {
         css: {
@@ -471,14 +476,16 @@ Use log.verbosity "verbose" or use CLI option --verbose for more details.`;
           reftest2: { $value: '{one}' },
           one: { $value: '1' },
         },
-        transform: {
-          'custom/add/px': {
-            type: 'value',
-            filter: (token) => {
-              return token.$type === 'dimension';
-            },
-            transformer: (token) => {
-              return `${sd.usesDtcg ? token.$value : token.value}px`;
+        hooks: {
+          transforms: {
+            'custom/add/px': {
+              type: 'value',
+              filter: (token) => {
+                return token.$type === 'dimension';
+              },
+              transform: (token) => {
+                return `${sd.usesDtcg ? token.$value : token.value}px`;
+              },
             },
           },
         },

--- a/__tests__/register/register.suite.js
+++ b/__tests__/register/register.suite.js
@@ -4,7 +4,7 @@ import { expect } from 'chai';
 export function registerSuite(opts) {
   /**
    * opts example: {
-   *   config: { transformer: () => {} },
+   *   config: { transform: () => {} },
    *   registerMethod: 'registerTransform',
    *   prop: 'transform',
    * }

--- a/__tests__/transform/config.test.js
+++ b/__tests__/transform/config.test.js
@@ -17,16 +17,16 @@ import chalk from 'chalk';
 
 const dictionary = {
   hooks: {
+    transforms: {
+      fooTransform: {
+        type: 'attribute',
+        transform: function () {
+          return { bar: 'foo' };
+        },
+      },
+    },
     transformGroups: {
       fooTransformGroup: ['barTransform'],
-    },
-  },
-  transform: {
-    fooTransform: {
-      type: 'attribute',
-      transformer: function () {
-        return { bar: 'foo' };
-      },
     },
   },
 };
@@ -62,31 +62,31 @@ None of "barTransform", "bazTransform" match the name of a registered transform.
     it('allows combining transformGroup with transforms', () => {
       const cfg = {
         hooks: {
+          transforms: {
+            fooTransform: {
+              name: 'fooTransform',
+              type: 'attribute',
+              transform: function () {
+                return { foo: 'foo' };
+              },
+            },
+            barTransform: {
+              name: 'barTransform',
+              type: 'attribute',
+              transform: function () {
+                return { bar: 'bar' };
+              },
+            },
+            quxTransform: {
+              name: 'quxTransform',
+              type: 'attribute',
+              transform: function () {
+                return { qux: 'qux' };
+              },
+            },
+          },
           transformGroups: {
             foobarTransformGroup: ['fooTransform', 'barTransform'],
-          },
-        },
-        transform: {
-          fooTransform: {
-            name: 'fooTransform',
-            type: 'attribute',
-            transformer: function () {
-              return { foo: 'foo' };
-            },
-          },
-          barTransform: {
-            name: 'barTransform',
-            type: 'attribute',
-            transformer: function () {
-              return { bar: 'bar' };
-            },
-          },
-          quxTransform: {
-            name: 'quxTransform',
-            type: 'attribute',
-            transformer: function () {
-              return { qux: 'qux' };
-            },
           },
         },
       };

--- a/__tests__/transform/object.test.js
+++ b/__tests__/transform/object.test.js
@@ -17,14 +17,14 @@ const config = {
   transforms: [
     {
       type: 'attribute',
-      transformer: function () {
+      transform: function () {
         return { foo: 'bar' };
       },
     },
     {
       type: 'attribute',
       // verify async transforms to also work properly
-      transformer: async function () {
+      transform: async function () {
         await new Promise((resolve) => setTimeout(resolve, 100));
         return { bar: 'foo' };
       },
@@ -35,9 +35,9 @@ const config = {
         return token.attributes.foo === 'bar';
       },
       // verify async transforms to also work properly
-      transformer: async function () {
+      transform: async function () {
         await new Promise((resolve) => setTimeout(resolve, 100));
-        return 'transformer result';
+        return 'transform result';
       },
     },
     {
@@ -45,7 +45,7 @@ const config = {
       filter: function (token) {
         return token.path[0] === 'spacing';
       },
-      transformer: function (val) {
+      transform: function (val) {
         return val + 'px';
       },
     },
@@ -86,7 +86,7 @@ describe('transform', () => {
           base: {
             attributes: { bar: 'foo', foo: 'bar' },
             comment: 'the base size of the font',
-            name: 'transformer result',
+            name: 'transform result',
             original: {
               comment: 'the base size of the font',
               value: '16',

--- a/__tests__/transform/transformToken.test.js
+++ b/__tests__/transform/transformToken.test.js
@@ -17,7 +17,7 @@ const config = {
   transforms: [
     {
       type: 'attribute',
-      transformer: function () {
+      transform: function () {
         return {
           foo: 'bar',
         };
@@ -25,7 +25,7 @@ const config = {
     },
     {
       type: 'attribute',
-      transformer: function () {
+      transform: function () {
         return { bar: 'foo' };
       },
     },
@@ -34,7 +34,7 @@ const config = {
       filter: function (prop) {
         return prop.attributes.foo === 'bar';
       },
-      transformer: function () {
+      transform: function () {
         return 'hello';
       },
     },
@@ -50,7 +50,7 @@ describe('transform', () => {
     });
 
     // This allows transformObject utility to then consider this token's transformation undefined and thus "deferred"
-    it('returns a token as undefined if transitive transformer dictates that the transformation has to be deferred', async () => {
+    it('returns a token as undefined if transitive transform dictates that the transformation has to be deferred', async () => {
       const result = await transformToken(
         {
           value: '16',
@@ -63,7 +63,7 @@ describe('transform', () => {
             {
               type: 'value',
               transitive: true,
-              transformer: () => {
+              transform: () => {
                 return undefined;
               },
             },

--- a/docs/src/content/docs/reference/Hooks/Transforms/index.md
+++ b/docs/src/content/docs/reference/Hooks/Transforms/index.md
@@ -25,14 +25,14 @@ You use transforms in your config file under `platforms` > `[platform]` > `trans
 }
 ```
 
-A transform consists of 4 parts: `type`, `name`, `filter`, and `transformer`. Transforms are run on all design tokens where the filter returns true.
+A transform consists of 4 parts: `type`, `name`, `filter`, and `transform`. Transforms are run on all design tokens where the filter returns true.
 
 :::tip
 If you don't provide a filter function, it will match all tokens.
 :::
 
 :::note
-`transformer` functions can be async as well.
+`transform` functions can be async as well.
 :::
 
 ## Transform Types
@@ -41,7 +41,7 @@ There are 3 types of transforms: `attribute`, `name`, and `value`.
 
 **Attribute:** An attribute transform adds to the attributes object on a design token. This is for including any meta-data about a design token such as it's CTI attributes or other information.
 
-**Name:** A name transform transforms the name of a design token. You should really only be applying one name transformer because they will override each other if you use more than one.
+**Name:** A name transform transforms the name of a design token. You should really only be applying one name transform because they will override each other if you use more than one.
 
 **Value:** The value transform is the most important as this is the one that modifies the value or changes the representation of the value. Colors can be turned into hex values, rgb, hsl, hsv, etc. Value transforms have a filter function that filter which tokens that transform runs on. This allows us to only run a color transform on only the colors and not every design token.
 
@@ -61,7 +61,7 @@ StyleDictionary.registerTransform({
   transitive: true,
   name: `myTransitiveTransform`,
   filter: (token) => {},
-  transformer: (token) => {
+  transform: (token) => {
     // token.value will be resolved and transformed at this point
   },
 });
@@ -97,7 +97,7 @@ Using a custom transitive transform you could have `color.danger` darken `color.
 
 ### Defer transitive transformation manually
 
-It's also possible to control, inside a transitive transform's `transformer` function, whether the transformation should be deferred until a later cycle of references resolution.
+It's also possible to control, inside a transitive transform's `transform` function, whether the transformation should be deferred until a later cycle of references resolution.
 This is done by returning `undefined`, which basically means "I cannot currently do the transform due to a reference not yet being resolved".
 
 Imagine the following transform:
@@ -110,7 +110,7 @@ StyleDictionary.registerTransform({
   name: '',
   type: 'value',
   transitive: true,
-  transformer: (token) => {
+  transform: (token) => {
     const darkenModifier = token.darken;
     if (usesReferences(darkenModifier)) {
       // defer this transform, because our darken value is a reference
@@ -133,7 +133,7 @@ Combined with the following tokens:
 }
 ```
 
-Due to `token.darken` being a property that uses a reference, we need the ability to defer its transformation from within the transformer,
-since the transformer is the only place where we know which token properties the transformation is reliant upon.
+Due to `token.darken` being a property that uses a reference, we need the ability to defer its transformation from within the transform,
+since the transform is the only place where we know which token properties the transformation is reliant upon.
 
 If you want to learn more about transitive transforms, take a look at the [transitive transforms example](https://github.com/amzn/style-dictionary/tree/main/examples/advanced/transitive-transforms).

--- a/docs/src/content/docs/reference/api.md
+++ b/docs/src/content/docs/reference/api.md
@@ -420,14 +420,14 @@ StyleDictionary.registerPreprocessor({
 Add a custom [transform](/reference/hooks/transforms) to the Style Dictionary.
 Transforms can manipulate a token's name, value, or attributes.
 
-| Param                 | Type       | Description                                                                                                                                                                                                                                                                                           |
-| --------------------- | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| transform             | `Object`   | Transform object                                                                                                                                                                                                                                                                                      |
-| transform.type        | `string`   | Type of transform, can be: name, attribute, or value                                                                                                                                                                                                                                                  |
-| transform.name        | `string`   | Name of the transformer (used by transformGroup to call a list of transforms).                                                                                                                                                                                                                        |
-| transform.transitive  | `boolean`  | If the value transform should be applied transitively, i.e. should be applied to referenced values as well as absolute values.                                                                                                                                                                        |
-| transform.filter      | `function` | [Filter](/reference/hooks/filters) function, return boolean if transform should be applied. If you omit the filter function, it will match all tokens.                                                                                                                                                |
-| transform.transformer | `function` | Modifies a design token object. The transformer function will receive the token and the platform configuration as its arguments. The transformer function should return a string for name transforms, an object for attribute transforms, and same type of value for a value transform. Can be async. |
+| Param                | Type       | Description                                                                                                                                                                                                                                                                                       |
+| -------------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| transform            | `Object`   | Transform object                                                                                                                                                                                                                                                                                  |
+| transform.type       | `string`   | Type of transform, can be: name, attribute, or value                                                                                                                                                                                                                                              |
+| transform.name       | `string`   | Name of the transform (used by transformGroup to call a list of transforms).                                                                                                                                                                                                                      |
+| transform.transitive | `boolean`  | If the value transform should be applied transitively, i.e. should be applied to referenced values as well as absolute values.                                                                                                                                                                    |
+| transform.filter     | `function` | [Filter](/reference/hooks/filters) function, return boolean if transform should be applied. If you omit the filter function, it will match all tokens.                                                                                                                                            |
+| transform.transform  | `function` | Modifies a design token object. The transform function will receive the token and the platform configuration as its arguments. The transform function should return a string for name transforms, an object for attribute transforms, and same type of value for a value transform. Can be async. |
 
 Example:
 
@@ -438,7 +438,7 @@ StyleDictionary.registerTransform({
   filter: function (token) {
     return token.type === 'time';
   },
-  transformer: function (token) {
+  transform: function (token) {
     // Note the use of prop.original.value,
     // before any transforms are performed, the build system
     // clones the original token to the 'original' attribute.

--- a/docs/src/content/docs/reference/config.md
+++ b/docs/src/content/docs/reference/config.md
@@ -64,7 +64,7 @@ export default {
     // Now we can use the transform 'myTransform' below
     myTransform: {
       type: 'name',
-      transformer: (token) => token.path.join('_').toUpperCase(),
+      transform: (token) => token.path.join('_').toUpperCase(),
     },
   },
   // Same with formats, you can now write them directly to this config

--- a/docs/src/content/docs/version-4/migration.md
+++ b/docs/src/content/docs/version-4/migration.md
@@ -117,9 +117,9 @@ Available hooks are: `parsers`, `preprocessors`, `transformGroups`, `transforms`
 
 :::note
 The other hooks are also going to change similarly to preprocessors, in an effort to align these APIs and make them consistent across.
-They will all be grouped under the `hooks` property, they will all use plural form vs singular (e.g. `transforms` vs `transform`), and lastly,
-they will all use the same signature, with a `name` property and a handler function name that is the same as the hook name (e.g. `transformer` will be `transform`).
-Parsers will also have to be applied explicitly similarly to preprocessors.
+Hooks are now all grouped under the `hooks` property, they all use plural form vs singular (e.g. `transforms` vs `transform`), and lastly,
+they will all use the same signature, with a `name` property and a handler function name that is the same as the hook name (e.g. `transformer` has become `transform`).
+Parsers and preprocessors now also have to be applied explicitly in the config.
 :::
 
 ### Parsers
@@ -183,7 +183,7 @@ export default {
   preprocessors: ['foo'],
   platforms: {
     css: {
-      // or apply is per platform
+      // or apply it per platform
       preprocessors: ['foo'],
     },
   },
@@ -210,8 +210,59 @@ export default {
   },
   platforms: {
     css: {
-      // or apply is per platform
+      // apply it per platform
       transformGroup: ['foo'],
+    },
+  },
+};
+```
+
+### Transforms
+
+Transform, when registered, are put inside the `hooks.transforms` property now, as opposed to `transform`.
+Note the change from singular to plural form here.
+
+The name of the filter function is now `filter` instead of `matcher`:
+
+```js title="build-tokens.js" del={6} ins={7} /filter/ /matcher/
+import StyleDictionary from 'style-dictionary';
+
+StyleDictionary.registerTransform({
+  name: 'color-transform',
+  type: 'value',
+  matcher: (token) => token.type === 'color',
+  filter: (token) => token.type === 'color',
+  transform: (token) => token.value,
+});
+```
+
+Lastly, the `transformer` handler function has been renamed to `transform` for consistency.
+
+Changes:
+
+```js title="config.js" del={3-9} ins={10-18} /transform(s): {/ /filter/ /matcher/ /transform(er)/ /(transform): (/
+export default {
+  // register it inline or by SD.registerTransform
+  transform: {
+    'color-transform': {
+      type: 'value',
+      matcher: (token) => token.type === 'color',
+      transformer: (token) => token.value,
+    },
+  },
+  hooks: {
+    transforms: {
+      'color-transform': {
+        type: 'value',
+        filter: (token) => token.type === 'color',
+        transform: (token) => token.value,
+      },
+    },
+  },
+  platforms: {
+    css: {
+      // apply it per platform
+      transforms: ['color-transform'],
     },
   },
 };
@@ -284,22 +335,6 @@ StyleDictionary.registerFilter({
 :::note
 These changes also apply for the [filter function inside transforms](#transforms).
 :::
-
-### Transforms
-
-The name of the filter function is now `filter` instead of `matcher`:
-
-```js title="build-tokens.js" del={6} ins={7}
-import StyleDictionary from 'style-dictionary';
-
-StyleDictionary.registerTransform({
-  name: 'color-transform',
-  type: 'value',
-  matcher: (token) => token.type === 'color',
-  filter: (token) => token.type === 'color',
-  transform: (token) => token.value,
-});
-```
 
 ### Actions
 

--- a/examples/advanced/component-cti/README.md
+++ b/examples/advanced/component-cti/README.md
@@ -72,7 +72,7 @@ const StyleDictionary = require('style-dictionary');
 const cti = StyleDictionary.transform['attribute/cti'];
 // {
 //   type: 'attribute',
-//   transformer: f () {}
+//   transform: f () {}
 // }
 ```
 
@@ -84,5 +84,5 @@ For example, if the key of the token (the last part of the object path) is "back
 
 - `config.js`:
   - `propertiesToCTI`: A plain object where we map the CSS property name to the proper category and type.
-  - `CTITransform`: A transform object that defines a transformer method, which will override the default `attribute/cti` transform. This is similar to creating a child class with some custom logic and then calling `super`. In the transformer function it first looks at the top-level namespace, the first item in the object path, and if it is 'component' we run our custom logic using the `propertiesToCTI` map. If it is not 'component', use the built-in `attribute/cti`.
+  - `CTITransform`: A transform object that defines a transform method, which will override the default `attribute/cti` transform. This is similar to creating a child class with some custom logic and then calling `super`. In the transform function it first looks at the top-level namespace, the first item in the object path, and if it is 'component' we run our custom logic using the `propertiesToCTI` map. If it is not 'component', use the built-in `attribute/cti`.
 - `tokens/component/button.json`: Take a look at how it defines the component tokens and uses the last part of the object path as the CSS property. Notice how we can define token values in here that are not references, but they still get transformed properly: font-size uses 'rem' and background-color uses hex in the output.

--- a/examples/advanced/component-cti/config.js
+++ b/examples/advanced/component-cti/config.js
@@ -1,5 +1,5 @@
 const StyleDictionary = require('style-dictionary');
-const transformer = StyleDictionary.transform['attribute/cti'].transformer;
+const transform = StyleDictionary.transform['attribute/cti'].transform;
 
 const propertiesToCTI = {
   width: { category: 'size', type: 'dimension' },
@@ -25,15 +25,15 @@ const propertiesToCTI = {
 
 const CTITransform = {
   type: `attribute`,
-  transformer: (prop) => {
+  transform: (prop) => {
     // Only do this custom functionality in the 'component' top-level namespace.
     if (prop.path[0] === 'component') {
       // When defining component tokens, the key of the token is the relevant CSS property
       // The key of the token is the last element in the path array
       return propertiesToCTI[prop.path[prop.path.length - 1]];
     } else {
-      // Fallback to the original 'attribute/cti' transformer
-      return transformer(prop);
+      // Fallback to the original 'attribute/cti' transform
+      return transform(prop);
     }
   },
 };
@@ -44,7 +44,7 @@ const CTITransform = {
 // StyleDictionary.registerTransform({
 //   name: 'attribute/cti',
 //   type: 'attribute',
-//   transformer: CTITransform.transformer
+//   transform: CTITransform.transform
 // });
 
 module.exports = {

--- a/examples/advanced/custom-transforms/README.md
+++ b/examples/advanced/custom-transforms/README.md
@@ -28,7 +28,7 @@ StyleDictionary.registerTransform({
   filter: function (token) {
     return token.group === 'ratio';
   },
-  transformer: function (token) {
+  transform: function (token) {
     return `${Math.floor(100 * token.value)}%`;
   },
 });

--- a/examples/advanced/custom-transforms/build.js
+++ b/examples/advanced/custom-transforms/build.js
@@ -16,7 +16,7 @@ StyleDictionary.registerTransform({
     // this is an example of a possible filter (based on the "cti" values) to show how a "filter" works
     return token.attributes.category === 'font' || token.attributes.category === 'margin';
   },
-  transformer: function (token) {
+  transform: function (token) {
     return `${token.value}px`;
   },
 });
@@ -28,7 +28,7 @@ StyleDictionary.registerTransform({
     // here we are using a custom attribute, declared in the token, to match the values where apply the transform
     return token.group === 'ratio';
   },
-  transformer: function (token) {
+  transform: function (token) {
     return `${Math.floor(100 * token.value)}%`;
   },
 });
@@ -39,7 +39,7 @@ StyleDictionary.registerTransform({
   filter: function (token) {
     return token.group === 'color';
   },
-  transformer: function (token) {
+  transform: function (token) {
     // for sake of simplicity, in this example we assume colors are always in the format #xxxxxx
     return token.value.replace(/^#/, '#FF');
   },
@@ -51,7 +51,7 @@ StyleDictionary.registerTransform({
   filter: function (token) {
     return token.group === 'typography' || token.group === 'spacing';
   },
-  transformer: function (token) {
+  transform: function (token) {
     // in Android font sizes are expressed in "sp" units
     let unit = token.group === 'typography' ? 'sp' : 'dp';
     return `${token.value}${unit}`;
@@ -63,7 +63,7 @@ StyleDictionary.registerTransform({
   name: 'name/squiggle',
   type: 'name',
   // notice: if you don't specify a filter, the transformation will be applied to all the tokens
-  transformer: function (token) {
+  transform: function (token) {
     return token.path.join('~');
   },
 });

--- a/examples/advanced/font-face-rules/sd.config.js
+++ b/examples/advanced/font-face-rules/sd.config.js
@@ -5,7 +5,7 @@ const StyleDictionary = require('style-dictionary');
 StyleDictionary.registerTransform({
   name: 'attribute/font',
   type: 'attribute',
-  transformer: (prop) => ({
+  transform: (prop) => ({
     category: prop.path[0],
     type: prop.path[1],
     family: prop.path[2],

--- a/examples/advanced/node-modules-as-config-and-properties/config.js
+++ b/examples/advanced/node-modules-as-config-and-properties/config.js
@@ -13,7 +13,7 @@ StyleDictionary.registerTransform({
   name: 'myRegisteredTransform',
   type: 'value',
   filter: (token) => token.attributes.category === 'size',
-  transformer: (token) => `${parseInt(token.value) * 16}px`,
+  transform: (token) => `${parseInt(token.value) * 16}px`,
 });
 
 StyleDictionary.registerFormat({
@@ -39,7 +39,7 @@ module.exports = {
     // Now we can use the transform 'myTransform' below
     myTransform: {
       type: 'name',
-      transformer: (token) => token.path.join('_').toUpperCase(),
+      transform: (token) => token.path.join('_').toUpperCase(),
     },
   },
   // Same with formats, you can now write them directly to this config

--- a/examples/advanced/transitive-transforms/sd.config.js
+++ b/examples/advanced/transitive-transforms/sd.config.js
@@ -43,7 +43,7 @@ export default {
       // that alias/reference other tokens
       transitive: true,
       filter: (token) => token.attributes.category === 'color' && token.modify,
-      transformer: colorTransform,
+      transform: colorTransform,
     },
 
     // For backwards compatibility, all built-in transforms are not transitive

--- a/lib/Register.js
+++ b/lib/Register.js
@@ -1,4 +1,4 @@
-import transform from './common/transforms.js';
+import transformBuiltins from './common/transforms.js';
 import transformGroupBuiltins from './common/transformGroups.js';
 import format from './common/formats.js';
 import actionBuiltins from './common/actions.js';
@@ -18,7 +18,7 @@ import { deepmerge } from './utils/deepmerge.js';
  */
 
 /**
- * @return {Hooks}
+ * @return {Required<Hooks>}
  */
 function getBuiltinHooks() {
   return {
@@ -26,6 +26,9 @@ function getBuiltinHooks() {
     preprocessors: {},
     transformGroups: {
       ...transformGroupBuiltins,
+    },
+    transforms: {
+      ...transformBuiltins,
     },
     fileHeaders: {},
     filters: {
@@ -46,20 +49,18 @@ export class Register {
    *
    * Therefore, we have to make use of static props vs instance props and use getters and setters to merge these together.
    */
-  /** @type {Hooks} */
   static hooks = getBuiltinHooks();
 
-  static transform = transform;
   static format = format;
 
-  /** @type {Hooks} */
+  /** @type {Required<Hooks>} */
   get hooks() {
     const ctor = /** @type {typeof Register} */ (this.constructor);
     return deepmerge(ctor.hooks, this._hooks ?? {});
   }
 
   /**
-   * @param {Hooks} v
+   * @param {Required<Hooks>} v
    */
   set hooks(v) {
     this._hooks = v;
@@ -87,35 +88,28 @@ export class Register {
    */
   static __registerTransform(transform, target) {
     const transformTypes = ['name', 'value', 'attribute'];
-    const { type, name, filter, transitive, transformer } = transform;
+    const { type, name, filter, transitive, transform: transformFn } = transform;
     if (typeof type !== 'string') throw new Error('type must be a string');
     if (transformTypes.indexOf(type) < 0)
       throw new Error(type + ' type is not one of: ' + transformTypes.join(', '));
     if (typeof name !== 'string') throw new Error('name must be a string');
     if (filter && typeof filter !== 'function') throw new Error('filter must be a function');
-    if (typeof transformer !== 'function') throw new Error('transformer must be a function');
+    if (typeof transformFn !== 'function') throw new Error('transform must be a function');
 
     // make sure to trigger the setter
-    target.transform = {
-      ...target.transform,
-      [name]: {
-        type,
-        filter,
-        transitive: !!transitive,
-        transformer,
+    target.hooks = {
+      ...target.hooks,
+      transforms: {
+        ...target.hooks.transforms,
+        [name]: {
+          type,
+          filter,
+          transitive: !!transitive,
+          transform: transformFn,
+        },
       },
     };
     return this;
-  }
-
-  get transform() {
-    const ctor = /** @type {typeof Register} */ (this.constructor);
-    return { ...ctor.transform, ...this._transform };
-  }
-
-  /** @param {Record<string, Omit<Transform, 'name'>>} v */
-  set transform(v) {
-    this._transform = v;
   }
 
   /**
@@ -145,7 +139,7 @@ export class Register {
       throw new Error('transforms must be an array of registered value transforms');
 
     transforms.forEach((t) => {
-      if (!(t in target.transform))
+      if (!target.hooks.transforms || !(t in target.hooks.transforms))
         throw new Error('transforms must be an array of registered value transforms');
     });
     // make sure to trigger the setter
@@ -398,8 +392,6 @@ export class Register {
   }
 
   constructor() {
-    this.transform = {};
-    this.transformGroup = {};
     this.format = {};
     this.hooks = getBuiltinHooks();
   }

--- a/lib/StyleDictionary.js
+++ b/lib/StyleDictionary.js
@@ -79,8 +79,6 @@ export default class StyleDictionary extends Register {
     // so that when we extend, we include registered things
     const opts = deepmerge(
       {
-        transform: this.transform,
-        transformGroup: this.transformGroup,
         format: this.format,
         hooks: this.hooks,
       },

--- a/lib/common/transforms.js
+++ b/lib/common/transforms.js
@@ -134,7 +134,7 @@ export default {
    */
   'attribute/cti': {
     type: 'attribute',
-    transformer: function (token) {
+    transform: function (token) {
       const attrNames = ['category', 'type', 'item', 'subitem', 'state'];
       const originalAttrs = token.attributes || {};
       /** @type {Record<string, string>} */
@@ -167,7 +167,7 @@ export default {
   'attribute/color': {
     type: 'attribute',
     filter: isColor,
-    transformer: function (token, _, options) {
+    transform: function (token, _, options) {
       const color = Color(options.usesDtcg ? token.$value : token.value);
       return {
         hex: color.toHex(),
@@ -191,7 +191,7 @@ export default {
    */
   'name/human': {
     type: 'name',
-    transformer: function (token) {
+    transform: function (token) {
       return [token.attributes?.item, token.attributes?.subitem].join(' ');
     },
   },
@@ -210,7 +210,7 @@ export default {
    */
   'name/camel': {
     type: 'name',
-    transformer: function (token, config) {
+    transform: function (token, config) {
       return camelCase([config.prefix].concat(token.path).join(' '), camelOpts);
     },
   },
@@ -229,7 +229,7 @@ export default {
    */
   'name/kebab': {
     type: 'name',
-    transformer: function (token, config) {
+    transform: function (token, config) {
       return kebabCase([config.prefix].concat(token.path).join(' '));
     },
   },
@@ -248,7 +248,7 @@ export default {
    */
   'name/snake': {
     type: 'name',
-    transformer: function (token, config) {
+    transform: function (token, config) {
       return snakeCase([config.prefix].concat(token.path).join(' '));
     },
   },
@@ -267,7 +267,7 @@ export default {
    */
   'name/constant': {
     type: 'name',
-    transformer: function (token, config) {
+    transform: function (token, config) {
       return snakeCase([config.prefix].concat(token.path).join(' ')).toUpperCase();
     },
   },
@@ -286,7 +286,7 @@ export default {
    */
   'name/pascal': {
     type: 'name',
-    transformer: function (token, config) {
+    transform: function (token, config) {
       /** @param {string} str */
       const upperFirst = function (str) {
         return str ? str[0].toUpperCase() + str.slice(1) : '';
@@ -309,7 +309,7 @@ export default {
   'color/rgb': {
     type: 'value',
     filter: isColor,
-    transformer: function (token, _, options) {
+    transform: function (token, _, options) {
       return Color(options.usesDtcg ? token.$value : token.value).toRgbString();
     },
   },
@@ -329,7 +329,7 @@ export default {
   'color/hsl': {
     type: 'value',
     filter: isColor,
-    transformer: function (token, _, options) {
+    transform: function (token, _, options) {
       return Color(options.usesDtcg ? token.$value : token.value).toHslString();
     },
   },
@@ -349,7 +349,7 @@ export default {
   'color/hsl-4': {
     type: 'value',
     filter: isColor,
-    transformer: function (token, _, options) {
+    transform: function (token, _, options) {
       const color = Color(options.usesDtcg ? token.$value : token.value);
       const o = color.toHsl();
       const vals = `${Math.round(o.h)} ${Math.round(o.s * 100)}% ${Math.round(o.l * 100)}%`;
@@ -375,7 +375,7 @@ export default {
   'color/hex': {
     type: 'value',
     filter: isColor,
-    transformer: function (token, _, options) {
+    transform: function (token, _, options) {
       return Color(options.usesDtcg ? token.$value : token.value).toHexString();
     },
   },
@@ -394,7 +394,7 @@ export default {
   'color/hex8': {
     type: 'value',
     filter: isColor,
-    transformer: function (token, _, options) {
+    transform: function (token, _, options) {
       return Color(options.usesDtcg ? token.$value : token.value).toHex8String();
     },
   },
@@ -413,7 +413,7 @@ export default {
   'color/hex8android': {
     type: 'value',
     filter: isColor,
-    transformer: function (token, _, options) {
+    transform: function (token, _, options) {
       const str = Color(options.usesDtcg ? token.$value : token.value).toHex8();
       return '#' + str.slice(6) + str.slice(0, 6);
     },
@@ -433,7 +433,7 @@ export default {
   'color/composeColor': {
     type: 'value',
     filter: isColor,
-    transformer: function (token, _, options) {
+    transform: function (token, _, options) {
       const str = Color(options.usesDtcg ? token.$value : token.value).toHex8();
       return 'Color(0x' + str.slice(6) + str.slice(0, 6) + ')';
     },
@@ -453,7 +453,7 @@ export default {
   'color/UIColor': {
     type: 'value',
     filter: isColor,
-    transformer: function (token, _, options) {
+    transform: function (token, _, options) {
       const rgb = Color(options.usesDtcg ? token.$value : token.value).toRgb();
       return (
         '[UIColor colorWithRed:' +
@@ -486,7 +486,7 @@ export default {
   'color/UIColorSwift': {
     type: 'value',
     filter: isColor,
-    transformer: function (token, _, options) {
+    transform: function (token, _, options) {
       const { r, g, b, a } = Color(options.usesDtcg ? token.$value : token.value).toRgb();
       const rFixed = (r / 255.0).toFixed(3);
       const gFixed = (g / 255.0).toFixed(3);
@@ -509,7 +509,7 @@ export default {
   'color/ColorSwiftUI': {
     type: 'value',
     filter: isColor,
-    transformer: function (token, _, options) {
+    transform: function (token, _, options) {
       const { r, g, b, a } = Color(options.usesDtcg ? token.$value : token.value).toRgb();
       const rFixed = (r / 255.0).toFixed(3);
       const gFixed = (g / 255.0).toFixed(3);
@@ -533,7 +533,7 @@ export default {
   'color/css': {
     type: 'value',
     filter: isColor,
-    transformer: function (token, _, options) {
+    transform: function (token, _, options) {
       const color = Color(options.usesDtcg ? token.$value : token.value);
       if (color.getAlpha() === 1) {
         return color.toHexString();
@@ -564,7 +564,7 @@ export default {
   'color/sketch': {
     type: 'value',
     filter: isColor,
-    transformer: function (token, _, options) {
+    transform: function (token, _, options) {
       let color = Color(options.usesDtcg ? token.$value : token.value).toRgb();
       return {
         red: (color.r / 255).toFixed(5),
@@ -589,7 +589,7 @@ export default {
   'size/sp': {
     type: 'value',
     filter: isFontSize,
-    transformer: function (token, _, options) {
+    transform: function (token, _, options) {
       const nonParsedVal = options.usesDtcg ? token.$value : token.value;
       const val = parseFloat(nonParsedVal);
       if (isNaN(val)) throwSizeError(token.name, nonParsedVal, 'sp');
@@ -611,7 +611,7 @@ export default {
   'size/dp': {
     type: 'value',
     filter: isDimension,
-    transformer: function (token, _, options) {
+    transform: function (token, _, options) {
       const nonParsedVal = options.usesDtcg ? token.$value : token.value;
       const val = parseFloat(nonParsedVal);
       if (isNaN(val)) throwSizeError(token.name, nonParsedVal, 'dp');
@@ -638,7 +638,7 @@ export default {
   'size/object': {
     type: 'value',
     filter: (token) => isDimension(token) || isFontSize(token),
-    transformer: function (token, config, options) {
+    transform: function (token, config, options) {
       const value = options.usesDtcg ? token.$value : token.value;
       const parsedVal = parseFloat(value);
       if (isNaN(parsedVal)) throwSizeError(token.name, value, 'object');
@@ -666,7 +666,7 @@ export default {
   'size/remToSp': {
     type: 'value',
     filter: isFontSize,
-    transformer: function (token, config, options) {
+    transform: function (token, config, options) {
       const value = options.usesDtcg ? token.$value : token.value;
       const parsedVal = parseFloat(value);
       const baseFont = getBasePxFontSize(config);
@@ -689,7 +689,7 @@ export default {
   'size/remToDp': {
     type: 'value',
     filter: isDimension,
-    transformer: function (token, config, options) {
+    transform: function (token, config, options) {
       const value = options.usesDtcg ? token.$value : token.value;
       const parsedVal = parseFloat(value);
       const baseFont = getBasePxFontSize(config);
@@ -712,7 +712,7 @@ export default {
   'size/px': {
     type: 'value',
     filter: (token) => isDimension(token) || isFontSize(token),
-    transformer: function (token, _, options) {
+    transform: function (token, _, options) {
       const value = options.usesDtcg ? token.$value : token.value;
       const parsedVal = parseFloat(value);
       if (isNaN(parsedVal)) throwSizeError(token.name, value, 'px');
@@ -734,7 +734,7 @@ export default {
   'size/rem': {
     type: 'value',
     filter: (token) => isDimension(token) || isFontSize(token),
-    transformer: function (token, _, options) {
+    transform: function (token, _, options) {
       const nonParsed = options.usesDtcg ? token.$value : token.value;
       const parsedVal = parseFloat(nonParsed);
       if (isNaN(parsedVal)) throwSizeError(token.name, nonParsed, 'rem');
@@ -756,7 +756,7 @@ export default {
   'size/remToPt': {
     type: 'value',
     filter: (token) => isDimension(token) || isFontSize(token),
-    transformer: function (token, config, options) {
+    transform: function (token, config, options) {
       const value = options.usesDtcg ? token.$value : token.value;
       const parsedVal = parseFloat(value);
       const baseFont = getBasePxFontSize(config);
@@ -779,7 +779,7 @@ export default {
   'size/compose/remToSp': {
     type: 'value',
     filter: isFontSize,
-    transformer: function (token, config, options) {
+    transform: function (token, config, options) {
       const value = options.usesDtcg ? token.$value : token.value;
       const parsedVal = parseFloat(value);
       const baseFont = getBasePxFontSize(config);
@@ -802,7 +802,7 @@ export default {
   'size/compose/remToDp': {
     type: 'value',
     filter: isDimension,
-    transformer: function (token, config, options) {
+    transform: function (token, config, options) {
       const value = options.usesDtcg ? token.$value : token.value;
       const parsedVal = parseFloat(value);
       const baseFont = getBasePxFontSize(config);
@@ -825,7 +825,7 @@ export default {
   'size/compose/em': {
     type: 'value',
     filter: isFontSize,
-    transformer: function (token, _, options) {
+    transform: function (token, _, options) {
       const value = options.usesDtcg ? token.$value : token.value;
       const parsedVal = parseFloat(value);
       if (isNaN(parsedVal)) throwSizeError(token.name, value, 'em');
@@ -846,7 +846,7 @@ export default {
   'size/swift/remToCGFloat': {
     type: 'value',
     filter: (token) => isDimension(token) || isFontSize(token),
-    transformer: function (token, config, options) {
+    transform: function (token, config, options) {
       const value = options.usesDtcg ? token.$value : token.value;
       const parsedVal = parseFloat(value);
       const baseFont = getBasePxFontSize(config);
@@ -869,7 +869,7 @@ export default {
   'size/remToPx': {
     type: 'value',
     filter: (token) => isDimension(token) || isFontSize(token),
-    transformer: function (token, config, options) {
+    transform: function (token, config, options) {
       const value = options.usesDtcg ? token.$value : token.value;
       const parsedVal = parseFloat(value);
       const baseFont = getBasePxFontSize(config);
@@ -893,7 +893,7 @@ export default {
   'size/pxToRem': {
     type: 'value',
     filter: (token) => isDimension(token) || isFontSize(token),
-    transformer: (token, config, options) => {
+    transform: (token, config, options) => {
       const value = options.usesDtcg ? token.$value : token.value;
       const parsedVal = parseFloat(value);
       const baseFont = getBasePxFontSize(config);
@@ -926,7 +926,7 @@ export default {
     filter: function (token) {
       return token.type === 'html';
     },
-    transformer: function (token, _, options) {
+    transform: function (token, _, options) {
       return (options.usesDtcg ? token.$value : token.value).replace(
         UNICODE_PATTERN,
         /**
@@ -953,7 +953,7 @@ export default {
   'content/quote': {
     type: 'value',
     filter: isContent,
-    transformer: function (token, _, options) {
+    transform: function (token, _, options) {
       return wrapValueWith("'", token, options);
     },
   },
@@ -972,7 +972,7 @@ export default {
   'content/objC/literal': {
     type: 'value',
     filter: isContent,
-    transformer: function (token, _, options) {
+    transform: function (token, _, options) {
       return '@' + wrapValueWithDoubleQuote(token, options);
     },
   },
@@ -991,7 +991,7 @@ export default {
   'content/swift/literal': {
     type: 'value',
     filter: isContent,
-    transformer: (token, _, options) => wrapValueWithDoubleQuote(token, options),
+    transform: (token, _, options) => wrapValueWithDoubleQuote(token, options),
   },
 
   /**
@@ -1010,7 +1010,7 @@ export default {
     filter: function (token) {
       return token.type === 'time';
     },
-    transformer: function (token, _, options) {
+    transform: function (token, _, options) {
       return (parseFloat(options.usesDtcg ? token.$value : token.value) / 1000).toFixed(2) + 's';
     },
   },
@@ -1029,7 +1029,7 @@ export default {
   'asset/url': {
     type: 'value',
     filter: isAsset,
-    transformer: function (token, _, options) {
+    transform: function (token, _, options) {
       return `url("${(options.usesDtcg ? token.$value : token.value).replace(/"/g, `\\"`)}")`;
     },
   },
@@ -1048,7 +1048,7 @@ export default {
   'asset/base64': {
     type: 'value',
     filter: isAsset,
-    transformer: function (token, _, options, vol) {
+    transform: function (token, _, options, vol) {
       return convertToBase64(options.usesDtcg ? token.$value : token.value, vol);
     },
   },
@@ -1067,7 +1067,7 @@ export default {
   'asset/path': {
     type: 'value',
     filter: isAsset,
-    transformer: function (token, _, options) {
+    transform: function (token, _, options) {
       return join(process?.cwd() ?? '/', options.usesDtcg ? token.$value : token.value);
     },
   },
@@ -1085,7 +1085,7 @@ export default {
   'asset/objC/literal': {
     type: 'value',
     filter: isAsset,
-    transformer: function (token, _, options) {
+    transform: function (token, _, options) {
       return '@' + wrapValueWithDoubleQuote(token, options);
     },
   },
@@ -1103,7 +1103,7 @@ export default {
   'asset/swift/literal': {
     type: 'value',
     filter: isAsset,
-    transformer: (token, _, options) => wrapValueWithDoubleQuote(token, options),
+    transform: (token, _, options) => wrapValueWithDoubleQuote(token, options),
   },
 
   /**
@@ -1119,7 +1119,7 @@ export default {
   'color/hex8flutter': {
     type: 'value',
     filter: isColor,
-    transformer: function (token, _, options) {
+    transform: function (token, _, options) {
       const str = Color(options.usesDtcg ? token.$value : token.value)
         .toHex8()
         .toUpperCase();
@@ -1140,7 +1140,7 @@ export default {
   'content/flutter/literal': {
     type: 'value',
     filter: (token) => isContent(token),
-    transformer: (token, _, options) => wrapValueWithDoubleQuote(token, options),
+    transform: (token, _, options) => wrapValueWithDoubleQuote(token, options),
   },
 
   /**
@@ -1156,7 +1156,7 @@ export default {
   'asset/flutter/literal': {
     type: 'value',
     filter: isAsset,
-    transformer: (token, _, options) => wrapValueWithDoubleQuote(token, options),
+    transform: (token, _, options) => wrapValueWithDoubleQuote(token, options),
   },
 
   /**
@@ -1172,7 +1172,7 @@ export default {
   'size/flutter/remToDouble': {
     type: 'value',
     filter: (token) => isDimension(token) || isFontSize(token),
-    transformer: function (token, config, options) {
+    transform: function (token, config, options) {
       const baseFont = getBasePxFontSize(config);
       return (parseFloat(options.usesDtcg ? token.$value : token.value) * baseFont).toFixed(2);
     },

--- a/lib/transform/config.js
+++ b/lib/transform/config.js
@@ -69,10 +69,10 @@ Unknown transformGroup "${to_ret.transformGroup}" found in platform "${platformN
   // the StyleDictionary module. We need to map the strings to
   // the actual functions.
   to_ret.transforms = transforms.map(function (name) {
-    if (!dictionary.transform[name]) {
+    if (!dictionary.hooks.transforms?.[name]) {
       GroupMessages.add(MISSING_TRANSFORM_ERRORS, `"${name}"`);
     }
-    return dictionary.transform[name];
+    return dictionary.hooks.transforms[name];
   });
 
   let missingTransformCount = GroupMessages.count(MISSING_TRANSFORM_ERRORS);

--- a/lib/transform/token.js
+++ b/lib/transform/token.js
@@ -42,7 +42,7 @@ export default async function transformToken(token, config, options, vol) {
 
     if (!transform.filter || transform.filter(to_ret)) {
       if (transform.type === 'name') {
-        to_ret.name = await /** @type {Omit<NameTransform, "name">} */ (transform).transformer(
+        to_ret.name = await /** @type {Omit<NameTransform, "name">} */ (transform).transform(
           to_ret,
           config,
           options,
@@ -64,7 +64,7 @@ export default async function transformToken(token, config, options, vol) {
           ) ||
           transform.transitive
         ) {
-          const transformedValue = await transform.transformer(to_ret, config, options, vol);
+          const transformedValue = await transform.transform(to_ret, config, options, vol);
           if (transformedValue === undefined) {
             return undefined;
           }
@@ -76,7 +76,7 @@ export default async function transformToken(token, config, options, vol) {
         to_ret.attributes = Object.assign(
           {},
           to_ret.attributes,
-          await transform.transformer(to_ret, config, options, vol),
+          await transform.transform(to_ret, config, options, vol),
         );
     }
   }

--- a/types/Config.d.ts
+++ b/types/Config.d.ts
@@ -24,6 +24,7 @@ export interface Hooks {
   parsers?: Record<string, Omit<Parser, 'name'>>;
   preprocessors?: Record<string, Preprocessor['preprocessor']>;
   transformGroups?: Record<string, string[]>;
+  transforms?: Record<string, Omit<Transform, 'name'>>;
   fileHeaders?: Record<string, FileHeader>;
   filters?: Record<string, Filter['filter']>;
   actions?: Record<string, Omit<Action, 'name'>>;
@@ -106,7 +107,6 @@ export interface Config {
   platforms?: Record<string, PlatformConfig>;
   parsers?: Parser[];
   preprocessors?: string[];
-  transform?: Record<string, Transform>;
   format?: Record<string, Formatter>;
   usesDtcg?: boolean;
 }

--- a/types/Transform.d.ts
+++ b/types/Transform.d.ts
@@ -21,7 +21,7 @@ interface BaseTransform<Type, Value> {
   type: Type;
   filter?: Filter['filter'];
   transitive?: boolean;
-  transformer: (
+  transform: (
     token: TransformedToken,
     config: PlatformConfig,
     options: Config,


### PR DESCRIPTION
Issue #, if available:
https://github.com/amzn/style-dictionary/issues/1049

Description of changes:
Similar to preprocessors, move it under the hooks prop, its transformer function has been renamed to transform

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
