### PR TITLE
fix: no longer outputs refs for tokens that were originally not a string

### DIFF
--- a/.changeset/tame-pears-talk.md
+++ b/.changeset/tame-pears-talk.md
@@ -1,0 +1,5 @@
+---
+'style-dictionary': patch
+---
+
+Fix `outputReferencesTransformed` util, would return `true` for tokens which original values were not strings.

--- a/__integration__/__snapshots__/outputReferences.test.snap.js
+++ b/__integration__/__snapshots__/outputReferences.test.snap.js
@@ -1,7 +1,31 @@
 /* @web/test-runner snapshot v1 */
 export const snapshots = {};
 
-snapshots["integration output references should warn the user if filters out references briefly"] =
+snapshots["integration output references should allow using outputReferencesTransformed to not output refs when value has been transitively transformed"] = 
+`/**
+ * Do not edit directly, this file was auto-generated.
+ */
+
+:root {
+  --base: rgb(0,0,0);
+  --referred: rgba(0,0,0,0.12);
+}
+`;
+/* end snapshot integration output references should allow using outputReferencesTransformed to not output refs when value has been transitively transformed */
+
+snapshots["integration output references should support outputReferencesTransformed for values that were originally objects"] = 
+`/**
+ * Do not edit directly, this file was auto-generated.
+ */
+
+:root {
+  --axis-0: 0;
+  --shadow: innerShadow 0 0 0 0 rgba(0,0,0,0.4);
+}
+`;
+/* end snapshot integration output references should support outputReferencesTransformed for values that were originally objects */
+
+snapshots["integration output references should warn the user if filters out references briefly"] = 
 `⚠️ __integration__/build/filteredVariables.css
 While building filteredVariables.css, filtered out token references were found; output may be unexpected. Ignore this warning if intentional.
 
@@ -9,7 +33,13 @@ Use log.verbosity "verbose" or use CLI option --verbose for more details.
 Refer to: https://styledictionary.com/reference/logging/`;
 /* end snapshot integration output references should warn the user if filters out references briefly */
 
-snapshots["integration output references should warn the user if filters out references with a detailed message when using verbose logging"] =
+snapshots["integration output references should not warn the user if filters out references is prevented with outputReferencesFilter"] = 
+`
+css
+✔︎ __integration__/build/filteredVariables.css`;
+/* end snapshot integration output references should not warn the user if filters out references is prevented with outputReferencesFilter */
+
+snapshots["integration output references should warn the user if filters out references with a detailed message when using verbose logging"] = 
 `⚠️ __integration__/build/filteredVariables.css
 While building filteredVariables.css, filtered out token references were found; output may be unexpected. Ignore this warning if intentional.
 Here are the references that are used but not defined in the file:
@@ -22,24 +52,6 @@ color.core.green.0
 color.core.blue.0
 This is caused when combining a filter and \`outputReferences\`.`;
 /* end snapshot integration output references should warn the user if filters out references with a detailed message when using verbose logging */
-
-snapshots["integration output references should not warn the user if filters out references is prevented with outputReferencesFilter"] =
-`
-css
-✔︎ __integration__/build/filteredVariables.css`;
-/* end snapshot integration output references should not warn the user if filters out references is prevented with outputReferencesFilter */
-
-snapshots["integration output references should allow using outputReferencesTransformed to not output refs when value has been transitively transformed"] =
-`/**
- * Do not edit directly, this file was auto-generated.
- */
-
-:root {
-  --base: rgb(0,0,0);
-  --referred: rgba(0,0,0,0.12);
-}
-`;
-/* end snapshot integration output references should allow using outputReferencesTransformed to not output refs when value has been transitively transformed */
 
 snapshots["integration output references should properly reference tokens in dtcg format"] = 
 `/**

--- a/__integration__/outputReferences.test.js
+++ b/__integration__/outputReferences.test.js
@@ -86,6 +86,51 @@ describe('integration', async () => {
       await expect(output).to.matchSnapshot();
     });
 
+    it('should support outputReferencesTransformed for values that were originally objects', async () => {
+      restore();
+      const sd = new StyleDictionary({
+        tokens: {
+          axis: {
+            0: {
+              value: '0',
+              type: 'number',
+            },
+          },
+          shadow: {
+            value: {
+              x: '{axis.0}',
+              y: '{axis.0}',
+              blur: '{axis.0}',
+              spread: '{axis.0}',
+              color: 'rgba(0,0,0,0.4)',
+              type: 'innerShadow',
+            },
+            type: 'shadow',
+          },
+        },
+        platforms: {
+          css: {
+            transforms: ['shadow/css/shorthand', 'name/kebab'],
+            buildPath,
+            files: [
+              {
+                destination: 'transformedShadowVars.css',
+                format: 'css/variables',
+                options: {
+                  outputReferences: outputReferencesTransformed,
+                },
+              },
+            ],
+          },
+        },
+      });
+      await sd.buildAllPlatforms();
+      const output = fs.readFileSync(resolve(`${buildPath}transformedShadowVars.css`), {
+        encoding: 'UTF-8',
+      });
+      await expect(output).to.matchSnapshot();
+    });
+
     it('should warn the user if filters out references briefly', async () => {
       const sd = new StyleDictionary({
         // we are only testing showFileHeader options so we don't need

--- a/lib/utils/references/outputReferencesTransformed.js
+++ b/lib/utils/references/outputReferencesTransformed.js
@@ -26,5 +26,5 @@ export function outputReferencesTransformed(token, { dictionary, usesDtcg }) {
       })
     );
   }
-  return true;
+  return false;
 }


### PR DESCRIPTION


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
