### PR TITLE
refactor/es6 module test

### DIFF
--- a/__tests__/formats/javascriptEsm.test.js
+++ b/__tests__/formats/javascriptEsm.test.js
@@ -96,8 +96,6 @@ describe('formats', () => {
             file,
             platform: {},
           }),
-          {},
-          file,
         ),
       ).to.matchSnapshot();
     });
@@ -113,8 +111,6 @@ describe('formats', () => {
               stripMeta: true,
             },
           }),
-          {},
-          file,
         ),
       ).to.matchSnapshot();
     });
@@ -132,8 +128,6 @@ describe('formats', () => {
               },
             },
           }),
-          {},
-          file,
         ),
       ).to.matchSnapshot();
     });
@@ -151,8 +145,6 @@ describe('formats', () => {
               },
             },
           }),
-          {},
-          file,
         ),
       ).to.matchSnapshot();
     });
@@ -172,8 +164,6 @@ describe('formats', () => {
               stripMeta: true,
             },
           }),
-          {},
-          file,
         ),
       ).to.matchSnapshot();
     });

--- a/__tests__/formats/javascriptEsm.test.js
+++ b/__tests__/formats/javascriptEsm.test.js
@@ -155,7 +155,7 @@ describe('formats', () => {
           createFormatArgs({
             dictionary: {
               tokens: DTCGTokens,
-              allTokens: convertTokenData(tokens, { output: 'array', usesDtcg: true }),
+              allTokens: convertTokenData(DTCGTokens, { output: 'array', usesDtcg: true }),
             },
             file,
             platform: {},


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_

- removing of unused function properties within es6Module.test.js
- fix allTokens reference since current function returns an empty Array instead of `allTokens`
  - possible open for debate if fixing this is better than removing all occurrences of `allTokens: convertTokenData(DTCGTokens, { output: 'array' })` since it is not used by the formatter `javascript/esm`, thus the value of `allTokens` does not matter and tests do not fail.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
