### PR TITLE
docs: fix remToDp matcher type in documentation

### DIFF
--- a/docs/src/content/docs/reference/Hooks/Transforms/predefined.md
+++ b/docs/src/content/docs/reference/Hooks/Transforms/predefined.md
@@ -415,7 +415,7 @@ Transforms the value from a REM size on web into a scale-independent pixel (sp) 
 Transforms the value from a REM size on web into a density-independent pixel (dp) value for font sizes in Compose. It WILL scale the number by a factor of 16 (or the value of `basePxFontSize` on the platform in your config).
 
 ```kotlin
-// Matches: token.type === 'fontSize'
+// Matches: token.type === 'dimension'
 // Returns:
 "16.0.dp"
 ```


### PR DESCRIPTION
_Issue #, if available:_
fixes https://github.com/amzn/style-dictionary/issues/1413

_Description of changes:_
This PR updates the documentation for `size/compose/remToDp` to reflect the correct matcher type.
- Changed `Matches: token.type === 'isFontSize'` to `Matches: token.type === 'isDimension'`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
