### PR TITLE
fix: prettier imports star *

### DIFF
--- a/.changeset/hungry-carrots-protect.md
+++ b/.changeset/hungry-carrots-protect.md
@@ -1,0 +1,5 @@
+---
+'style-dictionary': patch
+---
+
+Fix Prettier imports, see https://prettier.io/docs/en/api#custom-parser-api-removed for more info.

--- a/lib/common/formats.js
+++ b/lib/common/formats.js
@@ -11,9 +11,9 @@
  * and limitations under the License.
  */
 import * as prettier from 'prettier/standalone';
-import prettierPluginBabel from 'prettier/plugins/babel';
-import prettierPluginEstree from 'prettier/plugins/estree';
-import prettierPluginTypescript from 'prettier/plugins/typescript';
+import * as prettierPluginBabel from 'prettier/plugins/babel';
+import * as prettierPluginEstree from 'prettier/plugins/estree';
+import * as prettierPluginTypescript from 'prettier/plugins/typescript';
 
 import {
   fileHeader,


### PR DESCRIPTION
_Issue #, if available:_
https://github.com/amzn/style-dictionary/issues/1393

_Description of changes:_
User mentioned Prettier imports don't work in their environment so I checked the docs and found that you are indeed supposed to import them using `import * as ...` syntax. This probably has better support than default import?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
