### PR TITLE
fix(formats): handle DTCG-format tokens in typescript/es6-declarations

### DIFF
--- a/.changeset/beige-hounds-unite.md
+++ b/.changeset/beige-hounds-unite.md
@@ -1,0 +1,5 @@
+---
+'style-dictionary': patch
+---
+
+handle DTCG-format tokens in typescript/es6-declarations formatter

--- a/__tests__/formats/__snapshots__/typeScriptEs6Declarations.test.snap.js
+++ b/__tests__/formats/__snapshots__/typeScriptEs6Declarations.test.snap.js
@@ -12,3 +12,36 @@ export const fontFamily: '"Source Sans Pro", Arial, sans-serif';
 `;
 /* end snapshot formats typescript/es6-declarations with outputStringLiterals should match snapshot */
 
+snapshots["formats typescript/es6-declarations without outputStringLiterals should match snapshot"] = 
+`/**
+ * Do not edit directly, this file was auto-generated.
+ */
+
+/** Used for errors */
+export const colorRed: string;
+export const fontFamily: string;
+`;
+/* end snapshot formats typescript/es6-declarations without outputStringLiterals should match snapshot */
+
+snapshots["formats typescript/es6-declarations with DTCG tokens and outputStringLiterals should match snapshot"] = 
+`/**
+ * Do not edit directly, this file was auto-generated.
+ */
+
+/** Used for errors */
+export const colorRed: "#FF0000";
+export const fontFamily: '"Source Sans Pro", Arial, sans-serif';
+`;
+/* end snapshot formats typescript/es6-declarations with DTCG tokens and outputStringLiterals should match snapshot */
+
+snapshots["formats typescript/es6-declarations with DTCG tokens and without outputStringLiterals should match snapshot"] = 
+`/**
+ * Do not edit directly, this file was auto-generated.
+ */
+
+/** Used for errors */
+export const colorRed: string;
+export const fontFamily: string;
+`;
+/* end snapshot formats typescript/es6-declarations with DTCG tokens and without outputStringLiterals should match snapshot */
+

--- a/lib/common/formats.js
+++ b/lib/common/formats.js
@@ -730,22 +730,23 @@ const formats = {
       formatting: getFormattingCloneWithoutPrefix(formatting),
       options,
     });
-    const content =
-      header +
-      dictionary.allTokens
-        .map(function (token) {
-          let to_ret_token = '';
-          if (token.comment) to_ret_token += '/** ' + token.comment + ' */\n';
-          to_ret_token +=
-            'export const ' +
-            token.name +
-            ' : ' +
-            getTypeScriptType(options.usesDtcg ? token.$value : token.value, options) +
-            ';';
-          return to_ret_token;
-        })
-        .join('\n') +
-      '\n';
+    const content = [
+      header,
+      dictionary.allTokens.map((token) => {
+        const typescriptType = getTypeScriptType(
+          options.usesDtcg ? token.$value : token.value,
+          options,
+        );
+        const comment = options.usesDtcg ? token.$description : token.comment;
+
+        return [
+          `${comment ? `/** ${comment} */` : ''}`,
+          `export const ${token.name} : ${typescriptType};`,
+        ].join('\n');
+      }),
+    ]
+      .flat()
+      .join('');
     return formatJS(content, true);
   },
 


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_

the current "typescript/es6-declarations" formatter does not handle DTCG formatted tokens, namely the `comment` or `$description` attribute of a token respectively.

- add functionality to handle comment and $description
- update tests
  - add additional tests for `outputStringLiterals = false`
- update snapshots

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
