### PR TITLE
fix: missing filepath in falsy token values

### DIFF
--- a/.changeset/tender-carrots-accept.md
+++ b/.changeset/tender-carrots-accept.md
@@ -1,0 +1,5 @@
+---
+'style-dictionary': patch
+---
+
+Fix 'filePath' missing from falsy token values

--- a/__tests__/__json_files/not_circular.json
+++ b/__tests__/__json_files/not_circular.json
@@ -1,4 +1,6 @@
 {
+  "prop0" : { "value": 0 },
+  "prop01" : { "value": "" },
   "prop1" : { "value": "test1 value" },
   "prop2" : { "value": "test2 value" },
   "prop3" : { "value": "{prop1.value}" },

--- a/__tests__/utils/combineJSON.test.js
+++ b/__tests__/utils/combineJSON.test.js
@@ -61,6 +61,20 @@ describe('utils', () => {
       expect(tokens).to.have.nested.property('d.e.f.h', 2);
     });
 
+    it('should apply filePath for "falsy" values', async () => {
+      const { tokens } = await combineJSON(['__tests__/__json_files/not_circular.json']);
+      expect(tokens).to.have.deep.property('prop0', {
+        value: 0,
+        filePath: '__tests__/__json_files/not_circular.json',
+        isSource: true,
+      });
+      expect(tokens).to.have.deep.property('prop01', {
+        value: '',
+        filePath: '__tests__/__json_files/not_circular.json',
+        isSource: true,
+      });
+    });
+
     it('should fail on invalid JSON', async () => {
       await expectThrowsAsync(
         () => combineJSON(['__tests__/__json_files/broken/*.json']),

--- a/__tests__/utils/resolveObject.test.js
+++ b/__tests__/utils/resolveObject.test.js
@@ -167,6 +167,8 @@ describe('utils', () => {
       expect(GroupMessages.count(PROPERTY_REFERENCE_WARNINGS)).to.equal(0);
       expect(JSON.stringify(obj)).to.equal(
         JSON.stringify({
+          prop0: { value: 0 },
+          prop01: { value: '' },
           prop1: { value: 'test1 value' },
           prop2: { value: 'test2 value' },
           prop3: { value: 'test1 value' },

--- a/lib/utils/combineJSON.js
+++ b/lib/utils/combineJSON.js
@@ -33,7 +33,7 @@ import { detectDtcgSyntax } from './detectDtcgSyntax.js';
 function traverseObj(obj, fn) {
   for (let key in obj) {
     const prop = obj[key];
-    if (prop !== null && prop !== undefined) {
+    if (prop != null) {
       fn.apply(null, [obj, key, prop]);
       if (typeof prop === 'object') {
         traverseObj(prop, fn);

--- a/lib/utils/combineJSON.js
+++ b/lib/utils/combineJSON.js
@@ -33,7 +33,7 @@ import { detectDtcgSyntax } from './detectDtcgSyntax.js';
 function traverseObj(obj, fn) {
   for (let key in obj) {
     const prop = obj[key];
-    if (prop) {
+    if (prop !== null || prop !== undefined) {
       fn.apply(null, [obj, key, prop]);
       if (typeof prop === 'object') {
         traverseObj(prop, fn);

--- a/lib/utils/combineJSON.js
+++ b/lib/utils/combineJSON.js
@@ -33,7 +33,7 @@ import { detectDtcgSyntax } from './detectDtcgSyntax.js';
 function traverseObj(obj, fn) {
   for (let key in obj) {
     const prop = obj[key];
-    if (prop !== null || prop !== undefined) {
+    if (prop !== null && prop !== undefined) {
       fn.apply(null, [obj, key, prop]);
       if (typeof prop === 'object') {
         traverseObj(prop, fn);


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_

The `if (prop)` check in `traverseObj` checks, if the current value is 'truthy'. In the case of a token with a `0` value, this check will evaluate to false, and the filePath will not be part of the resulting obj, because we never traverse into the containing object.

In our case, we sometimes opt in to filter tokens by filePath, so with the recent 4.0 version, we lost a bunch of tokens in the output, because they didn't contain `filePath` and were filtered out. This is a regression to 3.x.

Reproduction: https://stackblitz.com/edit/vitejs-vite-h8axgu?file=config.js (the console should output two tokens: one with a positive integer and one with the 0 value)

---

Probably debatable if empty strings should be part of the tokens, but I opted to only check for null/undefined for now. I don't have strong feelings about this, tho.

I don't have a lot of experience in this repo, so I didn't know where to put tests for this. There is `combineJSON.test.js`, but I didn't see tests for the filePath in there. If someone gives me pointers, I can probably also add tests for this bug.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
