### PR TITLE
docs(format/flutter): document `className` option for `flutter/class.dart` format

### DIFF
--- a/docs/src/content/docs/reference/Hooks/Formats/predefined.md
+++ b/docs/src/content/docs/reference/Hooks/Formats/predefined.md
@@ -1007,6 +1007,7 @@ Creates a Dart implementation file of a class with values
 | -------------------------- | ------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `options.showFileHeader`   | `boolean`                             | Whether or not to include a comment that has the build date. Defaults to `true`                                                                                                                                                    |
 | `options.outputReferences` | `boolean \| OutputReferencesFunction` | Whether or not to keep [references](/reference/hooks/formats#references-in-output-files) (a -> b -> c) in the output. Defaults to `false`. Also allows passing a function to conditionally output references on a per token basis. |
+| `options.className`        | `string`                              | The name of the generated Dart Class                                                                                                                                                                                               |
 
 Example:
 

--- a/lib/common/formats.js
+++ b/lib/common/formats.js
@@ -1655,6 +1655,7 @@ declare const ${moduleName}: ${JSON.stringify(treeWalker(dictionary.tokens), nul
    * @typedef {Object} flutterClassOpts
    * @property {boolean} [flutterClassOpts.showFileHeader=true] - Whether or not to include a comment that has the build date
    * @property {OutputReferences} [flutterClassOpts.outputReferences=false] - Whether or not to keep [references](/#/formats?id=references-in-output-files) (a -> b -> c) in the output.
+   * @property {String} [flutterClassOpts.className] - The name of the generated Dart Class
    * @param {FormatArgs & { options?: flutterClassOpts }} options
    * @example
    * ```dart


### PR DESCRIPTION
**_Issue #, if available:_**

Resolves #1417

**_Description of changes:_**

This PR adds documentation for the `className` option, which can be applied when using the `flutter/class.dart` format;

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
