### PR TITLE
feat: allow not throwing on broken refs

### DIFF
--- a/.changeset/chilly-numbers-work.md
+++ b/.changeset/chilly-numbers-work.md
@@ -1,0 +1,21 @@
+---
+'style-dictionary': minor
+---
+
+Allow not throwing fatal errors on broken token references/aliases, but `console.error` instead.
+`resolveReferences` and `getReferences` both allow passing `throwOnBrokenReferences` option, setting this to false will prevent a fatal error.
+You can also configure this on global/platform `log` property:
+
+```json
+{
+  "log": {
+    "errors": {
+      "brokenReferences": "console"
+    }
+  }
+}
+```
+
+This setting defaults to `"error"` when not configured.
+
+Some minor grammatical improvements to some of the error logs were also done.

--- a/.changeset/chilly-numbers-work.md
+++ b/.changeset/chilly-numbers-work.md
@@ -3,7 +3,7 @@
 ---
 
 Allow not throwing fatal errors on broken token references/aliases, but `console.error` instead.
-`resolveReferences` and `getReferences` both allow passing `throwOnBrokenReferences` option, setting this to false will prevent a fatal error.
+
 You can also configure this on global/platform `log` property:
 
 ```json
@@ -17,5 +17,7 @@ You can also configure this on global/platform `log` property:
 ```
 
 This setting defaults to `"error"` when not configured.
+
+`resolveReferences` and `getReferences` `warnImmediately` option is set to `true` which causes an error to be thrown/warned immediately by default, which can be configured to `false` if you know those utils are running in the transform/format hooks respectively, where the errors are collected and grouped, then thrown as 1 error/warning instead of multiple.
 
 Some minor grammatical improvements to some of the error logs were also done.

