### PR TITLE
Updating example ES Module file names

### DIFF
--- a/docs/src/content/docs/info/tokens.md
+++ b/docs/src/content/docs/info/tokens.md
@@ -253,7 +253,7 @@ This example would show a warning in the console that you have a collision at `c
 
 One way to write your design token files is to write them in Javascript rather than JSON. The only requirement for writing your source files in Javascript is to use an ES Module containing a default export of a plain object. For example:
 
-```javascript title="config.js"
+```javascript title="color.js"
 export default {
   color: {
     base: {
@@ -265,7 +265,7 @@ export default {
 
 is equivalent to this JSON file:
 
-```json title="config.json"
+```json title="color.json"
 {
   "color": {
     "base": {


### PR DESCRIPTION
_Description of changes:_

On the [Design Tokens page](https://styledictionary.com/info/tokens/), there is an ES Modules example section. It seems that the examples are referencing a `config.js` and `config.json` file as an example way of supporting your tokens in javascript. 

This seemed confusing and wrong, as the `config` file is specifically related to the platforms, transforms, etc. 

This PR updates the file names to help others with any confusion around ES Modules and the example file names.

<img width="955" alt="Screenshot 2024-09-18 at 1 50 57 PM" src="https://github.com/user-attachments/assets/017aef3b-8aa9-4fc9-947d-179b66e6d9a7">



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
