### PR TITLE
fix: change fontWidth prop to fontStretch as per W3C spec

### DIFF
--- a/.changeset/thick-avocados-hunt.md
+++ b/.changeset/thick-avocados-hunt.md
@@ -1,0 +1,5 @@
+---
+'style-dictionary': patch
+---
+
+Change fontWidth property to fontStretch property, fontWidth is the incorrect name for this, according to W3C specs.

--- a/__tests__/common/transforms.test.js
+++ b/__tests__/common/transforms.test.js
@@ -1188,7 +1188,7 @@ describe('common', () => {
             fontWeight: '500',
             fontSize: '20px',
             fontVariant: 'small-caps',
-            fontWidth: 'condensed',
+            fontStretch: 'condensed',
             fontStyle: 'italic',
             lineHeight: '1.5',
             fontFamily: 'Arial',

--- a/lib/common/transforms.js
+++ b/lib/common/transforms.js
@@ -1253,13 +1253,13 @@ export default {
         return val;
       }
       let { fontFamily } = val;
-      const { fontWeight, fontVariant, fontWidth, fontSize, fontStyle, lineHeight } = val;
+      const { fontWeight, fontVariant, fontStretch, fontSize, fontStyle, lineHeight } = val;
 
       const CSSShorthandProps = [
         'fontStyle',
         'fontVariant',
         'fontWeight',
-        'fontWidth',
+        'fontStretch',
         'fontSize',
         'lineHeight',
         'fontFamily',
@@ -1279,7 +1279,7 @@ export default {
 
       return `${fontStyle ? `${fontStyle} ` : ''}${fontVariant ? `${fontVariant} ` : ''}${
         fontWeight ? `${fontWeight} ` : ''
-      }${fontWidth ? `${fontWidth} ` : ''}${
+      }${fontStretch ? `${fontStretch} ` : ''}${
         fontSize ? `${fontSize}` : `${getBasePxFontSize(platform)}px`
       }${lineHeight ? `/${lineHeight} ` : ' '}${fontFamily}`;
     },


### PR DESCRIPTION


_Description of changes:_
https://github.com/mdn/content/issues/35265 this was wrong in the MDN formal syntax heading and this mistake got adopted in the typography transform. This is a bug so even though technically breaking, acceptable to fix without a major bump imo.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