--- a/__integration__/__snapshots__/customFormats.test.snap.js
+++ b/__integration__/__snapshots__/customFormats.test.snap.js
@@ -557,7 +557,10 @@ snapshots["integration custom formats inline custom with new args should match s
     ],
     "log": {
       "warnings": "warn",
-      "verbosity": "default"
+      "verbosity": "default",
+      "errors": {
+        "brokenReferences": "throw"
+      }
     },
     "transforms": [
       {
@@ -945,7 +948,10 @@ snapshots["integration custom formats inline custom with new args should match s
     },
     "log": {
       "warnings": "warn",
-      "verbosity": "default"
+      "verbosity": "default",
+      "errors": {
+        "brokenReferences": "throw"
+      }
     },
     "usesDtcg": false,
     "otherOption": "Test",
@@ -1503,7 +1509,10 @@ snapshots["integration custom formats register custom format with new args shoul
     ],
     "log": {
       "warnings": "warn",
-      "verbosity": "default"
+      "verbosity": "default",
+      "errors": {
+        "brokenReferences": "throw"
+      }
     },
     "transforms": [
       {
@@ -1891,7 +1900,10 @@ snapshots["integration custom formats register custom format with new args shoul
     },
     "log": {
       "warnings": "warn",
-      "verbosity": "default"
+      "verbosity": "default",
+      "errors": {
+        "brokenReferences": "throw"
+      }
     },
     "usesDtcg": false,
     "otherOption": "Test",

--- a/__integration__/logging/__snapshots__/file.test.snap.js
+++ b/__integration__/logging/__snapshots__/file.test.snap.js
@@ -439,3 +439,9 @@ color.core.blue.0
 This is caused when combining a filter and \`outputReferences\`.`;
 /* end snapshot integration logging file filtered references should throw detailed error of filtered references through "verbose" verbosity and log level set to error */
 
+snapshots["integration logging file empty tokens should not warn user about empty tokens with silent log verbosity"] = 
+`
+css
+No tokens for empty.css. File not created.`;
+/* end snapshot integration logging file empty tokens should not warn user about empty tokens with silent log verbosity */
+

--- a/__tests__/StyleDictionary.test.js
+++ b/__tests__/StyleDictionary.test.js
@@ -393,6 +393,29 @@ Use log.verbosity "verbose" or use CLI option --verbose for more details.
 `);
     });
 
+    it('should allow silencing broken references errors with log.verbosity set to silent and log.errors.brokenReferences set to console', async () => {
+      const stub = stubMethod(console, 'error');
+      const sd = new StyleDictionary({
+        log: {
+          verbosity: 'silent',
+          errors: {
+            brokenReferences: 'console',
+          },
+        },
+        tokens: {
+          foo: {
+            value: '{bar}',
+            type: 'other',
+          },
+        },
+        platforms: {
+          css: {},
+        },
+      });
+      await sd.exportPlatform('css');
+      expect(stub.callCount).to.equal(0);
+    });
+
     it('should resolve correct references when the tokenset contains broken references and log.errors.brokenReferences is set to console', async () => {
       const stub = stubMethod(console, 'error');
       const sd = new StyleDictionary({

--- a/__tests__/StyleDictionary.test.js
+++ b/__tests__/StyleDictionary.test.js
@@ -19,6 +19,7 @@ import { resolve } from '../lib/resolve.js';
 import GroupMessages from '../lib/utils/groupMessages.js';
 import flattenTokens from '../lib/utils/flattenTokens.js';
 import formats from '../lib/common/formats.js';
+import { restore, stubMethod } from 'hanbi';
 
 function traverseObj(obj, fn) {
   for (let key in obj) {
@@ -52,6 +53,7 @@ const test_props = {
 // extend method is called by StyleDictionary constructor, therefore we're basically testing both things here
 describe('StyleDictionary class', () => {
   beforeEach(() => {
+    restore();
     clearOutput();
   });
 
@@ -341,6 +343,54 @@ describe('StyleDictionary class', () => {
         { init: false },
       );
       await expect(sd.init()).to.eventually.be.fulfilled;
+    });
+  });
+
+  describe('reference errors', () => {
+    it('should throw an error by default if broken references are encountered', async () => {
+      const sd = new StyleDictionary({
+        tokens: {
+          foo: {
+            value: '{bar}',
+            type: 'other',
+          },
+        },
+        platforms: {
+          css: {},
+        },
+      });
+
+      await expect(sd.exportPlatform('css')).to.eventually.be.rejectedWith(`
+Reference Errors:
+Some token references (1) could not be found.
+Use log.verbosity "verbose" or use CLI option --verbose for more details.
+`);
+    });
+
+    it('should only log an error if broken references are encountered and log.errors.brokenReferences is set to console-', async () => {
+      const stub = stubMethod(console, 'error');
+      const sd = new StyleDictionary({
+        log: {
+          errors: {
+            brokenReferences: 'console',
+          },
+        },
+        tokens: {
+          foo: {
+            value: '{bar}',
+            type: 'other',
+          },
+        },
+        platforms: {
+          css: {},
+        },
+      });
+      await sd.exportPlatform('css');
+      expect(stub.firstCall.args[0]).to.equal(`
+Reference Errors:
+Some token references (1) could not be found.
+Use log.verbosity "verbose" or use CLI option --verbose for more details.
+`);
     });
   });
 

--- a/__tests__/__helpers.js
+++ b/__tests__/__helpers.js
@@ -14,6 +14,7 @@
 import { expect } from 'chai';
 import { fs } from 'style-dictionary/fs';
 import { resolve } from '../lib/resolve.js';
+import isPlainObject from 'is-plain-obj';
 
 export const cleanConsoleOutput = (str) => {
   const arr = str
@@ -79,4 +80,24 @@ export function fixDate() {
   __global.Date.now = function () {
     return constantDate;
   };
+}
+
+export function clearSDMeta(tokens) {
+  const copy = structuredClone(tokens);
+  function recurse(slice) {
+    if (isPlainObject(slice)) {
+      if (Object.hasOwn(slice, 'value')) {
+        delete slice.path;
+        delete slice.original;
+        delete slice.name;
+        delete slice.attributes;
+      } else {
+        Object.values(slice).forEach((prop) => {
+          recurse(prop);
+        });
+      }
+    }
+  }
+  recurse(copy);
+  return copy;
 }

--- a/__tests__/__helpers.js
+++ b/__tests__/__helpers.js
@@ -87,10 +87,9 @@ export function clearSDMeta(tokens) {
   function recurse(slice) {
     if (isPlainObject(slice)) {
       if (Object.hasOwn(slice, 'value')) {
-        delete slice.path;
-        delete slice.original;
-        delete slice.name;
-        delete slice.attributes;
+        ['path', 'original', 'name', 'attributes', 'filePath', 'isSource'].forEach((prop) => {
+          delete slice[prop];
+        });
       } else {
         Object.values(slice).forEach((prop) => {
           recurse(prop);

--- a/__tests__/transform/tokenSetup.test.js
+++ b/__tests__/transform/tokenSetup.test.js
@@ -16,15 +16,17 @@ import tokenSetup from '../../lib/transform/tokenSetup.js';
 describe('transform', () => {
   describe('tokenSetup', () => {
     it('should error if property is not an object', () => {
-      expect(tokenSetup.bind(null, null, 'foo', [])).to.throw('Property object must be an object');
+      expect(tokenSetup.bind(null, null, 'foo', [])).to.throw(
+        'Token object must be of type "object"',
+      );
     });
 
     it('should error if name in not a string', () => {
-      expect(tokenSetup.bind(null, {}, null, [])).to.throw('Name must be a string');
+      expect(tokenSetup.bind(null, {}, null, [])).to.throw('Token name must be a string');
     });
 
     it('should error path is not an array', () => {
-      expect(tokenSetup.bind(null, {}, 'name', null)).to.throw('Path must be an array');
+      expect(tokenSetup.bind(null, {}, 'name', null)).to.throw('Token path must be an array');
     });
 
     it('should work if all the args are proper', () => {

--- a/__tests__/utils/reference/getReferences.test.js
+++ b/__tests__/utils/reference/getReferences.test.js
@@ -61,12 +61,9 @@ describe('utils', () => {
           );
         });
 
-        it('should not collect errors but rather throw immediately when using public API', () => {
-          const stub = stubMethod(console, 'error');
-          getReferences('{foo.bar}', tokens, { throwOnBrokenReferences: false });
-          expect(stub.firstCall.args[0]).to.equal(
-            `Tries to reference foo.bar, which is not defined.`,
-          );
+        it('should not collect errors but rather throw immediately when using public API', async () => {
+          const badFn = () => getReferences('{foo.bar}', tokens);
+          expect(badFn).to.throw(`Tries to reference foo.bar, which is not defined.`);
         });
 
         it('should allow warning immediately when references are filtered out', async () => {

--- a/__tests__/utils/reference/resolveReferences.test.js
+++ b/__tests__/utils/reference/resolveReferences.test.js
@@ -11,7 +11,7 @@
  * and limitations under the License.
  */
 import { expect } from 'chai';
-import { restore, stubMethod } from 'hanbi';
+import { restore } from 'hanbi';
 import { fileToJSON } from '../../__helpers.js';
 import {
   _resolveReferences as resolveReferences,
@@ -41,23 +41,6 @@ describe('utils', () => {
           expect(() => publicResolveReferences(obj.a.d, obj)).to.throw(
             `tries to reference d, which is not defined.`,
           );
-        });
-
-        it('should only console.error if throwOnBrokenReferences is disabled', async () => {
-          const stub = stubMethod(console, 'error');
-          publicResolveReferences('{foo.bar}', {}, { throwOnBrokenReferences: false });
-          expect(stub.firstCall.args[0]).to.equal(
-            `tries to reference foo.bar, which is not defined.`,
-          );
-        });
-
-        it('should gracefully handle basic circular references if throwOnBrokenReferences is disabled', () => {
-          const stub = stubMethod(console, 'error');
-          const obj = fileToJSON('__tests__/__json_files/circular.json');
-          expect(publicResolveReferences(obj.a, obj, { throwOnBrokenReferences: false })).to.equal(
-            '{b}',
-          );
-          expect(stub.firstCall.args[0]).to.equal('Circular definition cycle: b, c, d, a, b');
         });
       });
 

--- a/docs/src/content/docs/reference/Utils/references.md
+++ b/docs/src/content/docs/reference/Utils/references.md
@@ -56,7 +56,6 @@ resolveReferences('solid {spacing.2} {colors.black}', sd.tokens, { usesDtcg: tru
 You can pass a third `options` argument where you can pass some configuration options for how references are resolved:
 
 - `usesDtcg` boolean, if set to true, the `resolveReferences` utility will assume DTCG syntax (`$value` props)
-- `throwOnBrokenReferences` boolean, if set to true, it will `console.error` for reference errors instead of fatally throw
 - `warnImmediately` boolean, `true` by default. You should only set this to `false` if you know that this utility is used used inside of the Transform lifecycle hook of Style Dictionary, allowing the errors to be grouped and only thrown at the end of the transform step (end of [exportPlatform](/reference/api#exportplatform) method).
 
 ## getReferences
@@ -101,7 +100,6 @@ getReferences('solid {spacing.2} {colors.black}', sd.tokens, { usesDtcg: true })
 You can pass a third `options` argument where you can pass some configuration options for how references are resolved:
 
 - `usesDtcg` boolean, if set to true, the `resolveReferences` utility will assume DTCG syntax (`$value` props)
-- `throwOnBrokenReferences` boolean, if set to true, it will `console.error` for reference errors instead of fatally throw
 - `unfilteredTokens`, assuming the second `tokens` argument is your filtered `tokens` object where [filters](/reference/hooks/filters) have already done its work, you'll likely want to pass the unfiltered set in case the reference you're trying to find no longer exist in the filtered set, but you still want to get the reference values. This is useful when you're writing your own custom format with an `outputReferences` feature and you want to prevent outputting refs that no longer exist in the filtered set.
 - `warnImmediately` boolean, `true` by default. You should only set this to `false` if you know that this utility is used inside of the Format lifecycle hook of Style Dictionary, allowing the errors to be grouped and only thrown at the end of the format step.
 

--- a/docs/src/content/docs/reference/Utils/references.md
+++ b/docs/src/content/docs/reference/Utils/references.md
@@ -53,10 +53,11 @@ resolveReferences('solid {spacing.2} {colors.black}', sd.tokens); // alternative
 resolveReferences('solid {spacing.2} {colors.black}', sd.tokens, { usesDtcg: true }); // Assumes DTCG spec format, with $ prefix ($value, $type)
 ```
 
-:::note
-You can pass a third `options` argument where you can pass some configuration options for how references are resolved
-Most notable option for public usage is `usesDtcg`, if set to true, the `resolveReferences` utility will assume DTCG syntax (`$value` props).
-:::
+You can pass a third `options` argument where you can pass some configuration options for how references are resolved:
+
+- `usesDtcg` boolean, if set to true, the `resolveReferences` utility will assume DTCG syntax (`$value` props)
+- `throwOnBrokenReferences` boolean, if set to true, it will `console.error` for reference errors instead of fatally throw
+- `warnImmediately` boolean, `true` by default. You should only set this to `false` if you know that this utility is used used inside of the Transform lifecycle hook of Style Dictionary, allowing the errors to be grouped and only thrown at the end of the transform step (end of [exportPlatform](/reference/api#exportplatform) method).
 
 ## getReferences
 
@@ -97,10 +98,12 @@ getReferences('solid {spacing.2} {colors.black}', sd.tokens, { usesDtcg: true })
  */
 ```
 
-:::note
-You can pass a third `options` argument where you can pass some configuration options for how references are resolved
-Most notable option for public usage is `usesDtcg`, if set to true, the `resolveReferences` utility will assume DTCG syntax (`$value` props)
-:::
+You can pass a third `options` argument where you can pass some configuration options for how references are resolved:
+
+- `usesDtcg` boolean, if set to true, the `resolveReferences` utility will assume DTCG syntax (`$value` props)
+- `throwOnBrokenReferences` boolean, if set to true, it will `console.error` for reference errors instead of fatally throw
+- `unfilteredTokens`, assuming the second `tokens` argument is your filtered `tokens` object where [filters](/reference/hooks/filters) have already done its work, you'll likely want to pass the unfiltered set in case the reference you're trying to find no longer exist in the filtered set, but you still want to get the reference values. This is useful when you're writing your own custom format with an `outputReferences` feature and you want to prevent outputting refs that no longer exist in the filtered set.
+- `warnImmediately` boolean, `true` by default. You should only set this to `false` if you know that this utility is used inside of the Format lifecycle hook of Style Dictionary, allowing the errors to be grouped and only thrown at the end of the format step.
 
 ### Complicated example
 

--- a/docs/src/content/docs/reference/logging.md
+++ b/docs/src/content/docs/reference/logging.md
@@ -12,17 +12,22 @@ const sd = new StyleDictionary({
   log: {
     warnings: 'warn', // 'warn' | 'error' | 'disabled'
     verbosity: 'default', // 'default' | 'silent' | 'verbose'
+    errors: {
+      brokenReferences: 'throw', // 'throw' | 'console'
+    },
   },
 });
 ```
 
 > `log` can also be set on platform specific configuration
 
-| Param           | Type                                | Description                                                                                                                                                          |
-| --------------- | ----------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `log`           | `Object`                            |                                                                                                                                                                      |
-| `log.warnings`  | `'warn' \| 'error' \| 'disabled'`   | Whether warnings should be logged as warnings, thrown as errors or disabled entirely. Defaults to 'warn'                                                             |
-| `log.verbosity` | `'default' \|'silent' \| 'verbose'` | How verbose logs should be, default value is 'default'. 'silent' means no logs at all apart from fatal errors. 'verbose' means detailed error messages for debugging |
+| Param                         | Type                                | Description                                                                                                                                                          |
+| ----------------------------- | ----------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `log`                         | `Object`                            |                                                                                                                                                                      |
+| `log.warnings`                | `'warn' \| 'error' \| 'disabled'`   | Whether warnings should be logged as warnings, thrown as errors or disabled entirely. Defaults to 'warn'                                                             |
+| `log.verbosity`               | `'default' \|'silent' \| 'verbose'` | How verbose logs should be, default value is 'default'. 'silent' means no logs at all apart from fatal errors. 'verbose' means detailed error messages for debugging |
+| `log.errors`                  | `Object`                            | How verbose logs should be, default value is 'default'. 'silent' means no logs at all apart from fatal errors. 'verbose' means detailed error messages for debugging |
+| `log.errors.brokenReferences` | `'throw' \| 'console'`              | Whether broken references in tokens should throw a fatal error or only a `console.error` without exiting the process.                                                |
 
 There are five types of warnings that will be thrown as errors instead of being logged as warnings when `log.warnings` is set to `error`:
 

--- a/docs/starlight-config.ts
+++ b/docs/starlight-config.ts
@@ -18,11 +18,11 @@ export default {
     'Export your Design Tokens to any platform. iOS, Android, CSS, JS, HTML, sketch files, style documentation, or anything you can think of. Forward-compatible with Design Token Community Group spec.',
   logo: { src: './src/assets/logo.png', alt: 'Style-Dictionary logo, Pascal the chameleon.' },
   editLink: {
-    baseUrl: 'https://github.com/amzn/style-dictionary/edit/v4/src/content/docs/',
+    baseUrl: 'https://github.com/amzn/style-dictionary/edit/v4/docs/src/content/docs/',
   },
   favicon: '/favicon.png',
   social: {
-    github: 'https://github.com/amzn/style-dictionary',
+    github: 'https://github.com/amzn/style-dictionary/tree/v4',
     slack:
       'https://join.slack.com/t/tokens-studio/shared_invite/zt-1p8ea3m6t-C163oJcN9g3~YZTKRgo2hg',
   },

--- a/lib/StyleDictionary.js
+++ b/lib/StyleDictionary.js
@@ -59,6 +59,7 @@ import cleanActions from './cleanActions.js';
 const PROPERTY_VALUE_COLLISIONS = GroupMessages.GROUP.PropertyValueCollisions;
 const PROPERTY_REFERENCE_WARNINGS = GroupMessages.GROUP.PropertyReferenceWarnings;
 const UNKNOWN_CSS_FONT_PROPS_WARNINGS = GroupMessages.GROUP.UnknownCSSFontProperties;
+const FILTER_WARNINGS = GroupMessages.GROUP.FilteredOutputReferences;
 
 /**
  * Style Dictionary module
@@ -118,6 +119,9 @@ export default class StyleDictionary extends Register {
     this.log = {
       warnings: 'warn',
       verbosity: 'default',
+      errors: {
+        brokenReferences: 'throw',
+      },
     };
     /** @type {string[]} */
     this.source = [];
@@ -503,7 +507,11 @@ export default class StyleDictionary extends Register {
         err += `${verbosityInfo}\n`;
       }
 
-      throw new Error(err);
+      if (this.log.errors?.brokenReferences === 'throw') {
+        throw new Error(err);
+      } else {
+        console.error(err);
+      }
     }
 
     const unknownPropsWarningCount = GroupMessages.count(UNKNOWN_CSS_FONT_PROPS_WARNINGS);
@@ -669,9 +677,7 @@ export default class StyleDictionary extends Register {
       }),
     );
 
-    const filteredReferencesCount = GroupMessages.count(
-      GroupMessages.GROUP.FilteredOutputReferences,
-    );
+    const filteredReferencesCount = GroupMessages.count(FILTER_WARNINGS);
 
     // don't show name collision warnings for nested type formats
     // because they are not relevant.
@@ -716,9 +722,7 @@ export default class StyleDictionary extends Register {
       }
 
       if (filteredReferencesCount > 0) {
-        const filteredReferencesWarnings = GroupMessages.flush(
-          GroupMessages.GROUP.FilteredOutputReferences,
-        ).join('\n    ');
+        const filteredReferencesWarnings = GroupMessages.flush(FILTER_WARNINGS).join('\n    ');
         const title = `While building ${chalk
           .rgb(255, 69, 0)
           .bold(

--- a/lib/StyleDictionary.js
+++ b/lib/StyleDictionary.js
@@ -509,7 +509,7 @@ export default class StyleDictionary extends Register {
 
       if (this.log.errors?.brokenReferences === 'throw') {
         throw new Error(err);
-      } else {
+      } else if (this.log.verbosity !== 'silent') {
         console.error(err);
       }
     }

--- a/lib/cleanFiles.js
+++ b/lib/cleanFiles.js
@@ -38,7 +38,7 @@ export default async function cleanFiles(platform, vol) {
         if (file.format) {
           return cleanFile(file, platform, vol);
         } else {
-          throw new Error('Please supply a template or format');
+          throw new Error('Please supply a format');
         }
       }),
     );

--- a/lib/common/formatHelpers/createPropertyFormatter.js
+++ b/lib/common/formatHelpers/createPropertyFormatter.js
@@ -10,7 +10,7 @@
  * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
  * and limitations under the License.
  */
-import { _getReferences } from '../../utils/references/getReferences.js';
+import { getReferences } from '../../utils/references/getReferences.js';
 import usesReferences from '../../utils/references/usesReferences.js';
 
 /**
@@ -186,7 +186,12 @@ export default function createPropertyFormatter({
     if (shouldOutputRef) {
       // Formats that use this function expect `value` to be a string
       // or else you will get '[object Object]' in the output
-      const refs = _getReferences(originalValue, tokens, { unfilteredTokens }, []);
+      const refs = getReferences(
+        originalValue,
+        tokens,
+        { unfilteredTokens, warnImmediately: false },
+        [],
+      );
 
       // original can either be an object value, which requires transitive value transformation in web CSS formats
       // or a different (primitive) type, meaning it can be stringified.

--- a/lib/common/formatHelpers/sortByReference.js
+++ b/lib/common/formatHelpers/sortByReference.js
@@ -12,7 +12,7 @@
  */
 
 import usesReferences from '../../utils/references/usesReferences.js';
-import { _getReferences } from '../../utils/references/getReferences.js';
+import { getReferences } from '../../utils/references/getReferences.js';
 
 /**
  * @typedef {import('../../../types/DesignToken.d.ts').TransformedTokens} Tokens
@@ -57,11 +57,13 @@ export default function sortByReference(tokens, opts) {
     if (a.original && usesReferences(a.original.value)) {
       // Both a and b have references, we need to see if they reference each other
       if (b.original && usesReferences(b.original.value)) {
-        const aRefs = _getReferences(a.original.value, tokens, {
+        const aRefs = getReferences(a.original.value, tokens, {
           unfilteredTokens: opts?.unfilteredTokens,
+          warnImmediately: false,
         });
-        const bRefs = _getReferences(b.original.value, tokens, {
+        const bRefs = getReferences(b.original.value, tokens, {
           unfilteredTokens: opts?.unfilteredTokens,
+          warnImmediately: false,
         });
 
         aRefs.forEach((aRef) => {

--- a/lib/common/templates/android/resources.template.js
+++ b/lib/common/templates/android/resources.template.js
@@ -71,7 +71,10 @@ export default (opts) => {
     let originalValue = options.usesDtcg ? token.original.$value : token.original.value;
     if (file?.options && file.options.outputReferences && usesReferences(originalValue)) {
       return `@${tokenToType(token, options)}/${
-        getReferences(originalValue, tokens, { usesDtcg: options.usesDtcg })[0].name
+        getReferences(originalValue, tokens, {
+          usesDtcg: options.usesDtcg,
+          warnImmediately: false,
+        })[0].name
       }`;
     } else {
       return options.usesDtcg ? token.$value : token.value;

--- a/lib/transform/tokenSetup.js
+++ b/lib/transform/tokenSetup.js
@@ -30,9 +30,9 @@ import isPlainObject from 'is-plain-obj';
  * @returns {TransformedToken} - A new object that is setup and ready to go.
  */
 export default function tokenSetup(token, name, path) {
-  if (!token && !isPlainObject(token)) throw new Error('Property object must be an object');
-  if (!name || !(typeof name === 'string')) throw new Error('Name must be a string');
-  if (!path || !Array.isArray(path)) throw new Error('Path must be an array');
+  if (!token && !isPlainObject(token)) throw new Error('Token object must be of type "object"');
+  if (!name || !(typeof name === 'string')) throw new Error('Token name must be a string');
+  if (!path || !Array.isArray(path)) throw new Error('Token path must be an array');
 
   let to_ret = token;
 

--- a/lib/utils/convertToBase64.js
+++ b/lib/utils/convertToBase64.js
@@ -23,7 +23,7 @@ import { resolve } from '../resolve.js';
  * @returns {String}
  */
 export default function convertToBase64(filePath, vol = fs) {
-  if (typeof filePath !== 'string') throw new Error('filePath name must be a string');
+  if (typeof filePath !== 'string') throw new Error('Token filePath name must be a string');
 
   const body = /** @type {string} */ (
     vol.readFileSync(resolve(filePath, vol.__custom_fs__), 'utf-8')

--- a/lib/utils/references/getName.js
+++ b/lib/utils/references/getName.js
@@ -26,7 +26,7 @@ import defaults from './defaults.js';
 export default function getName(path, opts = {}) {
   const options = { ...defaults, ...opts };
   if (!Array.isArray(path)) {
-    throw new Error('Getting name for path failed. Path must be an array');
+    throw new Error('Getting name for path failed. Token path must be an array of strings');
   }
   return path.join(options.separator);
 }

--- a/lib/utils/references/getPathFromName.js
+++ b/lib/utils/references/getPathFromName.js
@@ -23,7 +23,7 @@ import defaults from './defaults.js';
 export default function getPathFromName(pathName, separator) {
   const sep = separator ?? defaults.separator;
   if (typeof pathName !== 'string') {
-    throw new Error('Getting path from name failed. Name must be a string');
+    throw new Error('Getting path from name failed. Token name must be a string');
   }
   return pathName.split(sep);
 }

--- a/lib/utils/references/getReferences.js
+++ b/lib/utils/references/getReferences.js
@@ -42,13 +42,7 @@ const FILTER_WARNINGS = GroupMessages.GROUP.FilteredOutputReferences;
  * @returns {Token[]}
  */
 export function getReferences(value, tokens, opts = {}, references = []) {
-  const {
-    usesDtcg,
-    separator,
-    throwOnBrokenReferences = true,
-    warnImmediately = true,
-    unfilteredTokens,
-  } = opts;
+  const { usesDtcg, separator, warnImmediately = true, unfilteredTokens } = opts;
   const regex = createReferenceRegex(opts);
 
   /**
@@ -87,10 +81,8 @@ export function getReferences(value, tokens, opts = {}, references = []) {
       }
     } else {
       const errMessage = `Tries to reference ${variable}, which is not defined.`;
-      if (throwOnBrokenReferences) {
+      if (warnImmediately) {
         throw new Error(errMessage);
-      } else {
-        console.error(errMessage);
       }
     }
     return '';

--- a/lib/utils/references/getReferences.js
+++ b/lib/utils/references/getReferences.js
@@ -23,19 +23,7 @@ const FILTER_WARNINGS = GroupMessages.GROUP.FilteredOutputReferences;
  * @typedef {import('../../StyleDictionary.js').default} Dictionary
  * @typedef {import('../../../types/DesignToken.d.ts').TransformedTokens} Tokens
  * @typedef {import('../../../types/DesignToken.d.ts').TransformedToken} Token
- *
- * Public API wrapper around the function below this one
- *
- * @memberof Dictionary
- * @param {string|Object<string, string|any>} value the value that contains a reference
- * @param {Tokens} tokens the dictionary to search in
- * @param {GetReferencesOptions} [opts]
- * @param {Token[]} [references] array of token's references because a token's value can contain multiple references due to string interpolation
- * @returns {Token[]}
  */
-export function getReferences(value, tokens, opts = {}, references = []) {
-  return _getReferences(value, tokens, opts, references, true);
-}
 
 /**
  * This is a helper function that is added to the dictionary object that
@@ -49,48 +37,61 @@ export function getReferences(value, tokens, opts = {}, references = []) {
  *
  * @param {string|Object<string, string|any>} value the value that contains a reference
  * @param {Tokens} tokens the dictionary to search in
- * @param {GetReferencesOptions & { unfilteredTokens?: Tokens }} [opts]
+ * @param {GetReferencesOptions} [opts]
  * @param {Token[]} [references] array of token's references because a token's value can contain multiple references due to string interpolation
- * @param {boolean} [throwImmediately]
  * @returns {Token[]}
  */
-export function _getReferences(
-  value,
-  tokens,
-  opts = {},
-  references = [],
-  throwImmediately = false,
-) {
-  const { usesDtcg } = opts;
+export function getReferences(value, tokens, opts = {}, references = []) {
+  const {
+    usesDtcg,
+    separator,
+    throwOnBrokenReferences = true,
+    warnImmediately = true,
+    unfilteredTokens,
+  } = opts;
   const regex = createReferenceRegex(opts);
 
   /**
    * this will update the references array with the referenced tokens it finds.
-   * @param {string} match
+   * @param {string} _
    * @param {string} variable
    */
-  function findReference(match, variable) {
+  function findReference(_, variable) {
     // remove 'value' to access the whole token object
     variable = variable.trim().replace(`.${usesDtcg ? '$' : ''}value`, '');
 
     // Find what the value is referencing
-    const pathName = getPathFromName(variable, opts.separator ?? defaults.separator);
+    const pathName = getPathFromName(variable, separator ?? defaults.separator);
 
     let ref = getValueByPath(pathName, tokens);
 
-    if (ref === undefined && opts.unfilteredTokens) {
-      if (!throwImmediately) {
-        // warn the user about this
+    let unfilteredWarning;
+    if (ref === undefined && unfilteredTokens) {
+      // warn the user about this
+      if (warnImmediately) {
+        unfilteredWarning = `Filtered out token references were found: ${variable}`;
+      } else {
+        // we collect the warning and warn later in the process
         GroupMessages.add(FILTER_WARNINGS, variable);
       }
       // fall back on unfilteredTokens as it is unfiltered
-      ref = getValueByPath(pathName, opts.unfilteredTokens);
+      ref = getValueByPath(pathName, unfilteredTokens);
     }
 
     if (ref !== undefined) {
       references.push({ ...ref, ref: pathName });
-    } else if (throwImmediately) {
-      throw new Error(`tries to reference ${variable}, which is not defined.`);
+      // not undefined anymore which means that if unfilteredWarning was set earlier,
+      // the missing ref is due to it being filtered out
+      if (unfilteredWarning) {
+        console.warn(unfilteredWarning);
+      }
+    } else {
+      const errMessage = `Tries to reference ${variable}, which is not defined.`;
+      if (throwOnBrokenReferences) {
+        throw new Error(errMessage);
+      } else {
+        console.error(errMessage);
+      }
     }
     return '';
   }
@@ -112,7 +113,7 @@ export function _getReferences(
         }
         // if it is an object, we go further down the rabbit hole
         if (typeof value[key] === 'object') {
-          _getReferences(value[key], tokens, opts, references);
+          getReferences(value[key], tokens, opts, references);
         }
       }
     }

--- a/lib/utils/references/outputReferencesFilter.js
+++ b/lib/utils/references/outputReferencesFilter.js
@@ -17,6 +17,7 @@ export function outputReferencesFilter(token, { dictionary, usesDtcg }) {
   const refs = getReferences(originalValue, dictionary.tokens, {
     unfilteredTokens: dictionary.unfilteredTokens,
     usesDtcg,
+    warnImmediately: false,
   });
   return refs.every((ref) => {
     // check whether every ref can be found in the filtered set of tokens

--- a/lib/utils/references/outputReferencesTransformed.js
+++ b/lib/utils/references/outputReferencesTransformed.js
@@ -22,6 +22,7 @@ export function outputReferencesTransformed(token, { dictionary, usesDtcg }) {
       value ===
       resolveReferences(originalValue, dictionary.unfilteredTokens ?? dictionary.tokens, {
         usesDtcg,
+        warnImmediately: false,
       })
     );
   }

--- a/lib/utils/references/resolveReferences.js
+++ b/lib/utils/references/resolveReferences.js
@@ -36,7 +36,9 @@ const PROPERTY_REFERENCE_WARNINGS = GroupMessages.GROUP.PropertyReferenceWarning
  * @returns {string|number|undefined}
  */
 export function resolveReferences(value, tokens, opts) {
-  return _resolveReferences(value, tokens, { ...opts, throwImmediately: true });
+  // when using this public API / util, we always throw warnings immediately rather than
+  // putting them in the GroupMessages PROPERTY_REFERENCE_WARNINGS to collect and throw later on.
+  return _resolveReferences(value, tokens, opts);
 }
 
 /**
@@ -54,14 +56,15 @@ export function _resolveReferences(
     separator = defaults.separator,
     opening_character = defaults.opening_character,
     closing_character = defaults.closing_character,
-    ignorePaths = [],
     usesDtcg = false,
+    throwOnBrokenReferences = true,
+    warnImmediately = true,
     // for internal usage
+    ignorePaths = [],
     current_context = [],
     stack = [],
     foundCirc = {},
     firstIteration = true,
-    throwImmediately = false,
   } = {},
 ) {
   const reg = regex ?? createReferenceRegex({ opening_character, closing_character, separator });
@@ -90,8 +93,6 @@ export function _resolveReferences(
     const pathName = getPathFromName(variable, separator);
 
     const refHasValue = valProp === pathName[pathName.length - 1];
-
-    // FIXME: shouldn't these two "refHasValue" conditions be reversed??
     if (refHasValue && ignorePaths.indexOf(variable) !== -1) {
       return '';
     } else if (!refHasValue && ignorePaths.indexOf(`${variable}.${valProp}`) !== -1) {
@@ -142,8 +143,12 @@ export function _resolveReferences(
 
             // Add circ reference info to our list of warning messages
             const warning = `Circular definition cycle: ${circStack.join(', ')}`;
-            if (throwImmediately) {
-              throw new Error(warning);
+            if (warnImmediately) {
+              if (throwOnBrokenReferences) {
+                throw new Error(warning);
+              } else {
+                console.error(warning);
+              }
             } else {
               GroupMessages.add(
                 PROPERTY_REFERENCE_WARNINGS,
@@ -155,6 +160,8 @@ export function _resolveReferences(
               regex: reg,
               ignorePaths,
               usesDtcg,
+              throwOnBrokenReferences,
+              warnImmediately,
               current_context,
               separator,
               stack,
@@ -178,8 +185,12 @@ export function _resolveReferences(
       const warning = `${
         context ? `${context} ` : ''
       }tries to reference ${variable}, which is not defined.`;
-      if (throwImmediately) {
-        throw new Error(warning);
+      if (warnImmediately) {
+        if (throwOnBrokenReferences) {
+          throw new Error(warning);
+        } else {
+          console.error(warning);
+        }
       } else {
         GroupMessages.add(PROPERTY_REFERENCE_WARNINGS, warning);
       }

--- a/lib/utils/references/resolveReferences.js
+++ b/lib/utils/references/resolveReferences.js
@@ -57,7 +57,6 @@ export function _resolveReferences(
     opening_character = defaults.opening_character,
     closing_character = defaults.closing_character,
     usesDtcg = false,
-    throwOnBrokenReferences = true,
     warnImmediately = true,
     // for internal usage
     ignorePaths = [],
@@ -144,11 +143,7 @@ export function _resolveReferences(
             // Add circ reference info to our list of warning messages
             const warning = `Circular definition cycle: ${circStack.join(', ')}`;
             if (warnImmediately) {
-              if (throwOnBrokenReferences) {
-                throw new Error(warning);
-              } else {
-                console.error(warning);
-              }
+              throw new Error(warning);
             } else {
               GroupMessages.add(
                 PROPERTY_REFERENCE_WARNINGS,
@@ -160,7 +155,6 @@ export function _resolveReferences(
               regex: reg,
               ignorePaths,
               usesDtcg,
-              throwOnBrokenReferences,
               warnImmediately,
               current_context,
               separator,
@@ -186,11 +180,7 @@ export function _resolveReferences(
         context ? `${context} ` : ''
       }tries to reference ${variable}, which is not defined.`;
       if (warnImmediately) {
-        if (throwOnBrokenReferences) {
-          throw new Error(warning);
-        } else {
-          console.error(warning);
-        }
+        throw new Error(warning);
       } else {
         GroupMessages.add(PROPERTY_REFERENCE_WARNINGS, warning);
       }

--- a/lib/utils/resolveObject.js
+++ b/lib/utils/resolveObject.js
@@ -74,6 +74,8 @@ function traverseObj(slice, fullObj, opts, current_context, foundCirc) {
       if (/** @type {string} */ (prop).indexOf('{') > -1) {
         const ref = _resolveReferences(prop, fullObj, {
           ...opts,
+          // we're in transform hook phase, we collect warnings and throw a grouped error later
+          warnImmediately: false,
           current_context,
           foundCirc,
         });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "style-dictionary",
-  "version": "4.0.0-prerelease.32",
+  "version": "4.0.0-prerelease.35",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "style-dictionary",
-      "version": "4.0.0-prerelease.32",
+      "version": "4.0.0-prerelease.35",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/types/Config.d.ts
+++ b/types/Config.d.ts
@@ -49,25 +49,31 @@ export interface RegexOptions {
 
 export interface GetReferencesOptions extends RegexOptions {
   usesDtcg?: boolean;
+  throwOnBrokenReferences?: boolean;
   unfilteredTokens?: DesignTokens;
+  warnImmediately?: boolean;
 }
 
 export interface ResolveReferencesOptions extends RegexOptions {
-  ignorePaths?: string[];
   usesDtcg?: boolean;
+  throwOnBrokenReferences?: boolean;
+  warnImmediately?: boolean;
 }
 
 export interface ResolveReferencesOptionsInternal extends ResolveReferencesOptions {
+  ignorePaths?: string[];
   current_context?: string[];
   stack?: string[];
   foundCirc?: Record<string, boolean>;
   firstIteration?: boolean;
-  throwImmediately?: boolean;
 }
 
 export interface LogConfig {
   warnings?: 'warn' | 'error' | 'disabled';
   verbosity?: 'default' | 'silent' | 'verbose';
+  errors?: {
+    brokenReferences?: 'throw' | 'console';
+  };
 }
 
 export type ExpandFilter = (

--- a/types/Config.d.ts
+++ b/types/Config.d.ts
@@ -49,14 +49,12 @@ export interface RegexOptions {
 
 export interface GetReferencesOptions extends RegexOptions {
   usesDtcg?: boolean;
-  throwOnBrokenReferences?: boolean;
   unfilteredTokens?: DesignTokens;
   warnImmediately?: boolean;
 }
 
 export interface ResolveReferencesOptions extends RegexOptions {
   usesDtcg?: boolean;
-  throwOnBrokenReferences?: boolean;
   warnImmediately?: boolean;
 }
 


### PR DESCRIPTION
Style Dictionary is being used now as a Tokens parser & resolver and not just for building outputs, which means that it makes more sense now to allow not throwing on broken references, which is a token author error rather than a misconfiguration of Style Dictionary.

This change will allow tool makers to use Style Dictionary to for example show a list of tokens with their resolved and original values and highlighting broken references.

TODO: 
- [x] docs
- [x] changeset

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
