### PR TITLE
fix: update sd-transforms doc / memfs dependency

### DIFF
--- a/.changeset/shy-cats-beam.md
+++ b/.changeset/shy-cats-beam.md
@@ -1,0 +1,5 @@
+---
+'style-dictionary': patch
+---
+
+Update memfs esm-fork dependency to allow named import Volume.

--- a/docs/src/content/docs/reference/Utils/references.md
+++ b/docs/src/content/docs/reference/Utils/references.md
@@ -460,10 +460,10 @@ export default {
 
 ```js script
 import StyleDictionary from 'style-dictionary';
-import { registerTransforms } from '@tokens-studio/sd-transforms';
+import { register } from '@tokens-studio/sd-transforms';
 
 // registers 'ts/color/css/hexrgba'
-registerTransforms(StyleDictionary);
+register(StyleDictionary);
 ```
 
 ### Combining multiple outputReference utility functions

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "@bundled-es-modules/deepmerge": "^4.3.1",
         "@bundled-es-modules/glob": "^10.4.2",
-        "@bundled-es-modules/memfs": "^4.9.3",
+        "@bundled-es-modules/memfs": "^4.9.4",
         "@zip.js/zip.js": "^2.7.44",
         "chalk": "^5.3.0",
         "change-case": "^5.3.0",
@@ -2445,9 +2445,9 @@
       }
     },
     "node_modules/@bundled-es-modules/memfs": {
-      "version": "4.9.3",
-      "resolved": "https://registry.npmjs.org/@bundled-es-modules/memfs/-/memfs-4.9.3.tgz",
-      "integrity": "sha512-dWX/xFPJnnl0K3ZCG0xAc6mcwtJBwQzixMxLlZgg6nSM2UpYD11XfM4bEjw1i/suaESh1g8IS9KMFcg85AYf5g==",
+      "version": "4.9.4",
+      "resolved": "https://registry.npmjs.org/@bundled-es-modules/memfs/-/memfs-4.9.4.tgz",
+      "integrity": "sha512-1XyYPUaIHwEOdF19wYVLBtHJRr42Do+3ctht17cZOHwHf67vkmRNPlYDGY2kJps4RgE5+c7nEZmEzxxvb1NZWA==",
       "dependencies": {
         "assert": "^2.0.0",
         "buffer": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
   "dependencies": {
     "@bundled-es-modules/deepmerge": "^4.3.1",
     "@bundled-es-modules/glob": "^10.4.2",
-    "@bundled-es-modules/memfs": "^4.9.3",
+    "@bundled-es-modules/memfs": "^4.9.4",
     "@zip.js/zip.js": "^2.7.44",
     "chalk": "^5.3.0",
     "change-case": "^5.3.0",


### PR DESCRIPTION
Update docs demo where it was still using old API for sd-transforms to demo transitive transform color modifier

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.