### PR TITLE
fix: unclear licensing memfs fork transitive deps, types

### DIFF
--- a/.changeset/wise-brooms-notice.md
+++ b/.changeset/wise-brooms-notice.md
@@ -1,0 +1,5 @@
+---
+'style-dictionary': patch
+---
+
+Upgrade memfs esm fork to publish types and bumping stream to fix unclear licensing issue with transitive dependency.

--- a/docs/src/components/sd-playground.ts
+++ b/docs/src/components/sd-playground.ts
@@ -1,6 +1,5 @@
 import StyleDictionary from 'style-dictionary';
-import memfs from '@bundled-es-modules/memfs';
-import type { fs as VolumeType } from 'memfs';
+import { Volume } from '@bundled-es-modules/memfs';
 import { LitElement, html, css } from 'lit';
 import { posix as path } from 'path-unified';
 import '@shoelace-style/shoelace/dist/components/radio-button/radio-button.js';
@@ -13,8 +12,6 @@ import { analyzeDependencies } from '../utils/analyzeDependencies.ts';
 import { downloadZIP } from '../../../lib/utils/downloadFile.js';
 import type SlRadioGroup from '@shoelace-style/shoelace/dist/components/radio-group/radio-group.js';
 import type { Config } from '../../../types/Config.ts';
-
-const { Volume } = memfs;
 
 const defaults = {
   tokens: {
@@ -175,7 +172,7 @@ class SdPlayground extends LitElement {
   declare outputFiles: string[];
   declare _currentFile: Files;
   declare editor: any;
-  declare volume: typeof VolumeType;
+  declare volume: InstanceType<typeof Volume>;
   declare hasInitialized: Promise<void>;
   declare hasInitializedResolve: (value: void) => void;
 

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -6,8 +6,10 @@ import memfs from '@bundled-es-modules/memfs';
 
 /**
  * Allow to be overridden by setter, set default to memfs for browser env, node:fs for node env
+ * Default CJS export when converted to ESM, messes up the types a bit so we need to
+ * cast the default import to type of Volume by first casting to unknown...
  */
-export let fs = /** @type {Volume} */ (memfs);
+export let fs = /** @type {Volume} */ (/** @type {unknown} */ (memfs));
 
 /**
  * since ES modules exports are read-only, use a setter

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "@bundled-es-modules/deepmerge": "^4.3.1",
         "@bundled-es-modules/glob": "^10.4.2",
-        "@bundled-es-modules/memfs": "^4.8.1",
+        "@bundled-es-modules/memfs": "^4.9.3",
         "@zip.js/zip.js": "^2.7.44",
         "chalk": "^5.3.0",
         "change-case": "^5.3.0",
@@ -60,7 +60,6 @@
         "lint-staged": "^12.3.1",
         "lit": "^3.1.2",
         "mdast": "^3.0.0",
-        "memfs": "^4.6.0",
         "mermaid": "^10.9.1",
         "mocha": "^10.2.0",
         "monaco-editor": "^0.47.0",
@@ -2446,25 +2445,17 @@
       }
     },
     "node_modules/@bundled-es-modules/memfs": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/@bundled-es-modules/memfs/-/memfs-4.8.1.tgz",
-      "integrity": "sha512-9BodQuihWm3XJGKYuV/vXckK8Tkf9EDiT/au1NJeFUyBMe7EMYRtOqL9eLzrjqJSDJUFoGwQFHvraFHwR8cysQ==",
+      "version": "4.9.3",
+      "resolved": "https://registry.npmjs.org/@bundled-es-modules/memfs/-/memfs-4.9.3.tgz",
+      "integrity": "sha512-dWX/xFPJnnl0K3ZCG0xAc6mcwtJBwQzixMxLlZgg6nSM2UpYD11XfM4bEjw1i/suaESh1g8IS9KMFcg85AYf5g==",
       "dependencies": {
         "assert": "^2.0.0",
         "buffer": "^6.0.3",
         "events": "^3.3.0",
-        "memfs": "^4.8.1",
+        "memfs": "^4.9.3",
         "path": "^0.12.7",
-        "stream": "^0.0.2",
+        "stream": "^0.0.3",
         "util": "^0.12.5"
-      }
-    },
-    "node_modules/@bundled-es-modules/memfs/node_modules/stream": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/stream/-/stream-0.0.2.tgz",
-      "integrity": "sha512-gCq3NDI2P35B2n6t76YJuOp7d6cN/C7Rt0577l91wllh0sY9ZBuw9KaSGqH/b0hzn3CWWJbpbW0W0WvQ1H/Q7g==",
-      "dependencies": {
-        "emitter-component": "^1.1.1"
       }
     },
     "node_modules/@changesets/apply-release-plan": {
@@ -10418,14 +10409,6 @@
       "resolved": "https://registry.npmjs.org/elkjs/-/elkjs-0.9.3.tgz",
       "integrity": "sha512-f/ZeWvW/BCXbhGEf1Ujp29EASo/lk1FDnETgNKwJrsVvGZhUWCZyg3xLJjAsxfOmt8KjswHmI5EwCQcPMpOYhQ==",
       "dev": true
-    },
-    "node_modules/emitter-component": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/emitter-component/-/emitter-component-1.1.2.tgz",
-      "integrity": "sha512-QdXO3nXOzZB4pAjM0n6ZE+R9/+kPpECA/XSELIcc54NeYVnBqIk+4DFiBgK+8QbV3mdvTG6nedl7dTYgO+5wDw==",
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/emmet": {
       "version": "2.4.7",

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
   "dependencies": {
     "@bundled-es-modules/deepmerge": "^4.3.1",
     "@bundled-es-modules/glob": "^10.4.2",
-    "@bundled-es-modules/memfs": "^4.8.1",
+    "@bundled-es-modules/memfs": "^4.9.3",
     "@zip.js/zip.js": "^2.7.44",
     "chalk": "^5.3.0",
     "change-case": "^5.3.0",
@@ -147,7 +147,6 @@
     "lint-staged": "^12.3.1",
     "lit": "^3.1.2",
     "mdast": "^3.0.0",
-    "memfs": "^4.6.0",
     "mermaid": "^10.9.1",
     "mocha": "^10.2.0",
     "monaco-editor": "^0.47.0",

--- a/types/Volume.ts
+++ b/types/Volume.ts
@@ -1,3 +1,5 @@
-import type { IFs } from 'memfs';
+import type { Volume as _Volume } from '@bundled-es-modules/memfs';
 
-export type Volume = (IFs | typeof import('node:fs')) & { __custom_fs__?: boolean };
+export type Volume = (InstanceType<typeof _Volume> | typeof import('node:fs')) & {
+  __custom_fs__?: boolean;
+};

--- a/types/typeless-modules/bundled-memfs.d.ts
+++ b/types/typeless-modules/bundled-memfs.d.ts
@@ -1,1 +1,0 @@
-declare module '@bundled-es-modules/memfs';


### PR DESCRIPTION
_Issue #, if available:_
https://github.com/amzn/style-dictionary/issues/1250

_Description of changes:_
- Upgrade memfs ESM fork (fixes unclear licensing issue in transitive dependencies: @bundled-es-modules/memfs -> stream -> emitter-component
- Fix types accordingly, now that the memfs ESM fork publishes the types

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
