### PR TITLE
fix: use js extensions instead of ts in imports

### DIFF
--- a/docs/src/components/sd-playground.ts
+++ b/docs/src/components/sd-playground.ts
@@ -6,12 +6,12 @@ import '@shoelace-style/shoelace/dist/components/radio-button/radio-button.js';
 import '@shoelace-style/shoelace/dist/components/radio-group/radio-group.js';
 import '@shoelace-style/shoelace/dist/components/select/select.js';
 import '@shoelace-style/shoelace/dist/components/option/option.js';
-import { bundle } from '../utils/rollup-bundle.ts';
-import { changeLang, init, monaco } from '../monaco/monaco.ts';
-import { analyzeDependencies } from '../utils/analyzeDependencies.ts';
+import { bundle } from '../utils/rollup-bundle.js';
+import { changeLang, init, monaco } from '../monaco/monaco.js';
+import { analyzeDependencies } from '../utils/analyzeDependencies.js';
 import { downloadZIP } from '../../../lib/utils/downloadFile.js';
 import type SlRadioGroup from '@shoelace-style/shoelace/dist/components/radio-group/radio-group.js';
-import type { Config } from '../../../types/Config.ts';
+import type { Config } from '../../../types/Config.js';
 
 const defaults = {
   tokens: {

--- a/docs/src/monaco/monaco.ts
+++ b/docs/src/monaco/monaco.ts
@@ -1,6 +1,6 @@
 import type * as monacoType from 'monaco-editor';
-import darkTheme from './dark-theme';
-import githubTheme from './github-light-theme';
+import darkTheme from './dark-theme.js';
+import githubTheme from './github-light-theme.js';
 
 export let monaco: typeof monacoType;
 

--- a/docs/src/setup.ts
+++ b/docs/src/setup.ts
@@ -1,7 +1,7 @@
 import dark from '@shoelace-style/shoelace/dist/themes/dark.css?raw' assert { type: 'css' };
 import light from '@shoelace-style/shoelace/dist/themes/light.css?raw' assert { type: 'css' };
 import mermaid from 'mermaid';
-import { registeredComponents } from './components/sd-playground.ts';
+import { registeredComponents } from './components/sd-playground.js';
 
 type Theme = 'dark' | 'light';
 type EnhancedCSSSheet = CSSStyleSheet & { theme?: boolean };

--- a/docs/starlight-config.ts
+++ b/docs/starlight-config.ts
@@ -1,11 +1,9 @@
 import type { StarlightUserConfig } from '@astrojs/starlight/types';
-import starlightLinksValidator from 'starlight-links-validator'
-import { pluginLanguageClass } from './expressive-code-plugin-language-class.ts';
+import starlightLinksValidator from 'starlight-links-validator';
+import { pluginLanguageClass } from './expressive-code-plugin-language-class.js';
 
 export default {
-  plugins: [
-    starlightLinksValidator()
-  ],
+  plugins: [starlightLinksValidator()],
   expressiveCode: {
     plugins: [
       // Call the plugin initialization function inside the `plugins` array

--- a/lib/Register.js
+++ b/lib/Register.js
@@ -6,14 +6,14 @@ import filterBuiltins from './common/filters.js';
 import { deepmerge } from './utils/deepmerge.js';
 
 /**
- * @typedef {import('../types/File.ts').FileHeader} FileHeader
- * @typedef {import('../types/Parser.ts').Parser} Parser
- * @typedef {import('../types/Preprocessor.ts').Preprocessor} Preprocessor
- * @typedef {import('../types/Transform.ts').Transform} Transform
- * @typedef {import('../types/Filter.ts').Filter} Filter
- * @typedef {import('../types/Format.ts').Format} Format
- * @typedef {import('../types/Action.ts').Action} Action
- * @typedef {import('../types/Config.ts').Hooks} Hooks
+ * @typedef {import('../types/File.d.ts').FileHeader} FileHeader
+ * @typedef {import('../types/Parser.d.ts').Parser} Parser
+ * @typedef {import('../types/Preprocessor.d.ts').Preprocessor} Preprocessor
+ * @typedef {import('../types/Transform.d.ts').Transform} Transform
+ * @typedef {import('../types/Filter.d.ts').Filter} Filter
+ * @typedef {import('../types/Format.d.ts').Format} Format
+ * @typedef {import('../types/Action.d.ts').Action} Action
+ * @typedef {import('../types/Config.d.ts').Hooks} Hooks
  */
 
 /**

--- a/lib/StyleDictionary.js
+++ b/lib/StyleDictionary.js
@@ -42,20 +42,20 @@ import cleanActions from './cleanActions.js';
 import { isNode } from './utils/isNode.js';
 
 /**
- * @typedef {import('../types/Volume.ts').Volume} Volume
- * @typedef {import('../types/Config.ts').Config} Config
- * @typedef {import('../types/Config.ts').PlatformConfig} PlatformConfig
- * @typedef {import('../types/Config.ts').LogConfig} LogConfig
- * @typedef {import('../types/Config.ts').Expand} Expand
- * @typedef {import('../types/Config.ts').ExpandConfig} ExpandConfig
- * @typedef {import('../types/File.ts').File} File
- * @typedef {import('../types/Filter.ts').Filter} Filter
- * @typedef {import('../types/DesignToken.ts').DesignToken} Token
- * @typedef {import('../types/DesignToken.ts').TransformedToken} TransformedToken
- * @typedef {import('../types/DesignToken.ts').DesignTokens} Tokens
- * @typedef {import('../types/DesignToken.ts').PreprocessedTokens} PreprocessedTokens
- * @typedef {import('../types/DesignToken.ts').TransformedTokens} TransformedTokens
- * @typedef {import('../types/DesignToken.ts').Dictionary} Dictionary
+ * @typedef {import('../types/Volume.d.ts').Volume} Volume
+ * @typedef {import('../types/Config.d.ts').Config} Config
+ * @typedef {import('../types/Config.d.ts').PlatformConfig} PlatformConfig
+ * @typedef {import('../types/Config.d.ts').LogConfig} LogConfig
+ * @typedef {import('../types/Config.d.ts').Expand} Expand
+ * @typedef {import('../types/Config.d.ts').ExpandConfig} ExpandConfig
+ * @typedef {import('../types/File.d.ts').File} File
+ * @typedef {import('../types/Filter.d.ts').Filter} Filter
+ * @typedef {import('../types/DesignToken.d.ts').DesignToken} Token
+ * @typedef {import('../types/DesignToken.d.ts').TransformedToken} TransformedToken
+ * @typedef {import('../types/DesignToken.d.ts').DesignTokens} Tokens
+ * @typedef {import('../types/DesignToken.d.ts').PreprocessedTokens} PreprocessedTokens
+ * @typedef {import('../types/DesignToken.d.ts').TransformedTokens} TransformedTokens
+ * @typedef {import('../types/DesignToken.d.ts').Dictionary} Dictionary
  */
 
 const PROPERTY_VALUE_COLLISIONS = GroupMessages.GROUP.PropertyValueCollisions;

--- a/lib/cleanActions.js
+++ b/lib/cleanActions.js
@@ -13,10 +13,10 @@
 import { fs } from 'style-dictionary/fs';
 
 /**
- * @typedef {import('../types/Volume.ts').Volume} Volume
- * @typedef {import('../types/DesignToken.ts').Dictionary} Dictionary
- * @typedef {import('../types/Config.ts').PlatformConfig} PlatformConfig
- * @typedef {import('../types/Config.ts').Config} Config
+ * @typedef {import('../types/Volume.d.ts').Volume} Volume
+ * @typedef {import('../types/DesignToken.d.ts').Dictionary} Dictionary
+ * @typedef {import('../types/Config.d.ts').PlatformConfig} PlatformConfig
+ * @typedef {import('../types/Config.d.ts').Config} Config
  */
 
 /**

--- a/lib/cleanDir.js
+++ b/lib/cleanDir.js
@@ -16,9 +16,9 @@ import { dirname } from 'path-unified';
 import { fs } from 'style-dictionary/fs';
 
 /**
- * @typedef {import('../types/Volume.ts').Volume} Volume
- * @typedef {import('../types/Config.ts').PlatformConfig} Config
- * @typedef {import('../types/File.ts').File} File
+ * @typedef {import('../types/Volume.d.ts').Volume} Volume
+ * @typedef {import('../types/Config.d.ts').PlatformConfig} Config
+ * @typedef {import('../types/File.d.ts').File} File
  */
 
 /**

--- a/lib/cleanDirs.js
+++ b/lib/cleanDirs.js
@@ -14,8 +14,8 @@
 import cleanDir from './cleanDir.js';
 
 /**
- * @typedef {import('../types/Volume.ts').Volume} Volume
- * @typedef {import('../types/Config.ts').PlatformConfig} Config
+ * @typedef {import('../types/Volume.d.ts').Volume} Volume
+ * @typedef {import('../types/Config.d.ts').PlatformConfig} Config
  */
 
 /**

--- a/lib/cleanFile.js
+++ b/lib/cleanFile.js
@@ -15,9 +15,9 @@ import chalk from 'chalk';
 import { fs } from 'style-dictionary/fs';
 
 /**
- * @typedef {import('../types/Volume.ts').Volume} Volume
- * @typedef {import('../types/File.ts').File} File
- * @typedef {import('../types/Config.ts').PlatformConfig} PlatformConfig
+ * @typedef {import('../types/Volume.d.ts').Volume} Volume
+ * @typedef {import('../types/File.d.ts').File} File
+ * @typedef {import('../types/Config.d.ts').PlatformConfig} PlatformConfig
  */
 
 /**

--- a/lib/cleanFiles.js
+++ b/lib/cleanFiles.js
@@ -14,8 +14,8 @@
 import cleanFile from './cleanFile.js';
 
 /**
- * @typedef {import('../types/Volume.ts').Volume} Volume
- * @typedef {import('../types/Config.ts').PlatformConfig} PlatformConfig
+ * @typedef {import('../types/Volume.d.ts').Volume} Volume
+ * @typedef {import('../types/Config.d.ts').PlatformConfig} PlatformConfig
  */
 
 /**

--- a/lib/common/actions.js
+++ b/lib/common/actions.js
@@ -14,10 +14,10 @@
 import { fs } from 'style-dictionary/fs';
 
 /**
- * @typedef {import('../../types/DesignToken.ts').Dictionary} Dictionary
- * @typedef {import('../../types/Action.ts').Action} Action
+ * @typedef {import('../../types/DesignToken.d.ts').Dictionary} Dictionary
+ * @typedef {import('../../types/Action.d.ts').Action} Action
  * @typedef {import('../../types/Config.js').PlatformConfig} Config
- * @typedef {import('../../types/DesignToken.ts').TransformedToken} Token
+ * @typedef {import('../../types/DesignToken.d.ts').TransformedToken} Token
  */
 
 /**

--- a/lib/common/filters.js
+++ b/lib/common/filters.js
@@ -12,7 +12,7 @@
  */
 
 /**
- * @typedef {import('../../types/Filter.ts').Filter} Filter
+ * @typedef {import('../../types/Filter.d.ts').Filter} Filter
  */
 
 /**

--- a/lib/common/formatHelpers/createPropertyFormatter.js
+++ b/lib/common/formatHelpers/createPropertyFormatter.js
@@ -14,10 +14,10 @@ import { getReferences } from '../../utils/references/getReferences.js';
 import usesReferences from '../../utils/references/usesReferences.js';
 
 /**
- * @typedef {import('../../../types/DesignToken.ts').TransformedToken} TransformedToken
- * @typedef {import('../../../types/DesignToken.ts').Dictionary} Dictionary
- * @typedef {import('../../../types/File.ts').FormattingOptions} Formatting
- * @typedef {import('../../../types/Format.ts').OutputReferences} OutputReferences
+ * @typedef {import('../../../types/DesignToken.d.ts').TransformedToken} TransformedToken
+ * @typedef {import('../../../types/DesignToken.d.ts').Dictionary} Dictionary
+ * @typedef {import('../../../types/File.d.ts').FormattingOptions} Formatting
+ * @typedef {import('../../../types/Format.d.ts').OutputReferences} OutputReferences
  */
 
 /**
@@ -116,7 +116,7 @@ export function addComment(to_ret_token, comment, options) {
  * @param {Formatting} [options.formatting] - Custom formatting properties that define parts of a declaration line in code. The configurable strings are: `prefix`, `indentation`, `separator`, `suffix`, `lineSeparator`, `fileHeaderTimestamp`, `header`, `footer`, `commentStyle` and `commentPosition`. Those are used to generate a line like this: `${indentation}${prefix}${token.name}${separator} ${prop.value}${suffix}`. The remaining formatting options are used for the fileHeader helper.
  * @param {boolean} [options.themeable] [false] - Whether tokens should default to being themeable.
  * @param {boolean} [options.usesDtcg] [false] - Whether DTCG token syntax should be uses.
- * @returns {(token: import('../../../types/DesignToken.ts').TransformedToken) => string}
+ * @returns {(token: import('../../../types/DesignToken.d.ts').TransformedToken) => string}
  */
 export default function createPropertyFormatter({
   outputReferences = false,

--- a/lib/common/formatHelpers/fileHeader.js
+++ b/lib/common/formatHelpers/fileHeader.js
@@ -13,10 +13,10 @@
 
 /**
  *
- * @typedef {import('../../../types/File.ts').File} File
- * @typedef {import('../../../types/File.ts').FileHeader} FileHeader
- * @typedef {import('../../../types/File.ts').FormattingOptions} Formatting
- * @typedef {import('../../../types/Config.ts').Config} Config
+ * @typedef {import('../../../types/File.d.ts').File} File
+ * @typedef {import('../../../types/File.d.ts').FileHeader} FileHeader
+ * @typedef {import('../../../types/File.d.ts').FormattingOptions} Formatting
+ * @typedef {import('../../../types/Config.d.ts').Config} Config
  */
 
 const lineSeparator = `\n`;

--- a/lib/common/formatHelpers/formattedVariables.js
+++ b/lib/common/formatHelpers/formattedVariables.js
@@ -15,11 +15,11 @@ import createPropertyFormatter from './createPropertyFormatter.js';
 import sortByReference from './sortByReference.js';
 
 /**
- * @typedef {import('../../../types/DesignToken.ts').TransformedToken} Token
- * @typedef {import('../../../types/DesignToken.ts').TransformedTokens} Tokens
- * @typedef {import('../../../types/File.ts').FormattingOptions} Formatting
- * @typedef {import('../../../types/Format').OutputReferences} OutputReferences
- * @typedef {import('../../../types/DesignToken.ts').Dictionary} Dictionary
+ * @typedef {import('../../../types/DesignToken.d.ts').TransformedToken} Token
+ * @typedef {import('../../../types/DesignToken.d.ts').TransformedTokens} Tokens
+ * @typedef {import('../../../types/File.d.ts').FormattingOptions} Formatting
+ * @typedef {import('../../../types/Format.d.ts').OutputReferences} OutputReferences
+ * @typedef {import('../../../types/DesignToken.d.ts').Dictionary} Dictionary
  */
 
 const defaultFormatting = {

--- a/lib/common/formatHelpers/getTypeScriptType.js
+++ b/lib/common/formatHelpers/getTypeScriptType.js
@@ -12,8 +12,8 @@
  */
 
 /**
- * @typedef {import('../../../types/Config.ts').LocalOptions} Options
- * @typedef {import('../../../types/Config.ts').Config} Config
+ * @typedef {import('../../../types/Config.d.ts').LocalOptions} Options
+ * @typedef {import('../../../types/Config.d.ts').Config} Config
  */
 
 /**

--- a/lib/common/formatHelpers/iconsWithPrefix.js
+++ b/lib/common/formatHelpers/iconsWithPrefix.js
@@ -12,9 +12,9 @@
  */
 
 /**
- * @typedef {import('../../../types/DesignToken.ts').TransformedToken} Token
- * @typedef {import('../../../types/Config.ts').Config} Options
- * @typedef {import('../../../types/Config.ts').PlatformConfig} PlatformConfig
+ * @typedef {import('../../../types/DesignToken.d.ts').TransformedToken} Token
+ * @typedef {import('../../../types/Config.d.ts').Config} Options
+ * @typedef {import('../../../types/Config.d.ts').PlatformConfig} PlatformConfig
  */
 
 /**

--- a/lib/common/formatHelpers/minifyDictionary.js
+++ b/lib/common/formatHelpers/minifyDictionary.js
@@ -12,7 +12,7 @@
  */
 
 /**
- * @typedef {import('../../../types/DesignToken.ts').TransformedTokens} Tokens
+ * @typedef {import('../../../types/DesignToken.d.ts').TransformedTokens} Tokens
  */
 
 /**

--- a/lib/common/formatHelpers/setComposeObjectProperties.js
+++ b/lib/common/formatHelpers/setComposeObjectProperties.js
@@ -12,7 +12,7 @@
  */
 
 /**
- * @typedef {import('../../../types/Config.ts').LocalOptions} Options
+ * @typedef {import('../../../types/Config.d.ts').LocalOptions} Options
  */
 
 /**

--- a/lib/common/formatHelpers/setSwiftFileProperties.js
+++ b/lib/common/formatHelpers/setSwiftFileProperties.js
@@ -12,7 +12,7 @@
  */
 
 /**
- * @typedef {import('../../../types/Config.ts').LocalOptions} Options
+ * @typedef {import('../../../types/Config.d.ts').LocalOptions} Options
  */
 
 /**

--- a/lib/common/formatHelpers/sortByReference.js
+++ b/lib/common/formatHelpers/sortByReference.js
@@ -15,8 +15,8 @@ import usesReferences from '../../utils/references/usesReferences.js';
 import { getReferences } from '../../utils/references/getReferences.js';
 
 /**
- * @typedef {import('../../../types/DesignToken.ts').TransformedTokens} Tokens
- * @typedef {import('../../../types/DesignToken.ts').TransformedToken} Token
+ * @typedef {import('../../../types/DesignToken.d.ts').TransformedTokens} Tokens
+ * @typedef {import('../../../types/DesignToken.d.ts').TransformedToken} Token
  */
 
 const A_COMES_FIRST = -1;

--- a/lib/common/formats.js
+++ b/lib/common/formats.js
@@ -47,12 +47,12 @@ import macrosTemplate from './templates/ios/macros.template.js';
 import plistTemplate from './templates/ios/plist.template.js';
 
 /**
- * @typedef {import('../../types/Format.ts').Format} Format
- * @typedef {import('../../types/Format.ts').FormatFnArguments} FormatArgs
- * @typedef {import('../../types/File').FormattingOverrides} FormattingOverrides
- * @typedef {import('../../types/Format.ts').OutputReferences} OutputReferences
- * @typedef {import('../../types/DesignToken.ts').TransformedToken} Token
- * @typedef {import('../../types/DesignToken.ts').TransformedTokens} Tokens
+ * @typedef {import('../../types/Format.d.ts').Format} Format
+ * @typedef {import('../../types/Format.d.ts').FormatFnArguments} FormatArgs
+ * @typedef {import('../../types/File.d.ts').FormattingOverrides} FormattingOverrides
+ * @typedef {import('../../types/Format.d.ts').OutputReferences} OutputReferences
+ * @typedef {import('../../types/DesignToken.d.ts').TransformedToken} Token
+ * @typedef {import('../../types/DesignToken.d.ts').TransformedTokens} Tokens
  */
 
 /**
@@ -668,7 +668,7 @@ const formats = {
       return type;
     }
 
-    // TODO: find a browser+node compatible way to read from '../../types/DesignToken.ts'
+    // TODO: find a browser+node compatible way to read from '../../types/DesignToken.d.ts'
     const designTokenInterface = `interface DesignToken {
   ${options.usesDtcg ? '$' : ''}value?: any;
   ${options.usesDtcg ? '$' : ''}type?: string;

--- a/lib/common/templates/android/colors.template.js
+++ b/lib/common/templates/android/colors.template.js
@@ -1,7 +1,7 @@
 /**
- * @typedef {import('../../../../types/DesignToken.ts').Dictionary} Dictionary
- * @typedef {import('../../../../types/Config.ts').Config} Config
- * @typedef {import('../../../../types/Config.ts').LocalOptions} LocalOptions
+ * @typedef {import('../../../../types/DesignToken.d.ts').Dictionary} Dictionary
+ * @typedef {import('../../../../types/Config.d.ts').Config} Config
+ * @typedef {import('../../../../types/Config.d.ts').LocalOptions} LocalOptions
  */
 
 /**

--- a/lib/common/templates/android/dimens.template.js
+++ b/lib/common/templates/android/dimens.template.js
@@ -1,7 +1,7 @@
 /**
- * @typedef {import('../../../../types/DesignToken.ts').Dictionary} Dictionary
- * @typedef {import('../../../../types/Config.ts').Config} Config
- * @typedef {import('../../../../types/Config.ts').LocalOptions} LocalOptions
+ * @typedef {import('../../../../types/DesignToken.d.ts').Dictionary} Dictionary
+ * @typedef {import('../../../../types/Config.d.ts').Config} Config
+ * @typedef {import('../../../../types/Config.d.ts').LocalOptions} LocalOptions
  */
 
 /**

--- a/lib/common/templates/android/fontDimens.template.js
+++ b/lib/common/templates/android/fontDimens.template.js
@@ -1,7 +1,7 @@
 /**
- * @typedef {import('../../../../types/DesignToken.ts').Dictionary} Dictionary
- * @typedef {import('../../../../types/Config.ts').Config} Config
- * @typedef {import('../../../../types/Config.ts').LocalOptions} LocalOptions
+ * @typedef {import('../../../../types/DesignToken.d.ts').Dictionary} Dictionary
+ * @typedef {import('../../../../types/Config.d.ts').Config} Config
+ * @typedef {import('../../../../types/Config.d.ts').LocalOptions} LocalOptions
  */
 
 /**

--- a/lib/common/templates/android/integers.template.js
+++ b/lib/common/templates/android/integers.template.js
@@ -1,7 +1,7 @@
 /**
- * @typedef {import('../../../../types/DesignToken.ts').Dictionary} Dictionary
- * @typedef {import('../../../../types/Config.ts').Config} Config
- * @typedef {import('../../../../types/Config.ts').LocalOptions} LocalOptions
+ * @typedef {import('../../../../types/DesignToken.d.ts').Dictionary} Dictionary
+ * @typedef {import('../../../../types/Config.d.ts').Config} Config
+ * @typedef {import('../../../../types/Config.d.ts').LocalOptions} LocalOptions
  */
 
 /**

--- a/lib/common/templates/android/resources.template.js
+++ b/lib/common/templates/android/resources.template.js
@@ -14,12 +14,12 @@
 import { usesReferences, getReferences } from 'style-dictionary/utils';
 
 /**
- * @typedef {import('../../../../types/DesignToken.ts').Dictionary} Dictionary
- * @typedef {import('../../../../types/DesignToken.ts').TransformedToken} Token
- * @typedef {import('../../../../types/DesignToken.ts').TransformedTokens} Tokens
- * @typedef {import('../../../../types/File.ts').File} File
- * @typedef {import('../../../../types/Config.ts').Config} Config
- * @typedef {import('../../../../types/File.ts').FileHeader} FileHeader
+ * @typedef {import('../../../../types/DesignToken.d.ts').Dictionary} Dictionary
+ * @typedef {import('../../../../types/DesignToken.d.ts').TransformedToken} Token
+ * @typedef {import('../../../../types/DesignToken.d.ts').TransformedTokens} Tokens
+ * @typedef {import('../../../../types/File.d.ts').File} File
+ * @typedef {import('../../../../types/Config.d.ts').Config} Config
+ * @typedef {import('../../../../types/File.d.ts').FileHeader} FileHeader
  */
 
 /**

--- a/lib/common/templates/android/strings.template.js
+++ b/lib/common/templates/android/strings.template.js
@@ -1,7 +1,7 @@
 /**
- * @typedef {import('../../../../types/DesignToken.ts').Dictionary} Dictionary
- * @typedef {import('../../../../types/Config.ts').Config} Config
- * @typedef {import('../../../../types/Config.ts').LocalOptions} LocalOptions
+ * @typedef {import('../../../../types/DesignToken.d.ts').Dictionary} Dictionary
+ * @typedef {import('../../../../types/Config.d.ts').Config} Config
+ * @typedef {import('../../../../types/Config.d.ts').LocalOptions} LocalOptions
  */
 
 /**

--- a/lib/common/templates/compose/object.kt.template.js
+++ b/lib/common/templates/compose/object.kt.template.js
@@ -1,7 +1,7 @@
 /**
- * @typedef {import('../../../../types/DesignToken.ts').TransformedToken} TransformedToken
- * @typedef {import('../../../../types/Config.ts').Config} Config
- * @typedef {import('../../../../types/Config.ts').LocalOptions} LocalOptions
+ * @typedef {import('../../../../types/DesignToken.d.ts').TransformedToken} TransformedToken
+ * @typedef {import('../../../../types/Config.d.ts').Config} Config
+ * @typedef {import('../../../../types/Config.d.ts').LocalOptions} LocalOptions
  */
 
 /**

--- a/lib/common/templates/css/fonts.css.template.js
+++ b/lib/common/templates/css/fonts.css.template.js
@@ -1,5 +1,5 @@
 /**
- * @typedef {import('../../../../types/DesignToken.ts').TransformedTokens} TransformedTokens
+ * @typedef {import('../../../../types/DesignToken.d.ts').TransformedTokens} TransformedTokens
  * @param {TransformedTokens} tokens
  */
 export default (tokens) =>

--- a/lib/common/templates/flutter/class.dart.template.js
+++ b/lib/common/templates/flutter/class.dart.template.js
@@ -1,8 +1,8 @@
 /**
- * @typedef {import('../../../../types/DesignToken.ts').TransformedToken} TransformedToken
- * @typedef {import('../../../../types/Config.ts').Config} Config
- * @typedef {import('../../../../types/File.ts').File} File
- * @typedef {import('../../../../types/Config.ts').LocalOptions} LocalOptions
+ * @typedef {import('../../../../types/DesignToken.d.ts').TransformedToken} TransformedToken
+ * @typedef {import('../../../../types/Config.d.ts').Config} Config
+ * @typedef {import('../../../../types/File.d.ts').File} File
+ * @typedef {import('../../../../types/Config.d.ts').LocalOptions} LocalOptions
  */
 
 /**

--- a/lib/common/templates/ios-swift/any.swift.template.js
+++ b/lib/common/templates/ios-swift/any.swift.template.js
@@ -1,8 +1,8 @@
 /**
- * @typedef {import('../../../../types/DesignToken.ts').TransformedToken} TransformedToken
- * @typedef {import('../../../../types/Config.ts').Config} Config
- * @typedef {import('../../../../types/File.ts').File} File
- * @typedef {import('../../../../types/Config.ts').LocalOptions} LocalOptions
+ * @typedef {import('../../../../types/DesignToken.d.ts').TransformedToken} TransformedToken
+ * @typedef {import('../../../../types/Config.d.ts').Config} Config
+ * @typedef {import('../../../../types/File.d.ts').File} File
+ * @typedef {import('../../../../types/Config.d.ts').LocalOptions} LocalOptions
  */
 
 /**

--- a/lib/common/templates/ios/colors.h.template.js
+++ b/lib/common/templates/ios/colors.h.template.js
@@ -1,8 +1,8 @@
 /**
- * @typedef {import('../../../../types/DesignToken.ts').Dictionary} Dictionary
- * @typedef {import('../../../../types/File.ts').File} File
- * @typedef {import('../../../../types/Config.ts').Config} Config
- * @typedef {import('../../../../types/Config.ts').LocalOptions} LocalOptions
+ * @typedef {import('../../../../types/DesignToken.d.ts').Dictionary} Dictionary
+ * @typedef {import('../../../../types/File.d.ts').File} File
+ * @typedef {import('../../../../types/Config.d.ts').Config} Config
+ * @typedef {import('../../../../types/Config.d.ts').LocalOptions} LocalOptions
  */
 
 /**

--- a/lib/common/templates/ios/colors.m.template.js
+++ b/lib/common/templates/ios/colors.m.template.js
@@ -1,8 +1,8 @@
 /**
- * @typedef {import('../../../../types/DesignToken.ts').Dictionary} Dictionary
- * @typedef {import('../../../../types/Config.ts').Config} Config
- * @typedef {import('../../../../types/File.ts').File} File
- * @typedef {import('../../../../types/Config.ts').LocalOptions} LocalOptions
+ * @typedef {import('../../../../types/DesignToken.d.ts').Dictionary} Dictionary
+ * @typedef {import('../../../../types/Config.d.ts').Config} Config
+ * @typedef {import('../../../../types/File.d.ts').File} File
+ * @typedef {import('../../../../types/Config.d.ts').LocalOptions} LocalOptions
  */
 
 /**

--- a/lib/common/templates/ios/macros.template.js
+++ b/lib/common/templates/ios/macros.template.js
@@ -1,8 +1,8 @@
 /**
- * @typedef {import('../../../../types/DesignToken.ts').Dictionary} Dictionary
- * @typedef {import('../../../../types/File.ts').File} File
- * @typedef {import('../../../../types/Config.ts').Config} Config
- * @typedef {import('../../../../types/Config.ts').LocalOptions} LocalOptions
+ * @typedef {import('../../../../types/DesignToken.d.ts').Dictionary} Dictionary
+ * @typedef {import('../../../../types/File.d.ts').File} File
+ * @typedef {import('../../../../types/Config.d.ts').Config} Config
+ * @typedef {import('../../../../types/Config.d.ts').LocalOptions} LocalOptions
  */
 
 /**

--- a/lib/common/templates/ios/plist.template.js
+++ b/lib/common/templates/ios/plist.template.js
@@ -1,8 +1,8 @@
 /**
- * @typedef {import('../../../../types/DesignToken.ts').Dictionary} Dictionary
- * @typedef {import('../../../../types/DesignToken.ts').TransformedToken} TransformedToken
- * @typedef {import('../../../../types/Config.ts').Config} Config
- * @typedef {import('../../../../types/Config.ts').LocalOptions} LocalOptions
+ * @typedef {import('../../../../types/DesignToken.d.ts').Dictionary} Dictionary
+ * @typedef {import('../../../../types/DesignToken.d.ts').TransformedToken} TransformedToken
+ * @typedef {import('../../../../types/Config.d.ts').Config} Config
+ * @typedef {import('../../../../types/Config.d.ts').LocalOptions} LocalOptions
  */
 
 /**

--- a/lib/common/templates/ios/singleton.h.template.js
+++ b/lib/common/templates/ios/singleton.h.template.js
@@ -1,7 +1,7 @@
 /**
- * @typedef {import('../../../../types/File.ts').File} File
- * @typedef {import('../../../../types/Config.ts').Config} Config
- * @typedef {import('../../../../types/Config.ts').LocalOptions} LocalOptions
+ * @typedef {import('../../../../types/File.d.ts').File} File
+ * @typedef {import('../../../../types/Config.d.ts').Config} Config
+ * @typedef {import('../../../../types/Config.d.ts').LocalOptions} LocalOptions
  */
 
 /**

--- a/lib/common/templates/ios/singleton.m.template.js
+++ b/lib/common/templates/ios/singleton.m.template.js
@@ -1,10 +1,10 @@
 /**
- * @typedef {import('../../../../types/DesignToken.ts').Dictionary} Dictionary
- * @typedef {import('../../../../types/DesignToken.ts').TransformedTokens} TransformedTokens
- * @typedef {import('../../../../types/DesignToken.ts').TransformedToken} TransformedToken
- * @typedef {import('../../../../types/File.ts').File} File
- * @typedef {import('../../../../types/Config.ts').Config} Config
- * @typedef {import('../../../../types/Config.ts').LocalOptions} LocalOptions
+ * @typedef {import('../../../../types/DesignToken.d.ts').Dictionary} Dictionary
+ * @typedef {import('../../../../types/DesignToken.d.ts').TransformedTokens} TransformedTokens
+ * @typedef {import('../../../../types/DesignToken.d.ts').TransformedToken} TransformedToken
+ * @typedef {import('../../../../types/File.d.ts').File} File
+ * @typedef {import('../../../../types/Config.d.ts').Config} Config
+ * @typedef {import('../../../../types/Config.d.ts').LocalOptions} LocalOptions
  */
 
 /**

--- a/lib/common/templates/ios/static.h.template.js
+++ b/lib/common/templates/ios/static.h.template.js
@@ -1,8 +1,8 @@
 /**
- * @typedef {import('../../../../types/DesignToken.ts').Dictionary} Dictionary
- * @typedef {import('../../../../types/File.ts').File} File
- * @typedef {import('../../../../types/Config.ts').Config} Config
- * @typedef {import('../../../../types/Config.ts').LocalOptions} LocalOptions
+ * @typedef {import('../../../../types/DesignToken.d.ts').Dictionary} Dictionary
+ * @typedef {import('../../../../types/File.d.ts').File} File
+ * @typedef {import('../../../../types/Config.d.ts').Config} Config
+ * @typedef {import('../../../../types/Config.d.ts').LocalOptions} LocalOptions
  */
 
 /**

--- a/lib/common/templates/ios/static.m.template.js
+++ b/lib/common/templates/ios/static.m.template.js
@@ -1,8 +1,8 @@
 /**
- * @typedef {import('../../../../types/DesignToken.ts').Dictionary} Dictionary
- * @typedef {import('../../../../types/Config.ts').Config} Config
- * @typedef {import('../../../../types/File.ts').File} File
- * @typedef {import('../../../../types/Config.ts').LocalOptions} LocalOptions
+ * @typedef {import('../../../../types/DesignToken.d.ts').Dictionary} Dictionary
+ * @typedef {import('../../../../types/Config.d.ts').Config} Config
+ * @typedef {import('../../../../types/File.d.ts').File} File
+ * @typedef {import('../../../../types/Config.d.ts').LocalOptions} LocalOptions
  */
 
 /**

--- a/lib/common/templates/ios/strings.h.template.js
+++ b/lib/common/templates/ios/strings.h.template.js
@@ -1,8 +1,8 @@
 /**
- * @typedef {import('../../../../types/DesignToken.ts').Dictionary} Dictionary
- * @typedef {import('../../../../types/File.ts').File} File
- * @typedef {import('../../../../types/Config.ts').Config} Config
- * @typedef {import('../../../../types/Config.ts').LocalOptions} LocalOptions
+ * @typedef {import('../../../../types/DesignToken.d.ts').Dictionary} Dictionary
+ * @typedef {import('../../../../types/File.d.ts').File} File
+ * @typedef {import('../../../../types/Config.d.ts').Config} Config
+ * @typedef {import('../../../../types/Config.d.ts').LocalOptions} LocalOptions
  */
 
 /**

--- a/lib/common/templates/ios/strings.m.template.js
+++ b/lib/common/templates/ios/strings.m.template.js
@@ -1,9 +1,9 @@
 /**
- * @typedef {import('../../../../types/DesignToken.ts').Dictionary} Dictionary
- * @typedef {import('../../../../types/DesignToken.ts').TransformedToken} TransformedToken
- * @typedef {import('../../../../types/Config.ts').Config} Config
- * @typedef {import('../../../../types/File.ts').File} File
- * @typedef {import('../../../../types/Config.ts').LocalOptions} LocalOptions
+ * @typedef {import('../../../../types/DesignToken.d.ts').Dictionary} Dictionary
+ * @typedef {import('../../../../types/DesignToken.d.ts').TransformedToken} TransformedToken
+ * @typedef {import('../../../../types/Config.d.ts').Config} Config
+ * @typedef {import('../../../../types/File.d.ts').File} File
+ * @typedef {import('../../../../types/Config.d.ts').LocalOptions} LocalOptions
  */
 
 /**

--- a/lib/common/templates/scss/map-deep.template.js
+++ b/lib/common/templates/scss/map-deep.template.js
@@ -1,8 +1,8 @@
 /**
- * @typedef {import('../../../../types/DesignToken.ts').TransformedTokens} Tokens
- * @typedef {import('../../../../types/DesignToken.ts').Dictionary} Dictionary
- * @typedef {import('../../../../types/Config.ts').Config} Config
- * @typedef {import('../../../../types/Config.ts').LocalOptions} LocalOptions
+ * @typedef {import('../../../../types/DesignToken.d.ts').TransformedTokens} Tokens
+ * @typedef {import('../../../../types/DesignToken.d.ts').Dictionary} Dictionary
+ * @typedef {import('../../../../types/Config.d.ts').Config} Config
+ * @typedef {import('../../../../types/Config.d.ts').LocalOptions} LocalOptions
  */
 
 /**

--- a/lib/common/templates/scss/map-flat.template.js
+++ b/lib/common/templates/scss/map-flat.template.js
@@ -1,9 +1,9 @@
 import { addComment } from '../../formatHelpers/createPropertyFormatter.js';
 
 /**
- * @typedef {import('../../../../types/DesignToken.ts').TransformedToken} TransformedToken
- * @typedef {import('../../../../types/Config.ts').Config} Config
- * @typedef {import('../../../../types/Config.ts').LocalOptions} LocalOptions
+ * @typedef {import('../../../../types/DesignToken.d.ts').TransformedToken} TransformedToken
+ * @typedef {import('../../../../types/Config.d.ts').Config} Config
+ * @typedef {import('../../../../types/Config.d.ts').LocalOptions} LocalOptions
  */
 
 /**

--- a/lib/common/transforms.js
+++ b/lib/common/transforms.js
@@ -18,10 +18,10 @@ import convertToBase64 from '../utils/convertToBase64.js';
 import GroupMessages from '../utils/groupMessages.js';
 
 /**
- * @typedef {import('../../types/Transform.ts').Transform} Transform
- * @typedef {import('../../types/DesignToken.ts').TransformedToken} Token
- * @typedef {import('../../types/Config.ts').PlatformConfig} PlatformConfig
- * @typedef {import('../../types/Config.ts').Config} Config
+ * @typedef {import('../../types/Transform.d.ts').Transform} Transform
+ * @typedef {import('../../types/DesignToken.d.ts').TransformedToken} Token
+ * @typedef {import('../../types/Config.d.ts').PlatformConfig} PlatformConfig
+ * @typedef {import('../../types/Config.d.ts').Config} Config
  */
 
 const UNKNOWN_CSS_FONT_PROPS_WARNINGS = GroupMessages.GROUP.UnknownCSSFontProperties;

--- a/lib/filterTokens.js
+++ b/lib/filterTokens.js
@@ -13,11 +13,11 @@
 import isPlainObject from 'is-plain-obj';
 
 /**
- * @typedef {import('../types/DesignToken.ts').Dictionary} Dictionary
- * @typedef {import('../types/DesignToken.ts').TransformedTokens} Tokens
- * @typedef {import('../types/DesignToken.ts').TransformedToken} Token
- * @typedef {import('../types/Filter.ts').Filter} Filter
- * @typedef {import('../types/Config.ts').Config} Config
+ * @typedef {import('../types/DesignToken.d.ts').Dictionary} Dictionary
+ * @typedef {import('../types/DesignToken.d.ts').TransformedTokens} Tokens
+ * @typedef {import('../types/DesignToken.d.ts').TransformedToken} Token
+ * @typedef {import('../types/Filter.d.ts').Filter} Filter
+ * @typedef {import('../types/Config.d.ts').Config} Config
  */
 
 /**

--- a/lib/fs-node.js
+++ b/lib/fs-node.js
@@ -4,7 +4,7 @@ import { setFs as _setFs, fs } from './fs.js';
 _setFs(_fs, true);
 
 /**
- * @param {import('../types/Volume.ts').Volume} v
+ * @param {import('../types/Volume.d.ts').Volume} v
  */
 const setFs = (v) => {
   // TODO: add a custom test process that tests NodeJS env with memfs FS shim,

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1,7 +1,7 @@
 import memfs from '@bundled-es-modules/memfs';
 
 /**
- * @typedef {import('../types/Volume.ts').Volume} Volume
+ * @typedef {import('../types/Volume.d.ts').Volume} Volume
  */
 
 /**

--- a/lib/transform/config.js
+++ b/lib/transform/config.js
@@ -19,10 +19,10 @@ import chalk from 'chalk';
 
 /**
  * @typedef {import('../StyleDictionary.js').default} StyleDictionary
- * @typedef {import('../../types/Transform.ts').Transform} Transform
- * @typedef {import('../../types/File.ts').File} File
- * @typedef {import('../../types/Action.ts').Action} Action
- * @typedef {import('../../types/Config.ts').PlatformConfig} PlatformConfig
+ * @typedef {import('../../types/Transform.d.ts').Transform} Transform
+ * @typedef {import('../../types/File.d.ts').File} File
+ * @typedef {import('../../types/Action.d.ts').Action} Action
+ * @typedef {import('../../types/Config.d.ts').PlatformConfig} PlatformConfig
  */
 
 const MISSING_TRANSFORM_ERRORS = GroupMessages.GROUP.MissingRegisterTransformErrors;

--- a/lib/transform/object.js
+++ b/lib/transform/object.js
@@ -18,13 +18,13 @@ import transformToken from './token.js';
 import tokenSetup from './tokenSetup.js';
 
 /**
- * @typedef {import('../../types/Volume.ts').Volume} Volume
- * @typedef {import('../../types/DesignToken.ts').PreprocessedTokens} Tokens
- * @typedef {import('../../types/DesignToken.ts').TransformedTokens} TransformedTokens
- * @typedef {import('../../types/DesignToken.ts').DesignToken} Token
- * @typedef {import('../../types/DesignToken.ts').TransformedToken} TransformedToken
- * @typedef {import('../../types/Config.ts').PlatformConfig} PlatformConfig
- * @typedef {import('../../types/Config.ts').Config} Config
+ * @typedef {import('../../types/Volume.d.ts').Volume} Volume
+ * @typedef {import('../../types/DesignToken.d.ts').PreprocessedTokens} Tokens
+ * @typedef {import('../../types/DesignToken.d.ts').TransformedTokens} TransformedTokens
+ * @typedef {import('../../types/DesignToken.d.ts').DesignToken} Token
+ * @typedef {import('../../types/DesignToken.d.ts').TransformedToken} TransformedToken
+ * @typedef {import('../../types/Config.d.ts').PlatformConfig} PlatformConfig
+ * @typedef {import('../../types/Config.d.ts').Config} Config
  */
 
 /**

--- a/lib/transform/token.js
+++ b/lib/transform/token.js
@@ -14,12 +14,12 @@
 import usesReferences from '../utils/references/usesReferences.js';
 
 /**
- * @typedef {import('../../types/Volume.ts').Volume} Volume
- * @typedef {import('../../types/DesignToken.ts').TransformedToken} Token
- * @typedef {import('../../types/Config.ts').PlatformConfig} PlatformConfig
- * @typedef {import('../../types/Config.ts').Config} Config
- * @typedef {import('../../types/Transform.ts').Transform} Transform
- * @typedef {import('../../types/Transform.ts').NameTransform} NameTransform
+ * @typedef {import('../../types/Volume.d.ts').Volume} Volume
+ * @typedef {import('../../types/DesignToken.d.ts').TransformedToken} Token
+ * @typedef {import('../../types/Config.d.ts').PlatformConfig} PlatformConfig
+ * @typedef {import('../../types/Config.d.ts').Config} Config
+ * @typedef {import('../../types/Transform.d.ts').Transform} Transform
+ * @typedef {import('../../types/Transform.d.ts').NameTransform} NameTransform
  */
 
 /**

--- a/lib/transform/tokenSetup.js
+++ b/lib/transform/tokenSetup.js
@@ -14,8 +14,8 @@
 import isPlainObject from 'is-plain-obj';
 
 /**
- * @typedef {import('../../types/DesignToken.ts').DesignToken} Token
- * @typedef {import('../../types/DesignToken.ts').TransformedToken} TransformedToken
+ * @typedef {import('../../types/DesignToken.d.ts').DesignToken} Token
+ * @typedef {import('../../types/DesignToken.d.ts').TransformedToken} TransformedToken
  */
 
 /**

--- a/lib/utils/cleanActions.js
+++ b/lib/utils/cleanActions.js
@@ -13,16 +13,17 @@
 import { fs } from 'style-dictionary/fs';
 
 /**
- * @typedef {import('../types/Volume.d.ts').Volume} Volume
- * @typedef {import('../types/DesignToken.d.ts').Dictionary} Dictionary
- * @typedef {import('../types/Config.d.ts').PlatformConfig} PlatformConfig
- * @typedef {import('../types/Config.d.ts').Config} Config
+ * @typedef {import('../../types/Volume.d.ts').Volume} Volume
+ * @typedef {import('../../types/DesignToken.d.ts').Dictionary} Dictionary
+ * @typedef {import('../../types/Config.d.ts').PlatformConfig} PlatformConfig
+ * @typedef {import('../../types/Config.d.ts').Config} Config
  */
 
 /**
- * Performs any actions in a platform config. Pretty
+ * Performs the undo of any actions defined in a platform. Pretty
  * simple really. Actions should be an array of functions,
  * the calling function should map the functions accordingly.
+ * @static
  * @private
  * @memberof module:style-dictionary
  * @param {Dictionary} dictionary
@@ -30,12 +31,12 @@ import { fs } from 'style-dictionary/fs';
  * @param {Config} options
  * @param {Volume} [vol]
  */
-export default async function performActions(dictionary, platform, options, vol = fs) {
+export default async function cleanActions(dictionary, platform, options, vol = fs) {
   if (platform.actions) {
     return Promise.all(
       platform.actions.map((action) => {
-        if (typeof action !== 'string' && typeof action.do === 'function') {
-          return action.do(dictionary, platform, options, vol);
+        if (typeof action !== 'string' && typeof action.undo === 'function') {
+          return action.undo(dictionary, platform, options, vol);
         }
       }),
     );

--- a/lib/utils/combineJSON.js
+++ b/lib/utils/combineJSON.js
@@ -21,10 +21,10 @@ import { detectDtcgSyntax } from './detectDtcgSyntax.js';
 import { isNode } from './isNode.js';
 
 /**
- * @typedef {import('../../types/Volume.ts').Volume} Volume
- * @typedef {import('../../types/DesignToken.ts').DesignTokens} Tokens
- * @typedef {import('../../types/DesignToken.ts').DesignToken} Token
- * @typedef {import('../../types/Parser.ts').Parser} Parser
+ * @typedef {import('../../types/Volume.d.ts').Volume} Volume
+ * @typedef {import('../../types/DesignToken.d.ts').DesignTokens} Tokens
+ * @typedef {import('../../types/DesignToken.d.ts').DesignToken} Token
+ * @typedef {import('../../types/Parser.d.ts').Parser} Parser
  */
 
 /**

--- a/lib/utils/convertToBase64.js
+++ b/lib/utils/convertToBase64.js
@@ -39,7 +39,7 @@ function toBase64(buffer) {
 }
 
 /**
- * @typedef {import('../../types/Volume.ts').Volume} Volume
+ * @typedef {import('../../types/Volume.d.ts').Volume} Volume
  * Takes a file and converts it to a base64 string.
  * @private
  * @param {string} filePath - Path to the file you want base64'd

--- a/lib/utils/convertToDTCG.js
+++ b/lib/utils/convertToDTCG.js
@@ -11,8 +11,8 @@ import { fs } from 'style-dictionary/fs';
 
 /**
  * @typedef {import('@zip.js/zip.js').Entry} Entry
- * @typedef {import('../../types/DesignToken.ts').DesignToken} DesignToken
- * @typedef {import('../../types/DesignToken.ts').DesignTokens} DesignTokens
+ * @typedef {import('../../types/DesignToken.d.ts').DesignToken} DesignToken
+ * @typedef {import('../../types/DesignToken.d.ts').DesignTokens} DesignTokens
  */
 
 /**

--- a/lib/utils/createFormatArgs.js
+++ b/lib/utils/createFormatArgs.js
@@ -15,10 +15,10 @@ import deepExtend from './deepExtend.js';
 
 /**
  * @typedef {import('../../types/DesignToken.js').Dictionary} Dictionary
- * @typedef {import('../../types/Config.ts').PlatformConfig} PlatformConfig
- * @typedef {import('../../types/Config.ts').Config} Options
- * @typedef {import('../../types/File.ts').File} File
- * @typedef {import('../../types/Format.ts').FormatFnArguments} FormatFnArguments
+ * @typedef {import('../../types/Config.d.ts').PlatformConfig} PlatformConfig
+ * @typedef {import('../../types/Config.d.ts').Config} Options
+ * @typedef {import('../../types/File.d.ts').File} File
+ * @typedef {import('../../types/Format.d.ts').FormatFnArguments} FormatFnArguments
  *
 
 /**

--- a/lib/utils/deepExtend.js
+++ b/lib/utils/deepExtend.js
@@ -14,8 +14,8 @@
 import isPlainObject from 'is-plain-obj';
 
 /**
- * @typedef {import('../../types/DesignToken.ts').DesignTokens} Tokens
- * @typedef {import('../../types/DesignToken.ts').TransformedTokens} TransformedTokens
+ * @typedef {import('../../types/DesignToken.d.ts').DesignTokens} Tokens
+ * @typedef {import('../../types/DesignToken.d.ts').TransformedTokens} TransformedTokens
  */
 
 /**

--- a/lib/utils/expandObjectTokens.js
+++ b/lib/utils/expandObjectTokens.js
@@ -16,13 +16,13 @@ import { deepmerge } from './deepmerge.js';
 import isPlainObject from 'is-plain-obj';
 
 /**
- * @typedef {import('../../types/DesignToken.ts').DesignToken} DesignToken
- * @typedef {import('../../types/DesignToken.ts').PreprocessedTokens} PreprocessedTokens
- * @typedef {import('../../types/Config.ts').Expand} Expand
- * @typedef {import('../../types/Config.ts').ExpandConfig} ExpandConfig
- * @typedef {import('../../types/Config.ts').ExpandFilter} ExpandFilter
- * @typedef {import('../../types/Config.ts').Config} Config
- * @typedef {import('../../types/Config.ts').PlatformConfig} PlatformConfig
+ * @typedef {import('../../types/DesignToken.d.ts').DesignToken} DesignToken
+ * @typedef {import('../../types/DesignToken.d.ts').PreprocessedTokens} PreprocessedTokens
+ * @typedef {import('../../types/Config.d.ts').Expand} Expand
+ * @typedef {import('../../types/Config.d.ts').ExpandConfig} ExpandConfig
+ * @typedef {import('../../types/Config.d.ts').ExpandFilter} ExpandFilter
+ * @typedef {import('../../types/Config.d.ts').Config} Config
+ * @typedef {import('../../types/Config.d.ts').PlatformConfig} PlatformConfig
  */
 
 export const DTCGTypesMap = {

--- a/lib/utils/flattenTokens.js
+++ b/lib/utils/flattenTokens.js
@@ -14,8 +14,8 @@
 import isPlainObject from 'is-plain-obj';
 
 /**
- * @typedef {import('../../types/DesignToken.ts').TransformedTokens} Tokens
- * @typedef {import('../../types/DesignToken.ts').TransformedToken} Token
+ * @typedef {import('../../types/DesignToken.d.ts').TransformedTokens} Tokens
+ * @typedef {import('../../types/DesignToken.d.ts').TransformedToken} Token
  */
 
 /**

--- a/lib/utils/preprocess.js
+++ b/lib/utils/preprocess.js
@@ -12,10 +12,10 @@
  */
 
 /**
- * @typedef {import('../../types/DesignToken.ts').PreprocessedTokens} PreprocessedTokens
- * @typedef {import('../../types/Config.ts').Config} Config
- * @typedef {import('../../types/Config.ts').PlatformConfig} PlatformConfig
- * @typedef {import('../../types/Preprocessor.ts').Preprocessor} Preprocessor
+ * @typedef {import('../../types/DesignToken.d.ts').PreprocessedTokens} PreprocessedTokens
+ * @typedef {import('../../types/Config.d.ts').Config} Config
+ * @typedef {import('../../types/Config.d.ts').PlatformConfig} PlatformConfig
+ * @typedef {import('../../types/Preprocessor.d.ts').Preprocessor} Preprocessor
  */
 
 /**

--- a/lib/utils/references/createReferenceRegex.js
+++ b/lib/utils/references/createReferenceRegex.js
@@ -14,7 +14,7 @@
 import defaults from './defaults.js';
 
 /**
- * @typedef {import('../../../types/Config.ts').RegexOptions} RegexOptions
+ * @typedef {import('../../../types/Config.d.ts').RegexOptions} RegexOptions
  * @param {RegexOptions} opts
  * @returns {RegExp}
  */

--- a/lib/utils/references/defaults.js
+++ b/lib/utils/references/defaults.js
@@ -12,7 +12,7 @@
  */
 
 /**
- * @type {Omit<Required<import('../../../types/Config.ts').RegexOptions>, "regex">}
+ * @type {Omit<Required<import('../../../types/Config.d.ts').RegexOptions>, "regex">}
  */
 export default {
   opening_character: '{',

--- a/lib/utils/references/getName.js
+++ b/lib/utils/references/getName.js
@@ -16,7 +16,7 @@ import defaults from './defaults.js';
 /**
  * Returns the paths name be joining its parts with a given separator.
  *
- * @typedef {import('../../../types/Config.ts').RegexOptions} RegexOptions
+ * @typedef {import('../../../types/Config.d.ts').RegexOptions} RegexOptions
  *
  * @private
  * @param {string[]} path

--- a/lib/utils/references/getReferences.js
+++ b/lib/utils/references/getReferences.js
@@ -19,10 +19,10 @@ import defaults from './defaults.js';
 const FILTER_WARNINGS = GroupMessages.GROUP.FilteredOutputReferences;
 
 /**
- * @typedef {import('../../../types/Config.ts').GetReferencesOptions} GetReferencesOptions
+ * @typedef {import('../../../types/Config.d.ts').GetReferencesOptions} GetReferencesOptions
  * @typedef {import('../../StyleDictionary.js').default} Dictionary
- * @typedef {import('../../../types/DesignToken.ts').TransformedTokens} Tokens
- * @typedef {import('../../../types/DesignToken.ts').TransformedToken} Token
+ * @typedef {import('../../../types/DesignToken.d.ts').TransformedTokens} Tokens
+ * @typedef {import('../../../types/DesignToken.d.ts').TransformedToken} Token
  */
 
 /**

--- a/lib/utils/references/getValueByPath.js
+++ b/lib/utils/references/getValueByPath.js
@@ -12,8 +12,8 @@
  */
 
 /**
- * @typedef {import('../../../types/DesignToken.ts').TransformedTokens} Tokens
- * @typedef {import('../../../types/DesignToken.ts').TransformedToken} Token
+ * @typedef {import('../../../types/DesignToken.d.ts').TransformedTokens} Tokens
+ * @typedef {import('../../../types/DesignToken.d.ts').TransformedToken} Token
  * @param {string[]} path
  * @param {Tokens} tokensObj
  * @returns {Token|undefined}

--- a/lib/utils/references/outputReferencesFilter.js
+++ b/lib/utils/references/outputReferencesFilter.js
@@ -4,8 +4,8 @@ import { getReferences } from './getReferences.js';
 const FILTER_WARNINGS = GroupMessages.GROUP.FilteredOutputReferences;
 
 /**
- * @typedef {import('../../../types/DesignToken.ts').TransformedToken} TransformedToken
- * @typedef {import('../../../types/DesignToken.ts').Dictionary} Dictionary
+ * @typedef {import('../../../types/DesignToken.d.ts').TransformedToken} TransformedToken
+ * @typedef {import('../../../types/DesignToken.d.ts').Dictionary} Dictionary
  *
  * @param {TransformedToken} token
  * @param {{ dictionary: Dictionary, usesDtcg?: boolean }} dictionary

--- a/lib/utils/references/outputReferencesTransformed.js
+++ b/lib/utils/references/outputReferencesTransformed.js
@@ -1,8 +1,8 @@
 import { resolveReferences } from './resolveReferences.js';
 
 /**
- * @typedef {import('../../../types/DesignToken.ts').TransformedToken} TransformedToken
- * @typedef {import('../../../types/DesignToken.ts').Dictionary} Dictionary
+ * @typedef {import('../../../types/DesignToken.d.ts').TransformedToken} TransformedToken
+ * @typedef {import('../../../types/DesignToken.d.ts').Dictionary} Dictionary
  *
  * @param {TransformedToken} token
  * @param {{ dictionary: Dictionary, usesDtcg?: boolean }} dictionary

--- a/lib/utils/references/resolveReferences.js
+++ b/lib/utils/references/resolveReferences.js
@@ -22,10 +22,10 @@ import defaults from './defaults.js';
 const PROPERTY_REFERENCE_WARNINGS = GroupMessages.GROUP.PropertyReferenceWarnings;
 
 /**
- * @typedef {import('../../../types/Config.ts').ResolveReferencesOptions} RefOpts
- * @typedef {import('../../../types/Config.ts').ResolveReferencesOptionsInternal} RefOptsInternal
- * @typedef {import('../../../types/DesignToken.ts').PreprocessedTokens} Tokens
- * @typedef {import('../../../types/DesignToken.ts').DesignToken} Token
+ * @typedef {import('../../../types/Config.d.ts').ResolveReferencesOptions} RefOpts
+ * @typedef {import('../../../types/Config.d.ts').ResolveReferencesOptionsInternal} RefOptsInternal
+ * @typedef {import('../../../types/DesignToken.d.ts').PreprocessedTokens} Tokens
+ * @typedef {import('../../../types/DesignToken.d.ts').DesignToken} Token
  */
 
 /**

--- a/lib/utils/references/usesReferences.js
+++ b/lib/utils/references/usesReferences.js
@@ -14,7 +14,7 @@
 import createRegex from './createReferenceRegex.js';
 
 /**
- * @typedef {import('../../../types/Config.ts').RegexOptions} RegexOptions
+ * @typedef {import('../../../types/Config.d.ts').RegexOptions} RegexOptions
  * Checks if the value uses a value reference.
  * @memberof Dictionary
  * @param {string|any} value

--- a/lib/utils/resolveObject.js
+++ b/lib/utils/resolveObject.js
@@ -14,9 +14,9 @@ import createReferenceRegex from './references/createReferenceRegex.js';
 import { _resolveReferences } from './references/resolveReferences.js';
 
 /**
- * @typedef {import('../../types/DesignToken.ts').TransformedTokens} TransformedTokens
- * @typedef {import('../../types/DesignToken.ts').TransformedToken} TransformedToken
- * @typedef {import('../../types/Config.ts').RegexOptions} RegexOptions
+ * @typedef {import('../../types/DesignToken.d.ts').TransformedTokens} TransformedTokens
+ * @typedef {import('../../types/DesignToken.d.ts').TransformedToken} TransformedToken
+ * @typedef {import('../../types/Config.d.ts').RegexOptions} RegexOptions
  * @typedef {RegexOptions & {ignorePaths?: string[]; ignoreKeys?: string[]; usesDtcg?: boolean }} Options
  */
 

--- a/lib/utils/typeDtcgDelegate.js
+++ b/lib/utils/typeDtcgDelegate.js
@@ -1,9 +1,9 @@
 import isPlainObject from 'is-plain-obj';
 
 /**
- * @typedef {import('../../types/DesignToken.ts').DesignTokens} DesignTokens
- * @typedef {import('../../types/DesignToken.ts').DesignToken} DesignToken
- * @typedef {import('../../types/DesignToken.ts').PreprocessedTokens} PreprocessedTokens
+ * @typedef {import('../../types/DesignToken.d.ts').DesignTokens} DesignTokens
+ * @typedef {import('../../types/DesignToken.d.ts').DesignToken} DesignToken
+ * @typedef {import('../../types/DesignToken.d.ts').PreprocessedTokens} PreprocessedTokens
  */
 
 /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,8 +3,6 @@
     "target": "ESNext",
     "module": "ESNext",
     "moduleResolution": "Bundler",
-    // Allow importing TypeScript files using their native extension (.ts(x)).
-    "allowImportingTsExtensions": true,
     // Enable JSON imports.
     "resolveJsonModule": true,
     // Enforce the usage of type-only imports when needed, which helps avoiding bundling issues.

--- a/types/Action.ts
+++ b/types/Action.ts
@@ -11,9 +11,9 @@
  * and limitations under the License.
  */
 
-import type { Dictionary } from './DesignToken.ts';
-import type { PlatformConfig, Config } from './Config.ts';
-import type { Volume } from './Volume.ts';
+import type { Dictionary } from './DesignToken.js';
+import type { PlatformConfig, Config } from './Config.js';
+import type { Volume } from './Volume.js';
 
 export interface Action {
   name: string;

--- a/types/Config.ts
+++ b/types/Config.ts
@@ -11,14 +11,14 @@
  * and limitations under the License.
  */
 
-import type { DesignToken, DesignTokens, PreprocessedTokens } from './DesignToken.ts';
-import type { Filter } from './Filter.ts';
-import type { FileHeader, File, FormattingOverrides } from './File.ts';
-import type { Parser } from './Parser.ts';
-import type { Preprocessor } from './Preprocessor.ts';
-import type { Transform } from './Transform.ts';
-import type { Format, OutputReferences } from './Format.ts';
-import type { Action } from './Action.ts';
+import type { DesignToken, DesignTokens, PreprocessedTokens } from './DesignToken.js';
+import type { Filter } from './Filter.js';
+import type { FileHeader, File, FormattingOverrides } from './File.js';
+import type { Parser } from './Parser.js';
+import type { Preprocessor } from './Preprocessor.js';
+import type { Transform } from './Transform.js';
+import type { Format, OutputReferences } from './Format.js';
+import type { Action } from './Action.js';
 
 export interface Hooks {
   parsers?: Record<string, Omit<Parser, 'name'>>;

--- a/types/File.ts
+++ b/types/File.ts
@@ -1,7 +1,7 @@
-import type { TransformedToken } from './DesignToken.ts';
-import type { FormatFn } from './Format.ts';
-import type { LocalOptions, Config } from './Config.ts';
-import type { Filter } from './Filter.ts';
+import type { TransformedToken } from './DesignToken.js';
+import type { FormatFn } from './Format.js';
+import type { LocalOptions, Config } from './Config.js';
+import type { Filter } from './Filter.js';
 
 // Generally, overriding these would break most formats and are meant
 // for the FormattedVariables/createPropertyFormatter helpers,

--- a/types/Filter.ts
+++ b/types/Filter.ts
@@ -10,8 +10,8 @@
  * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
  * and limitations under the License.
  */
-import type { TransformedToken } from './DesignToken.ts';
-import type { Config } from './Config.ts';
+import type { TransformedToken } from './DesignToken.js';
+import type { Config } from './Config.js';
 
 export interface Filter {
   name: string;

--- a/types/Format.ts
+++ b/types/Format.ts
@@ -11,9 +11,9 @@
  * and limitations under the License.
  */
 
-import type { Dictionary, TransformedToken } from './DesignToken.ts';
-import type { File } from './File.ts';
-import type { LocalOptions, Config, PlatformConfig } from './Config.ts';
+import type { Dictionary, TransformedToken } from './DesignToken.js';
+import type { File } from './File.js';
+import type { LocalOptions, Config, PlatformConfig } from './Config.js';
 
 export interface FormatFnArguments {
   /**

--- a/types/Parser.ts
+++ b/types/Parser.ts
@@ -11,7 +11,7 @@
  * and limitations under the License.
  */
 
-import type { DesignTokens } from './DesignToken.ts';
+import type { DesignTokens } from './DesignToken.js';
 
 export interface ParserOptions {
   contents: string;

--- a/types/Preprocessor.ts
+++ b/types/Preprocessor.ts
@@ -11,8 +11,8 @@
  * and limitations under the License.
  */
 
-import type { PreprocessedTokens } from './DesignToken.ts';
-import type { Config, PlatformConfig } from './Config.ts';
+import type { PreprocessedTokens } from './DesignToken.js';
+import type { Config, PlatformConfig } from './Config.js';
 
 export type Preprocessor = {
   name: string;

--- a/types/Transform.ts
+++ b/types/Transform.ts
@@ -11,10 +11,10 @@
  * and limitations under the License.
  */
 
-import type { Filter } from './Filter.ts';
-import type { TransformedToken } from './DesignToken.ts';
-import type { PlatformConfig, Config } from './Config.ts';
-import type { Volume } from './Volume.ts';
+import type { Filter } from './Filter.js';
+import type { TransformedToken } from './DesignToken.js';
+import type { PlatformConfig, Config } from './Config.js';
+import type { Volume } from './Volume.js';
 
 interface BaseTransform<Type, Value> {
   name: string;

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,4 +1,4 @@
-export type { Action } from './Action.ts';
+export type { Action } from './Action.js';
 
 export type {
   PlatformConfig,
@@ -9,7 +9,7 @@ export type {
   ExpandFilter,
   Expand,
   ExpandConfig,
-} from './Config.ts';
+} from './Config.js';
 
 export type {
   DesignToken,
@@ -18,18 +18,18 @@ export type {
   TransformedToken,
   TransformedTokens,
   Dictionary,
-} from './DesignToken.ts';
+} from './DesignToken.js';
 
-export type { FileHeader, File, FormattingOptions } from './File.ts';
+export type { FileHeader, File, FormattingOptions } from './File.js';
 
-export type { Filter } from './Filter.ts';
+export type { Filter } from './Filter.js';
 
-export type { Format, FormatFnArguments, FormatFn, OutputReferences } from './Format.ts';
+export type { Format, FormatFnArguments, FormatFn, OutputReferences } from './Format.js';
 
-export type { Parser, ParserOptions } from './Parser.ts';
+export type { Parser, ParserOptions } from './Parser.js';
 
-export type { Preprocessor } from './Preprocessor.ts';
+export type { Preprocessor } from './Preprocessor.js';
 
-export type { Transform, NameTransform, AttributeTransform, ValueTransform } from './Transform.ts';
+export type { Transform, NameTransform, AttributeTransform, ValueTransform } from './Transform.js';
 
-export type { Volume } from './Volume.ts';
+export type { Volume } from './Volume.js';


### PR DESCRIPTION
_Issue #, if available:_
closes https://github.com/amzn/style-dictionary/issues/1371

_Description of changes:_

Generally speaking TypeScript expects .js extensions for imports because the compiled output is .js. In the future TS might release a new feature allowing .ts extensions, but currently under NodeNext moduleResolution, .js is the way to go for files that actually compile to JS.

That said, in JSDocs annotated type-only imports we should use .d.ts extension because we only emit declaration files for these, so the compiled output is just .d.ts files.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
