### PR TITLE
docs: fix `compose/object` parameters table

### DIFF
--- a/docs/src/content/docs/reference/Hooks/Formats/predefined.md
+++ b/docs/src/content/docs/reference/Hooks/Formats/predefined.md
@@ -559,15 +559,14 @@ Example:
 
 Creates a Kotlin file for Compose containing an object with a `val` for each property.
 
-| Param | Type | Description |
-| ----- | ---- | ----------- |
-
-| `options` | `Object` | |
-| `options.import` | `string[] \| string` | Modules to import. Can be a string or array of strings. Defaults to `['androidx.compose.ui.graphics.Color', 'androidx.compose.ui.unit.*']`. |
-| `options.showFileHeader` | `boolean` | Whether or not to include a comment that has the build date. Defaults to `true` |
+| Param                      | Type                                  | Description                                                                                                                                                                                                |
+| -------------------------- | ------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `options`                  | `Object`                              |                                                                                                                                                                                                            |
+| `options.import`           | `string[] \| string`                  | Modules to import. Can be a string or array of strings. Defaults to `['androidx.compose.ui.graphics.Color', 'androidx.compose.ui.unit.*']`.                                                                |
+| `options.showFileHeader`   | `boolean`                             | Whether or not to include a comment that has the build date. Defaults to `true`                                                                                                                            |
 | `options.outputReferences` | `boolean \| OutputReferencesFunction` | Whether or not to keep [references](#references-in-output-files) (a -> b -> c) in the output. Defaults to `false`. Also allows passing a function to conditionally output references on a per token basis. |
-| `options.className` | `string` | The name of the generated Kotlin object |
-| `options.packageName` | `string` | The package for the generated Kotlin object |
+| `options.className`        | `string`                              | The name of the generated Kotlin object                                                                                                                                                                    |
+| `options.packageName`      | `string`                              | The package for the generated Kotlin object                                                                                                                                                                |
 
 Example:
 


### PR DESCRIPTION
### Description

This PR fixes a rendering issue in the documentation at https://styledictionary.com/reference/hooks/formats/predefined/#composeobject. Indeed, the table containing the parameters is not rendered properly:

![Screenshot 2024-09-05 at 10 23 22](https://github.com/user-attachments/assets/39b90970-8690-4049-b24a-3e5a931ccc30)

The fix uses the same Markdown table formatting as for the other formats.

The new rendering can be seen at https://pr-1328.d16eby4ekpss5y.amplifyapp.com/reference/hooks/formats/predefined/#composeobject. Here's a screenshot:

![Screenshot 2024-09-05 at 10 24 19](https://github.com/user-attachments/assets/975b8e23-3a41-4587-9dbe-c231af8b958e)

