### PR TITLE
chore: update release version script to bump pkg lock

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,8 @@ jobs:
           # This expects you to have a script called release which does a build for your packages and calls changeset publish
           publish: npm run release
           commit: 'chore: release'
+          # to ensure the lock file also gets bumped accordingly and added to the commit
+          version: 'npx changeset version && npm install'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "style-dictionary",
-  "version": "4.1.4",
+  "version": "4.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "style-dictionary",
-      "version": "4.1.4",
+      "version": "4.2.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {


### PR DESCRIPTION
_Description of changes:_

Will ensure that after bumping the version of the package.json, `npm install` is ran which will bump the package-lock.json versions accordingly, which will then be added to the changeset bot's release commit. This way pkg lock version stays in sync with pkg json.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
