### PR TITLE
feat: add logging link to errors

### DIFF
--- a/.changeset/seven-dolphins-dream.md
+++ b/.changeset/seven-dolphins-dream.md
@@ -1,0 +1,5 @@
+---
+'style-dictionary': patch
+---
+
+Added link to logging documentation inside all of the warnings and errors that refer to verbosity.

--- a/__integration__/__snapshots__/nameCollisions.test.snap.js
+++ b/__integration__/__snapshots__/nameCollisions.test.snap.js
@@ -17,6 +17,7 @@ snapshots["integration name collisions should warn users of name collisions for 
 `⚠️ __integration__/build/variables.css
 While building variables.css, token collisions were found; output may be unexpected. Ignore this warning if intentional.
 
-Use log.verbosity "verbose" or use CLI option --verbose for more details.`;
+Use log.verbosity "verbose" or use CLI option --verbose for more details.
+Refer to: https://styledictionary.com/reference/logging/`;
 /* end snapshot integration name collisions should warn users of name collisions for flat files, brief version */
 

--- a/__integration__/__snapshots__/outputReferences.test.snap.js
+++ b/__integration__/__snapshots__/outputReferences.test.snap.js
@@ -5,7 +5,8 @@ snapshots["integration output references should warn the user if filters out ref
 `⚠️ __integration__/build/filteredVariables.css
 While building filteredVariables.css, filtered out token references were found; output may be unexpected. Ignore this warning if intentional.
 
-Use log.verbosity "verbose" or use CLI option --verbose for more details.`;
+Use log.verbosity "verbose" or use CLI option --verbose for more details.
+Refer to: https://styledictionary.com/reference/logging/`;
 /* end snapshot integration output references should warn the user if filters out references briefly */
 
 snapshots["integration output references should warn the user if filters out references with a detailed message when using verbose logging"] = 

--- a/__integration__/logging/__snapshots__/config.test.snap.js
+++ b/__integration__/logging/__snapshots__/config.test.snap.js
@@ -3,12 +3,14 @@ export const snapshots = {};
 snapshots["integration > logging > config > property value collisions should not throw, but notify users by default"] = 
 `
 Token collisions detected (16):
-Use log.verbosity "verbose" or use CLI option --verbose for more details.`;
+Use log.verbosity "verbose" or use CLI option --verbose for more details.
+Refer to: https://styledictionary.com/reference/logging/`;
 /* end snapshot integration > logging > config > property value collisions should not throw, but notify users by default */
 
 snapshots["integration > logging > config > property value collisions should not show warnings if given higher log level"] = 
 `
 Token collisions detected (16):
-Use log.verbosity "verbose" or use CLI option --verbose for more details.`;
+Use log.verbosity "verbose" or use CLI option --verbose for more details.
+Refer to: https://styledictionary.com/reference/logging/`;
 /* end snapshot integration > logging > config > property value collisions should not show warnings if given higher log level */
 

--- a/__integration__/logging/__snapshots__/file.test.snap.js
+++ b/__integration__/logging/__snapshots__/file.test.snap.js
@@ -13,21 +13,24 @@ css
 ⚠️ __integration__/build/nameCollisions.css
 While building nameCollisions.css, token collisions were found; output may be unexpected. Ignore this warning if intentional.
 
-Use log.verbosity "verbose" or use CLI option --verbose for more details.`;
+Use log.verbosity "verbose" or use CLI option --verbose for more details.
+Refer to: https://styledictionary.com/reference/logging/`;
 /* end snapshot integration logging file name collisions should warn users briefly of name collisions by default */
 
 snapshots["integration logging file name collisions should throw a brief error of name collisions with log level set to error"] = 
 `⚠️ __integration__/build/nameCollisions.css
 While building nameCollisions.css, token collisions were found; output may be unexpected. Ignore this warning if intentional.
 
-Use log.verbosity "verbose" or use CLI option --verbose for more details.`;
+Use log.verbosity "verbose" or use CLI option --verbose for more details.
+Refer to: https://styledictionary.com/reference/logging/`;
 /* end snapshot integration logging file name collisions should throw a brief error of name collisions with log level set to error */
 
 snapshots["integration logging file name collisions should throw a brief error of name collisions with log level set to error on platform level"] = 
 `⚠️ __integration__/build/nameCollisions.css
 While building nameCollisions.css, token collisions were found; output may be unexpected. Ignore this warning if intentional.
 
-Use log.verbosity "verbose" or use CLI option --verbose for more details.`;
+Use log.verbosity "verbose" or use CLI option --verbose for more details.
+Refer to: https://styledictionary.com/reference/logging/`;
 /* end snapshot integration logging file name collisions should throw a brief error of name collisions with log level set to error on platform level */
 
 snapshots["integration logging file name collisions should warn user of name collisions with a detailed message through \"verbose\" verbosity"] = 
@@ -392,21 +395,24 @@ css
 ⚠️ __integration__/build/filteredReferences.css
 While building filteredReferences.css, filtered out token references were found; output may be unexpected. Ignore this warning if intentional.
 
-Use log.verbosity "verbose" or use CLI option --verbose for more details.`;
+Use log.verbosity "verbose" or use CLI option --verbose for more details.
+Refer to: https://styledictionary.com/reference/logging/`;
 /* end snapshot integration logging file filtered references should warn users briefly of filtered references by default */
 
 snapshots["integration logging file filtered references should throw a brief error of filtered references with log level set to error"] = 
 `⚠️ __integration__/build/filteredReferences.css
 While building filteredReferences.css, filtered out token references were found; output may be unexpected. Ignore this warning if intentional.
 
-Use log.verbosity "verbose" or use CLI option --verbose for more details.`;
+Use log.verbosity "verbose" or use CLI option --verbose for more details.
+Refer to: https://styledictionary.com/reference/logging/`;
 /* end snapshot integration logging file filtered references should throw a brief error of filtered references with log level set to error */
 
 snapshots["integration logging file filtered references should throw a brief error of filtered references with log level set to error on platform level"] = 
 `⚠️ __integration__/build/filteredReferences.css
 While building filteredReferences.css, filtered out token references were found; output may be unexpected. Ignore this warning if intentional.
 
-Use log.verbosity "verbose" or use CLI option --verbose for more details.`;
+Use log.verbosity "verbose" or use CLI option --verbose for more details.
+Refer to: https://styledictionary.com/reference/logging/`;
 /* end snapshot integration logging file filtered references should throw a brief error of filtered references with log level set to error on platform level */
 
 snapshots["integration logging file filtered references should warn user of filtered references with a detailed message through \"verbose\" verbosity"] = 

--- a/__integration__/logging/__snapshots__/platform.test.snap.js
+++ b/__integration__/logging/__snapshots__/platform.test.snap.js
@@ -23,6 +23,7 @@ snapshots["integration logging platform property reference errors should throw a
 Reference Errors:
 Some token references (1) could not be found.
 Use log.verbosity "verbose" or use CLI option --verbose for more details.
+Refer to: https://styledictionary.com/reference/logging/
 `;
 /* end snapshot integration logging platform property reference errors should throw and notify users of unknown references */
 
@@ -31,6 +32,7 @@ snapshots["integration logging platform property reference errors circular refer
 Reference Errors:
 Some token references (2) could not be found.
 Use log.verbosity "verbose" or use CLI option --verbose for more details.
+Refer to: https://styledictionary.com/reference/logging/
 `;
 /* end snapshot integration logging platform property reference errors circular references should throw and notify users */
 

--- a/__node_tests__/cliBuild.test.js
+++ b/__node_tests__/cliBuild.test.js
@@ -62,7 +62,8 @@ css
 ⚠️ __tests__/__output/css/vars.css
 While building vars.css, token collisions were found; output may be unexpected. Ignore this warning if intentional.
 
-Use log.verbosity "verbose" or use CLI option --verbose for more details.\n`);
+Use log.verbosity "verbose" or use CLI option --verbose for more details.
+Refer to: https://styledictionary.com/reference/logging/\n`);
     });
 
     it('should log verbosely if --verbose is used', () => {

--- a/__tests__/StyleDictionary.test.js
+++ b/__tests__/StyleDictionary.test.js
@@ -416,6 +416,7 @@ Use log.verbosity "verbose" or use CLI option --verbose for more details.
 Reference Errors:
 Some token references (1) could not be found.
 Use log.verbosity "verbose" or use CLI option --verbose for more details.
+Refer to: https://styledictionary.com/reference/logging/
 `);
     });
 
@@ -473,6 +474,7 @@ Use log.verbosity "verbose" or use CLI option --verbose for more details.
 Reference Errors:
 Some token references (1) could not be found.
 Use log.verbosity "verbose" or use CLI option --verbose for more details.
+Refer to: https://styledictionary.com/reference/logging/
 `);
 
       expect(clearSDMeta(transformed)).to.eql({

--- a/__tests__/__snapshots__/StyleDictionary.test.snap.js
+++ b/__tests__/__snapshots__/StyleDictionary.test.snap.js
@@ -60,7 +60,8 @@ Collision detected at: size.padding.xxl! Original value: true, New value: true
 snapshots["StyleDictionary class collisions should throw a brief error if the collision is in source files and log is set to error and verbosity default"] = 
 `
 Token collisions detected (28):
-Use log.verbosity "verbose" or use CLI option --verbose for more details.`;
+Use log.verbosity "verbose" or use CLI option --verbose for more details.
+Refer to: https://styledictionary.com/reference/logging/`;
 /* end snapshot StyleDictionary class collisions should throw a brief error if the collision is in source files and log is set to error and verbosity default */
 
 snapshots["StyleDictionary class formatFile should support asynchronous formats"] = 

--- a/__tests__/exportPlatform.test.js
+++ b/__tests__/exportPlatform.test.js
@@ -481,6 +481,7 @@ Use log.verbosity "verbose" or use CLI option --verbose for more details.`;
         expect(cleanConsoleOutput(logStub.firstCall.args[0])).to.equal(`
 Unknown CSS Font Shorthand properties found for 1 tokens, CSS output for Font values will be missing some typography token properties as a result:
 Use log.verbosity "verbose" or use CLI option --verbose for more details.
+Refer to: https://styledictionary.com/reference/logging/
 `);
 
         sd.log.verbosity = 'verbose';

--- a/lib/utils/groupMessages.js
+++ b/lib/utils/groupMessages.js
@@ -11,7 +11,7 @@
  * and limitations under the License.
  */
 
-export const verbosityInfo = `Use log.verbosity "verbose" or use CLI option --verbose for more details.`;
+export const verbosityInfo = `Use log.verbosity "verbose" or use CLI option --verbose for more details.\nRefer to: https://styledictionary.com/reference/logging/`;
 
 export class GroupMessages {
   constructor() {


### PR DESCRIPTION
_Issue #, if available:_

fixes https://github.com/amzn/style-dictionary/issues/1320

_Description of changes:_

Added link to logging documentation inside all of the warnings and errors that refer to verbosity.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
