### PR TITLE
fix: zero value is returned without a unit at size/rem transform

### DIFF
--- a/__tests__/common/transforms.test.js
+++ b/__tests__/common/transforms.test.js
@@ -930,15 +930,18 @@ describe('common', () => {
         );
         expect(value).to.equal('1rem');
       });
-      it('zero value is returned without a unit', () => {
-        const value = transforms['size/rem'].transform(
-          {
-            value: '0',
-          },
-          {},
-          {},
-        );
-        expect(value).to.equal('0');
+      ['0', 0].forEach((value) => {
+        it('zero value is returned without a unit and remains same type', () => {
+          expect(
+            transforms['size/rem'].transform(
+              {
+                value,
+              },
+              {},
+              {},
+            ),
+          ).to.equal(value);
+        });
       });
       it('should throw an error if prop value is Nan', () => {
         expect(() => transforms['size/dp'].transform({ value: 'a' }, {}, {})).to.throw();

--- a/__tests__/common/transforms.test.js
+++ b/__tests__/common/transforms.test.js
@@ -930,6 +930,16 @@ describe('common', () => {
         );
         expect(value).to.equal('1rem');
       });
+      it('zero value is returned without a unit', () => {
+        const value = transforms['size/rem'].transform(
+          {
+            value: '0',
+          },
+          {},
+          {},
+        );
+        expect(value).to.equal('0');
+      });
       it('should throw an error if prop value is Nan', () => {
         expect(() => transforms['size/dp'].transform({ value: 'a' }, {}, {})).to.throw();
       });

--- a/lib/common/transforms.js
+++ b/lib/common/transforms.js
@@ -832,6 +832,7 @@ export default {
       }
       const parsedVal = parseFloat(nonParsed);
       if (isNaN(parsedVal)) throwSizeError(token.name, nonParsed, 'rem');
+      if (parsedVal === 0) return '0';
       return parsedVal + 'rem';
     },
   },

--- a/lib/common/transforms.js
+++ b/lib/common/transforms.js
@@ -832,7 +832,7 @@ export default {
       }
       const parsedVal = parseFloat(nonParsed);
       if (isNaN(parsedVal)) throwSizeError(token.name, nonParsed, 'rem');
-      if (parsedVal === 0) return '0';
+      if (parsedVal === 0) return Number.isInteger(nonParsed) ? 0 : '0';
       return parsedVal + 'rem';
     },
   },


### PR DESCRIPTION
_Issue #, if available:_
#1267

_Description of changes:_
As the title says,  I fixed that zero value is returned without a unit at size/rem transform.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
