### PR TITLE
fix(outputReferences): sorting of tokens in dtcg format

### DIFF
--- a/.changeset/tall-comics-grow.md
+++ b/.changeset/tall-comics-grow.md
@@ -1,0 +1,5 @@
+---
+'style-dictionary': patch
+---
+
+(#1305): fix reference sorting in `sortByReference` function for DTCG token format, ensuring token references are declared after their targets

--- a/__integration__/__snapshots__/outputReferences.test.snap.js
+++ b/__integration__/__snapshots__/outputReferences.test.snap.js
@@ -1,7 +1,7 @@
 /* @web/test-runner snapshot v1 */
 export const snapshots = {};
 
-snapshots["integration output references should warn the user if filters out references briefly"] = 
+snapshots["integration output references should warn the user if filters out references briefly"] =
 `⚠️ __integration__/build/filteredVariables.css
 While building filteredVariables.css, filtered out token references were found; output may be unexpected. Ignore this warning if intentional.
 
@@ -9,7 +9,7 @@ Use log.verbosity "verbose" or use CLI option --verbose for more details.
 Refer to: https://styledictionary.com/reference/logging/`;
 /* end snapshot integration output references should warn the user if filters out references briefly */
 
-snapshots["integration output references should warn the user if filters out references with a detailed message when using verbose logging"] = 
+snapshots["integration output references should warn the user if filters out references with a detailed message when using verbose logging"] =
 `⚠️ __integration__/build/filteredVariables.css
 While building filteredVariables.css, filtered out token references were found; output may be unexpected. Ignore this warning if intentional.
 Here are the references that are used but not defined in the file:
@@ -23,13 +23,13 @@ color.core.blue.0
 This is caused when combining a filter and \`outputReferences\`.`;
 /* end snapshot integration output references should warn the user if filters out references with a detailed message when using verbose logging */
 
-snapshots["integration output references should not warn the user if filters out references is prevented with outputReferencesFilter"] = 
+snapshots["integration output references should not warn the user if filters out references is prevented with outputReferencesFilter"] =
 `
 css
 ✔︎ __integration__/build/filteredVariables.css`;
 /* end snapshot integration output references should not warn the user if filters out references is prevented with outputReferencesFilter */
 
-snapshots["integration output references should allow using outputReferencesTransformed to not output refs when value has been transitively transformed"] = 
+snapshots["integration output references should allow using outputReferencesTransformed to not output refs when value has been transitively transformed"] =
 `/**
  * Do not edit directly, this file was auto-generated.
  */
@@ -40,4 +40,16 @@ snapshots["integration output references should allow using outputReferencesTran
 }
 `;
 /* end snapshot integration output references should allow using outputReferencesTransformed to not output refs when value has been transitively transformed */
+
+snapshots["integration output references should properly reference tokens in dtcg format"] = 
+`/**
+ * Do not edit directly, this file was auto-generated.
+ */
+
+:root {
+  --base: #ff0000;
+  --referred: var(--base);
+}
+`;
+/* end snapshot integration output references should properly reference tokens in dtcg format */
 

--- a/__integration__/outputReferences.test.js
+++ b/__integration__/outputReferences.test.js
@@ -176,5 +176,41 @@ describe('integration', async () => {
       await sd.buildAllPlatforms();
       await expect(stub.lastCall.args.map(cleanConsoleOutput).join('\n')).to.matchSnapshot();
     });
+
+    it('should properly reference tokens in dtcg format', async () => {
+      const sd = new StyleDictionary({
+        tokens: {
+          base: {
+            $value: '#FF0000',
+            $type: 'color',
+          },
+          referred: {
+            $value: '{base}',
+            $type: 'color',
+          },
+        },
+        platforms: {
+          css: {
+            transformGroup: 'css',
+            buildPath,
+            files: [
+              {
+                destination: 'dtcgOutputRef.css',
+                format: 'css/variables',
+                options: {
+                  outputReferences: true,
+                  usesDtcg: true,
+                },
+              },
+            ],
+          },
+        },
+      });
+      await sd.buildAllPlatforms();
+      const output = fs.readFileSync(resolve(`${buildPath}dtcgOutputRef.css`), {
+        encoding: 'UTF-8',
+      });
+      await expect(output).to.matchSnapshot();
+    });
   });
 });

