### PR TITLE
fix the format which does not handle newline in the comment.

### DIFF
--- a/lib/common/formats.js
+++ b/lib/common/formats.js
@@ -640,7 +640,12 @@ const formats = {
         const comment = options.usesDtcg ? token.$description : token.comment;
         const to_ret = `export const ${token.name} = ${value};`;
 
-        return comment ? to_ret.concat(`// ${comment}`) : to_ret;
+        if(comment){
+          //Sanitizing comment by escaping problematic comments.
+          const sanitizedComment = comment
+            .replace(/\n/g, ' ') //replace newline comments with spaces.                       
+            .replace(/\*\//g, '*\\/'); //Escape "*/" to prevent premature block closure.
+          return `${to_ret} /* ${sanitizedComment} */`;
       }),
     ]
       .flat()


### PR DESCRIPTION
_Issue #1420 

_Description of changes:_ My approach will sanitize the comments by:
1. Escaping any occurrences of `*/` to prevent premature block closure using `.replace(/\*\//g, '*\\/')`.
2. Replacing newline characters (`\n`) with spaces to ensure the comment remains on a single line using `.replace(/\n/g, ' ')`.
This ensures generated code is valid and comments are readable without formatting issues.

I'm open to suggestions if there's a preferred way to handle this. Looking forward to your guidance!


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
