### PR TITLE
Typing fix for parsers in Config interface

### DIFF
--- a/.changeset/angry-dots-provide.md
+++ b/.changeset/angry-dots-provide.md
@@ -1,0 +1,5 @@
+---
+'style-dictionary': patch
+---
+
+Fix type information for Config.parser

--- a/types/Config.ts
+++ b/types/Config.ts
@@ -110,7 +110,7 @@ export interface Config {
   hooks?: Hooks;
   expand?: ExpandConfig;
   platforms?: Record<string, PlatformConfig>;
-  parsers?: Parser[];
+  parsers?: string[];
   preprocessors?: string[];
   usesDtcg?: boolean;
 }


### PR DESCRIPTION
Changes the `parsers` array to `string` instead of `Parsers` as it is supposed to be a list of parsers names.

This fixes #1280

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
