### PR TITLE
docs: add note to v4 migration guide about node 18 min version

### DIFF
--- a/docs/src/content/docs/version-4/migration.md
+++ b/docs/src/content/docs/version-4/migration.md
@@ -9,6 +9,10 @@ Version 4 of Style-Dictionary comes with a good amount of breaking changes compa
 In this document, we will outline those breaking changes, ordered from most impactful to least.
 Before and after examples are added to enable you to adjust your code to account for the changes.
 
+:::note
+**Important:** Version 4 of Style Dictionary requires Node.js 18+.
+:::
+
 ## ES Modules instead of CommonJS
 
 There are different ways to write JavaScript, NodeJS came up with CommonJS format and later browsers brought ES Modules format which NodeJS also supports.


### PR DESCRIPTION
_Issue #, if available:_ 

* https://github.com/amzn/style-dictionary/issues/1191
* https://github.com/amzn/style-dictionary/issues/1304

_Description of changes:_

Adds documentation regarding minimum supported version of Node.js 18+ to the Version 4 migration guide. Not sure how detailed the note should be; opted for brevity, highlighted in a note.

[Preview](https://pr-1324.d16eby4ekpss5y.amplifyapp.com/version-4/migration/)

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
