### PR TITLE
fix: empty tokens in filterTokenObject

### DIFF
--- a/lib/filterTokens.js
+++ b/lib/filterTokens.js
@@ -48,6 +48,9 @@ async function filterTokenObject(tokens, filter, options) {
   // out
   const result = await Object.entries(tokens ?? []).reduce(async (_acc, [key, token]) => {
     const acc = await _acc;
+    if (!token) {
+      return acc;
+    }
     const tokenValue = options.usesDtcg ? token.$value : token.value;
     // If the token is not an object, we don't know what it is. We return it as-is.
     if (!isPlainObject(token)) {


### PR DESCRIPTION
My tokens have a description key which often is empty which resulted in the following error

```javascript
const tokenValue = options.usesDtcg ? token.$value : token.value;
                                                               ^

TypeError: Cannot read properties of null (reading 'value')
    at file:///project-dir/node_modules/style-dictionary/lib/filterTokens.js:51:64
    at async file:///project-dir/node_modules/style-dictionary/lib/filterTokens.js:50:17
    at async filterTokenObject (file:///project-dir/node_modules/style-dictionary/lib/filterTokens.js:49:18)
    at async file:///project-dir/node_modules/style-dictionary/lib/filterTokens.js:65:24
    at async file:///project-dir/node_modules/style-dictionary/lib/filterTokens.js:50:17
    at async file:///project-dir/node_modules/style-dictionary/lib/filterTokens.js:50:17
    at async filterTokenObject (file:///project-dir/node_modules/style-dictionary/lib/filterTokens.js:49:18)
    at async file:///project-dir/node_modules/style-dictionary/lib/filterTokens.js:65:24
    at async filterTokenObject (file:///project-dir/node_modules/style-dictionary/lib/filterTokens.js:49:18)
    at async file:///project-dir/node_modules/style-dictionary/lib/filterTokens.js:65:24
``` 