### PR TITLE
 fix(example) : format-helpers import path

### DIFF
--- a/examples/advanced/format-helpers/sd.config.js
+++ b/examples/advanced/format-helpers/sd.config.js
@@ -3,7 +3,7 @@ import {
   fileHeader,
   formattedVariables,
   sortByReference,
-} from 'style-dictionary';
+} from 'style-dictionary/utils';
 
 export default {
   hooks: {


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_

When version 4 was released (#1258 ), the import location for formatHelpers was changed to be under utils/index line:36.
![스크린샷 2024-08-19 오후 5 05 28](https://github.com/user-attachments/assets/4dc41c64-7c65-4933-b6ea-1ef4fc5dc1ae)


The official documentation also guides the import path to be under utils.
![스크린샷 2024-08-19 오후 5 10 16](https://github.com/user-attachments/assets/45684b88-2ec7-44de-b6af-b1d371103124)


I am submitting a fix PR for better examples.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
