### PR TITLE
fix: expand to run after user prepros, tolerate broken refs (#1268)

### DIFF
--- a/.changeset/nine-kiwis-lie.md
+++ b/.changeset/nine-kiwis-lie.md
@@ -1,0 +1,5 @@
+---
+'style-dictionary': patch
+---
+
+Fix bugs with expand tokens where they would run before instead of after user-configured preprocessors, and would fatally error on broken references. Broken refs should be tolerated at the expand stage, and errors will be thrown after preprocessor lifecycle if the refs are still broken at that point.

--- a/docs/src/content/docs/info/architecture.md
+++ b/docs/src/content/docs/info/architecture.md
@@ -67,6 +67,7 @@ Style Dictionary takes all the files it found and performs a deep merge. This al
 Allows users to configure [custom preprocessors](/reference/hooks/preprocessors), to process the merged dictionary as a whole, rather than per token file individually.
 These preprocessors have to be applied in the config, either on a global or platform level.
 Platform level preprocessors run once you get/export/format/build a platform, at the very start.
+Note that [tokens expansion](/reference/config#expand) runs after the user-configured preprocessors (for both global vs platform configured, respectively).
 
 ## 6. Transform the tokens
 

--- a/docs/src/content/docs/reference/Utils/references.md
+++ b/docs/src/content/docs/reference/Utils/references.md
@@ -460,10 +460,10 @@ export default {
 
 ```js script
 import StyleDictionary from 'style-dictionary';
-import { registerTransforms } from '@tokens-studio/sd-transforms';
+import { register } from '@tokens-studio/sd-transforms';
 
 // registers 'ts/color/css/hexrgba'
-registerTransforms(StyleDictionary);
+register(StyleDictionary);
 ```
 
 ### Combining multiple outputReference utility functions

--- a/docs/src/content/docs/reference/config.md
+++ b/docs/src/content/docs/reference/config.md
@@ -262,11 +262,15 @@ The value of expand can be multiple things:
 
 You can enable the expanding of tokens both on a global level and on a platform level.
 
-One notable difference to keep in mind is that when you configure it on a global level, the token expansion will happen immediately **after** the [parsing hook](/reference/hooks/parsers) and **before** [preprocessing](/reference/hooks/preprocessors) or [transform](/reference/hooks/transforms) hooks.\
-This means that token metadata properties that are added by Style Dictionary such as `name`, `filePath`, `path`, `attributes` etc. are not present yet.\
-The advantage is having the expanded tokens (`sd.tokens` prop) available before doing any exporting to platforms.
+Whether configured on platform or global level, the token expansion will happen immediately **after** user-configured [preprocessors](/reference/hooks/preprocessors) and **before** [transform](/reference/hooks/transforms) hooks.\
+That said, platform expand happens only when calling `(get/export/format/build)Platform` methods for the specific platform, whereas global expand happens on StyleDictionary instantiation already.
 
-If you configure it on the platform level however, the metadata mentioned earlier is available and can be used to conditionally expand tokens.
+Refer to the [lifecycle hooks diagram](/info/architecture) for a better overview.
+
+When expanding globally, token metadata properties that are added by Style Dictionary such as `name`, `filePath`, `path`, `attributes` etc. are not present yet.\
+The advantage of global expand however, is having the expanded tokens (`sd.tokens` prop) available before doing any exporting to platforms.
+
+If you configure it on the platform level, the metadata mentioned earlier is available and can be used to conditionally expand tokens.
 It also allows you to expand tokens for some platforms but not for others.\
 The downside there is needing to configure it for every platform separately.
 

--- a/lib/StyleDictionary.js
+++ b/lib/StyleDictionary.js
@@ -331,25 +331,27 @@ export default class StyleDictionary extends Register {
         }
       }
     }
+    this.options = { ...this.options, usesDtcg: this.usesDtcg };
 
     // Merge inline, include, and source tokens
-    /** @type {PreprocessedTokens|Tokens} */
-    let tokens = deepExtend([{}, inlineTokens, includeTokens, sourceTokens]);
-    if (this.usesDtcg) {
-      // this is where they go from type Tokens -> Preprocessed tokens because the prop $type is removed
-      tokens = typeDtcgDelegate(tokens);
-    }
-    let preprocessedTokens = /** @type {PreprocessedTokens} */ (tokens);
-    if (this.shouldRunExpansion(this.expand)) {
-      preprocessedTokens = expandTokens(preprocessedTokens, this.options);
-    }
-    this.options = { ...this.options, usesDtcg: this.usesDtcg };
-    this.tokens = await preprocess(
+    let preprocessedTokens = /** @type {PreprocessedTokens} */ (
+      deepExtend([{}, inlineTokens, includeTokens, sourceTokens])
+    );
+
+    preprocessedTokens = await preprocess(
       preprocessedTokens,
       this.preprocessors,
       this.hooks.preprocessors,
       this.options,
     );
+    if (this.usesDtcg) {
+      // this is where they go from type Tokens -> Preprocessed tokens because the prop $type is removed
+      preprocessedTokens = typeDtcgDelegate(preprocessedTokens);
+    }
+    if (this.shouldRunExpansion(this.expand)) {
+      preprocessedTokens = expandTokens(preprocessedTokens, this.options);
+    }
+    this.tokens = preprocessedTokens;
     this.hasInitializedResolve(null);
 
     // For chaining
@@ -391,14 +393,15 @@ export default class StyleDictionary extends Register {
     const platformConfig = transformConfig(this.platforms[platform], this, platform);
 
     let platformProcessedTokens = /** @type {PreprocessedTokens} */ (this.tokens);
-    if (this.shouldRunExpansion(platformConfig.expand)) {
-      platformProcessedTokens = expandTokens(platformProcessedTokens, this.options, platformConfig);
-    }
+
     platformProcessedTokens = await preprocess(
       platformProcessedTokens,
       platformConfig.preprocessors,
       this.hooks.preprocessors,
     );
+    if (this.shouldRunExpansion(platformConfig.expand)) {
+      platformProcessedTokens = expandTokens(platformProcessedTokens, this.options, platformConfig);
+    }
 
     let exportableResult = /** @type {PreprocessedTokens|TransformedTokens} */ (
       platformProcessedTokens

--- a/lib/utils/expandObjectTokens.js
+++ b/lib/utils/expandObjectTokens.js
@@ -211,7 +211,13 @@ function expandTokensRecurse(slice, original, opts, platform) {
     if (value) {
       // if our token is a ref, we have to resolve it first in order to expand its value
       if (typeof value === 'string' && usesReferences(value)) {
-        value = resolveReferences(value, original, { usesDtcg: uses$ });
+        try {
+          value = resolveReferences(value, original, { usesDtcg: uses$ });
+        } catch (e) {
+          // do nothing, references may be broken but now is not the time to
+          // complain about it, as we're just doing this here so we can expand
+          // tokens that reference object-value tokens that need to be expanded
+        }
       }
 
       if (

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "@bundled-es-modules/deepmerge": "^4.3.1",
         "@bundled-es-modules/glob": "^10.4.2",
-        "@bundled-es-modules/memfs": "^4.9.3",
+        "@bundled-es-modules/memfs": "^4.9.4",
         "@zip.js/zip.js": "^2.7.44",
         "chalk": "^5.3.0",
         "change-case": "^5.3.0",
@@ -2445,9 +2445,9 @@
       }
     },
     "node_modules/@bundled-es-modules/memfs": {
-      "version": "4.9.3",
-      "resolved": "https://registry.npmjs.org/@bundled-es-modules/memfs/-/memfs-4.9.3.tgz",
-      "integrity": "sha512-dWX/xFPJnnl0K3ZCG0xAc6mcwtJBwQzixMxLlZgg6nSM2UpYD11XfM4bEjw1i/suaESh1g8IS9KMFcg85AYf5g==",
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/@bundled-es-modules/memfs/-/memfs-4.9.4.tgz",
+      "integrity": "sha512-1XyYPUaIHwEOdF19wYVLBtHJRr42Do+3ctht17cZOHwHf67vkmRNPlYDGY2kJps4RgE5+c7nEZmEzxxvb1NZWA==",
       "dependencies": {
         "assert": "^2.0.0",
         "buffer": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
   "dependencies": {
     "@bundled-es-modules/deepmerge": "^4.3.1",
     "@bundled-es-modules/glob": "^10.4.2",
-    "@bundled-es-modules/memfs": "^4.9.3",
+    "@bundled-es-modules/memfs": "^4.9.4",
     "@zip.js/zip.js": "^2.7.44",
     "chalk": "^5.3.0",
     "change-case": "^5.3.0",


### PR DESCRIPTION
Update docs demo where it was still using old API for sd-transforms to demo transitive transform color modifier

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