--- a/__tests__/common/formatHelpers/sortByReference.test.js
+++ b/__tests__/common/formatHelpers/sortByReference.test.js
@@ -13,35 +13,24 @@
 import { expect } from 'chai';
 import sortByReference from '../../../lib/common/formatHelpers/sortByReference.js';
 
-const DEFAULT_TRANSFORMED_TOKENS = {
+const TRANSFORMED_TOKENS = (dtcg) => ({
   color: {
     primary: {
-      value: '#FF0000',
-      type: 'color',
-      original: { value: '{color.red}', type: 'color' },
+      [`${dtcg ? '$' : ''}value`]: '#FF0000',
+      [`${dtcg ? '$' : ''}type`]: 'color',
+      original: { 
+        [`${dtcg ? '$' : ''}value`]: '{color.red}',
+        [`${dtcg ? '$' : ''}type`]: 'color' },
     },
     red: {
-      value: '#FF0000',
-      type: 'color',
-      original: { value: '#FF0000', type: 'color' },
+      [`${dtcg ? '$' : ''}value`]: '#FF0000',
+      [`${dtcg ? '$' : ''}type`]: 'color',
+      original: { 
+        [`${dtcg ? '$' : ''}value`]: '#FF0000',
+        [`${dtcg ? '$' : ''}type`]: 'color' },
     },
   },
-};
-
-const DTCG_TRANSFORMED_TOKENS = {
-  color: {
-    primary: {
-      $value: '#FF0000',
-      $type: 'color',
-      original: { $value: '{color.red}', $type: 'color' },
-    },
-    red: {
-      $value: '#FF0000',
-      $type: 'color',
-      original: { $value: '#FF0000', $type: 'color' },
-    },
-  },
-};
+});
 
 describe('common', () => {
   describe('formatHelpers', () => {

--- a/__tests__/common/formatHelpers/sortByReference.test.js
+++ b/__tests__/common/formatHelpers/sortByReference.test.js
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
+ * the License. A copy of the License is located at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ */
+import { expect } from 'chai';
+import sortByReference from '../../../lib/common/formatHelpers/sortByReference.js';
+
+const DEFAULT_TRANSFORMED_TOKENS = {
+  color: {
+    primary: {
+      value: '#FF0000',
+      type: 'color',
+      original: { value: '{color.red}', type: 'color' },
+    },
+    red: {
+      value: '#FF0000',
+      type: 'color',
+      original: { value: '#FF0000', type: 'color' },
+    },
+  },
+};
+
+const DTCG_TRANSFORMED_TOKENS = {
+  color: {
+    primary: {
+      $value: '#FF0000',
+      $type: 'color',
+      original: { $value: '{color.red}', $type: 'color' },
+    },
+    red: {
+      $value: '#FF0000',
+      $type: 'color',
+      original: { $value: '#FF0000', $type: 'color' },
+    },
+  },
+};
+
+describe('common', () => {
+  describe('formatHelpers', () => {
+    describe('sortByReference', () => {
+      [
+        ['default', false, DEFAULT_TRANSFORMED_TOKENS],
+        ['dtcg', true, DTCG_TRANSFORMED_TOKENS],
+      ].forEach(([tokenFormat, usesDtcg, tokens]) => {
+        it(`should keep order when idx0 has no reference(${tokenFormat})`, () => {
+          const allTokens = [tokens.color.red, tokens.color.primary];
+
+          const sorted = [...allTokens].sort(
+            sortByReference(tokens, {
+              usesDtcg,
+            }),
+          );
+
+          expect(sorted).to.eql([tokens.color.red, tokens.color.primary]);
+        });
+        it(`should reorder, if idx0 references idx1 (${tokenFormat})`, () => {
+          const allTokens = [tokens.color.primary, tokens.color.red];
+
+          const sorted = [...allTokens].sort(
+            sortByReference(tokens, {
+              usesDtcg,
+            }),
+          );
+
+          expect(sorted).to.eql([tokens.color.red, tokens.color.primary]);
+        });
+      });
+      it('should reorder when idx0 is undefined', () => {
+        const transformedTokensWithUndefined = {
+          ...DEFAULT_TRANSFORMED_TOKENS,
+          color: { ...DEFAULT_TRANSFORMED_TOKENS.color, primary: undefined },
+        };
+        const allTokens = [
+          transformedTokensWithUndefined.color.primary,
+          transformedTokensWithUndefined.color.red,
+        ];
+
+        const sorted = [...allTokens].sort(sortByReference(transformedTokensWithUndefined));
+
+        expect(sorted).to.eql([
+          transformedTokensWithUndefined.color.red,
+          transformedTokensWithUndefined.color.primary,
+        ]);
+      });
+      it('should keep order when idx1 is undefined', () => {
+        const transformedTokensWithUndefined = {
+          ...DEFAULT_TRANSFORMED_TOKENS,
+          color: { ...DEFAULT_TRANSFORMED_TOKENS.color, primary: undefined },
+        };
+        const allTokens = [
+          transformedTokensWithUndefined.color.red,
+          transformedTokensWithUndefined.color.primary,
+        ];
+
+        const sorted = [...allTokens].sort(sortByReference(transformedTokensWithUndefined));
+
+        expect(sorted).to.eql([
+          transformedTokensWithUndefined.color.red,
+          transformedTokensWithUndefined.color.primary,
+        ]);
+      });
+    });
+  });
+});

--- a/__tests__/common/formatHelpers/sortByReference.test.js
+++ b/__tests__/common/formatHelpers/sortByReference.test.js
@@ -13,31 +13,38 @@
 import { expect } from 'chai';
 import sortByReference from '../../../lib/common/formatHelpers/sortByReference.js';
 
-const TRANSFORMED_TOKENS = (dtcg) => ({
-  color: {
-    primary: {
-      [`${dtcg ? '$' : ''}value`]: '#FF0000',
-      [`${dtcg ? '$' : ''}type`]: 'color',
-      original: { 
-        [`${dtcg ? '$' : ''}value`]: '{color.red}',
-        [`${dtcg ? '$' : ''}type`]: 'color' },
+const TRANSFORMED_TOKENS = (usesDtcg) => {
+  const valueKey = usesDtcg ? '$value' : 'value';
+  const typeKey = usesDtcg ? '$type' : 'type';
+
+  return {
+    color: {
+      primary: {
+        [valueKey]: '#FF0000',
+        [typeKey]: 'color',
+        original: {
+          [valueKey]: '{color.red}',
+          [typeKey]: 'color',
+        },
+      },
+      red: {
+        [valueKey]: '#FF0000',
+        [typeKey]: 'color',
+        original: {
+          [valueKey]: '#FF0000',
+          [typeKey]: 'color',
+        },
+      },
     },
-    red: {
-      [`${dtcg ? '$' : ''}value`]: '#FF0000',
-      [`${dtcg ? '$' : ''}type`]: 'color',
-      original: { 
-        [`${dtcg ? '$' : ''}value`]: '#FF0000',
-        [`${dtcg ? '$' : ''}type`]: 'color' },
-    },
-  },
-});
+  };
+};
 
 describe('common', () => {
   describe('formatHelpers', () => {
     describe('sortByReference', () => {
       [
-        ['default', false, DEFAULT_TRANSFORMED_TOKENS],
-        ['dtcg', true, DTCG_TRANSFORMED_TOKENS],
+        ['default', false, TRANSFORMED_TOKENS(false)],
+        ['dtcg', true, TRANSFORMED_TOKENS(true)],
       ].forEach(([tokenFormat, usesDtcg, tokens]) => {
         it(`should keep order when idx0 has no reference(${tokenFormat})`, () => {
           const allTokens = [tokens.color.red, tokens.color.primary];
@@ -63,37 +70,39 @@ describe('common', () => {
         });
       });
       it('should reorder when idx0 is undefined', () => {
-        const transformedTokensWithUndefined = {
-          ...DEFAULT_TRANSFORMED_TOKENS,
-          color: { ...DEFAULT_TRANSFORMED_TOKENS.color, primary: undefined },
+        const tokens = TRANSFORMED_TOKENS(false);
+        const tokensWithAnUndefinedValue = {
+          ...tokens,
+          color: { ...tokens.color, primary: undefined },
         };
         const allTokens = [
-          transformedTokensWithUndefined.color.primary,
-          transformedTokensWithUndefined.color.red,
+          tokensWithAnUndefinedValue.color.primary,
+          tokensWithAnUndefinedValue.color.red,
         ];
 
-        const sorted = [...allTokens].sort(sortByReference(transformedTokensWithUndefined));
+        const sorted = [...allTokens].sort(sortByReference(tokensWithAnUndefinedValue));
 
         expect(sorted).to.eql([
-          transformedTokensWithUndefined.color.red,
-          transformedTokensWithUndefined.color.primary,
+          tokensWithAnUndefinedValue.color.red,
+          tokensWithAnUndefinedValue.color.primary,
         ]);
       });
       it('should keep order when idx1 is undefined', () => {
-        const transformedTokensWithUndefined = {
-          ...DEFAULT_TRANSFORMED_TOKENS,
-          color: { ...DEFAULT_TRANSFORMED_TOKENS.color, primary: undefined },
+        const tokens = TRANSFORMED_TOKENS(false);
+        const tokensWithUndefinedValue = {
+          ...tokens,
+          color: { ...tokens.color, primary: undefined },
         };
         const allTokens = [
-          transformedTokensWithUndefined.color.red,
-          transformedTokensWithUndefined.color.primary,
+          tokensWithUndefinedValue.color.red,
+          tokensWithUndefinedValue.color.primary,
         ];
 
-        const sorted = [...allTokens].sort(sortByReference(transformedTokensWithUndefined));
+        const sorted = [...allTokens].sort(sortByReference(tokensWithUndefinedValue));
 
         expect(sorted).to.eql([
-          transformedTokensWithUndefined.color.red,
-          transformedTokensWithUndefined.color.primary,
+          tokensWithUndefinedValue.color.red,
+          tokensWithUndefinedValue.color.primary,
         ]);
       });
     });

--- a/lib/common/formatHelpers/formattedVariables.js
+++ b/lib/common/formatHelpers/formattedVariables.js
@@ -80,7 +80,7 @@ export default function formattedVariables({
     // note: using the spread operator here so we get a new array rather than
     // mutating the original
     allTokens = [...allTokens].sort(
-      sortByReference(tokens, { unfilteredTokens: dictionary.unfilteredTokens }),
+      sortByReference(tokens, { unfilteredTokens: dictionary.unfilteredTokens, usesDtcg }),
     );
   }
 

--- a/lib/common/formatHelpers/sortByReference.js
+++ b/lib/common/formatHelpers/sortByReference.js
@@ -31,7 +31,7 @@ import { getReferences } from '../../utils/references/getReferences.js';
  * dictionary.allTokens.sort(sortByReference(dictionary))
  * ```
  * @param {Tokens} tokens
- * @param {{unfilteredTokens?: Tokens}} [opts]
+ * @param {{unfilteredTokens?: Tokens, usesDtcg?: boolean}} [opts]
  * @returns {(a: Token, b: Token) => number}
  */
 export default function sortByReference(tokens, opts) {
@@ -44,6 +44,7 @@ export default function sortByReference(tokens, opts) {
   function sorter(a, b) {
     const aComesFirst = -1;
     const bComesFirst = 1;
+    const valueKey = opts?.usesDtcg ? '$value' : 'value';
 
     // return early if a or b ar undefined
     if (typeof a === 'undefined') {
@@ -54,14 +55,14 @@ export default function sortByReference(tokens, opts) {
 
     // If token a uses a reference and token b doesn't, b might come before a
     // read on..
-    if (a.original && usesReferences(a.original.value)) {
+    if (a.original && usesReferences(a.original[valueKey])) {
       // Both a and b have references, we need to see if they reference each other
-      if (b.original && usesReferences(b.original.value)) {
-        const aRefs = getReferences(a.original.value, tokens, {
+      if (b.original && usesReferences(b.original[valueKey])) {
+        const aRefs = getReferences(a.original[valueKey], tokens, {
           unfilteredTokens: opts?.unfilteredTokens,
           warnImmediately: false,
         });
-        const bRefs = getReferences(b.original.value, tokens, {
+        const bRefs = getReferences(b.original[valueKey], tokens, {
           unfilteredTokens: opts?.unfilteredTokens,
           warnImmediately: false,
         });

--- a/lib/common/formatHelpers/sortByReference.js
+++ b/lib/common/formatHelpers/sortByReference.js
@@ -19,6 +19,9 @@ import { getReferences } from '../../utils/references/getReferences.js';
  * @typedef {import('../../../types/DesignToken.ts').TransformedToken} Token
  */
 
+const A_COMES_FIRST = -1;
+const B_COMES_FIRST = 1;
+
 /**
  * A function that returns a sorting function to be used with Array.sort that
  * will sort the allTokens array based on references. This is to make sure
@@ -34,64 +37,59 @@ import { getReferences } from '../../utils/references/getReferences.js';
  * @param {{unfilteredTokens?: Tokens, usesDtcg?: boolean}} [opts]
  * @returns {(a: Token, b: Token) => number}
  */
-export default function sortByReference(tokens, opts) {
+export default function sortByReference(tokens, { unfilteredTokens, usesDtcg } = {}) {
+  const valueKey = usesDtcg ? '$value' : 'value';
+
   /**
    * The sorter function is recursive to account for multiple levels of nesting
    * @param {Token} a
    * @param {Token} b
-   * @returns
+   * @returns {number}
    */
   function sorter(a, b) {
-    const aComesFirst = -1;
-    const bComesFirst = 1;
-    const valueKey = opts?.usesDtcg ? '$value' : 'value';
-
-    // return early if a or b ar undefined
     if (typeof a === 'undefined') {
-      return aComesFirst;
-    } else if (typeof b === 'undefined') {
-      return bComesFirst;
+      return A_COMES_FIRST;
+    }
+    if (typeof b === 'undefined') {
+      return B_COMES_FIRST;
     }
 
-    // If token a uses a reference and token b doesn't, b might come before a
-    // read on..
-    if (a.original && usesReferences(a.original[valueKey])) {
-      // Both a and b have references, we need to see if they reference each other
-      if (b.original && usesReferences(b.original[valueKey])) {
-        const aRefs = getReferences(a.original[valueKey], tokens, {
-          unfilteredTokens: opts?.unfilteredTokens,
-          warnImmediately: false,
-        });
-        const bRefs = getReferences(b.original[valueKey], tokens, {
-          unfilteredTokens: opts?.unfilteredTokens,
-          warnImmediately: false,
-        });
+    const aUsesRefs = a.original && usesReferences(a.original[valueKey]);
+    const bUsesRefs = b.original && usesReferences(b.original[valueKey]);
 
-        aRefs.forEach((aRef) => {
-          // a references b, we want b to come first
-          if (aRef.name === b.name) {
-            return bComesFirst;
-          }
-        });
+    // -----BOTH REFERENCE-----
+    if (aUsesRefs && bUsesRefs) {
+      // Collect references for 'a' and 'b'
+      const aRefs = getReferences(a.original[valueKey], tokens, {
+        unfilteredTokens,
+        warnImmediately: false,
+      });
+      const bRefs = getReferences(b.original[valueKey], tokens, {
+        unfilteredTokens,
+        warnImmediately: false,
+      });
 
-        bRefs.forEach((bRef) => {
-          // ditto but opposite
-          if (bRef.name === a.name) {
-            return aComesFirst;
-          }
-        });
-
-        // both a and b have references and don't reference each other
-        // we go further down the rabbit hole (reference chain)
-        return sorter(aRefs[0], bRefs[0]);
-      } else {
-        // a has a reference and b does not:
-        return bComesFirst;
+      // 'a' references 'b' -> 'b' should come first
+      if (aRefs.some((aRef) => aRef.name === b.name)) {
+        return B_COMES_FIRST;
       }
-      // a does not have a reference it should come first regardless if b has one
-    } else {
-      return aComesFirst;
+      // 'b' references 'a' -> 'a' should come first
+      if (bRefs.some((bRef) => bRef.name === a.name)) {
+        return A_COMES_FIRST;
+      }
+
+      // 'a' and 'b' reference, but not each other. Recurse to next level
+      return sorter(aRefs[0], bRefs[0]);
     }
+
+    // ----- ONLY ONE REFERENCES -----
+    // 'a' references, 'b' doesn't -> 'b' should come first
+    if (aUsesRefs) {
+      return B_COMES_FIRST;
+    }
+
+    // 'a' doesn't reference. It should come first regardless of 'b'
+    return A_COMES_FIRST;
   }
 
   return sorter;

--- a/lib/common/formats.js
+++ b/lib/common/formats.js
@@ -1190,7 +1190,7 @@ declare const ${moduleName}: ${JSON.stringify(treeWalker(dictionary.tokens), nul
 
     let sortedTokens;
     if (outputReferences) {
-      sortedTokens = [...allTokens].sort(sortByReference(tokens, { unfilteredTokens }));
+      sortedTokens = [...allTokens].sort(sortByReference(tokens, { unfilteredTokens, usesDtcg }));
     } else {
       sortedTokens = [...allTokens].sort(sortByName);
     }
@@ -1238,7 +1238,7 @@ declare const ${moduleName}: ${JSON.stringify(treeWalker(dictionary.tokens), nul
 
     let sortedTokens;
     if (outputReferences) {
-      sortedTokens = [...allTokens].sort(sortByReference(tokens, { unfilteredTokens }));
+      sortedTokens = [...allTokens].sort(sortByReference(tokens, { unfilteredTokens, usesDtcg }));
     } else {
       sortedTokens = [...allTokens].sort(sortByName);
     }
@@ -1297,7 +1297,7 @@ declare const ${moduleName}: ${JSON.stringify(treeWalker(dictionary.tokens), nul
 
     let sortedTokens;
     if (outputReferences) {
-      sortedTokens = [...allTokens].sort(sortByReference(tokens, { unfilteredTokens }));
+      sortedTokens = [...allTokens].sort(sortByReference(tokens, { unfilteredTokens, usesDtcg }));
     } else {
       sortedTokens = [...allTokens].sort(sortByName);
     }
@@ -1520,7 +1520,7 @@ declare const ${moduleName}: ${JSON.stringify(treeWalker(dictionary.tokens), nul
 
     let sortedTokens;
     if (outputReferences) {
-      sortedTokens = [...allTokens].sort(sortByReference(tokens, { unfilteredTokens }));
+      sortedTokens = [...allTokens].sort(sortByReference(tokens, { unfilteredTokens, usesDtcg }));
     } else {
       sortedTokens = [...allTokens].sort(sortByName);
     }


### PR DESCRIPTION
Fixes https://github.com/amzn/style-dictionary/issues/1305

**Issue Summary**:
The current implementation of the `sortByReference` function doesn't properly handle the DTCG token format, causing references in the output to be declared before their target. This occurs because the function assumes that token values can be accessed using the `value` attribute, which is not the case for the DTCG format, where the attribute is `$value`.

For example, this issue results in incorrect output like:
```scss
// Do not edit directly, this file was auto-generated.

$colors-primary: $colors-red;
$colors-red: #ff0000;
```
caused by:
```js
// -- sortByReference.js
function sortByReference(dictionary)
  function sorter(a, b) {
    // [...]
    // If token a uses a reference and token b doesn't, b might come before a
    // read on..
    if (a.original && dictionary.usesReference(a.original.value)) {
      // Both a and b have references, we need to see if the reference each other
      if (b.original && dictionary.usesReference(b.original.value)) {
        const aRefs = dictionary.getReferences(a.original.value);
        const bRefs = dictionary.getReferences(b.original.value);
    // [...]
  }
}
```

**Description of changes:**
This PR addresses the issue by modifying the `sortByReference` function to account for the `usesDtcg` options. It ensures that the correct token value is accessed based on the format (default or DTCG), preventing incorrect reference sorting.
```js
// -- sortByReference.js
// [...]
  const valueKey = usesDtcg ? '$value' : 'value';
// [...]
  const aUsesRefs = a.original && usesReferences(a.original[valueKey]);
  const bUsesRefs = b.original && usesReferences(b.original[valueKey]);
```

**Additional Changes:**
- Refactored the module to improve readability and follow clean code conventions.
- Inline comments where already used heavily, so I stuck to that practice and commented some lines.

**Checklist**
- [x] fix issue
- [x] add unit tests
- [x] add integration tests 
- [x] refactor code
 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
