### PR TITLE
fix: fix sizeRem not transforming negative values

### DIFF
--- a/.changeset/cool-bears-glow.md
+++ b/.changeset/cool-bears-glow.md
@@ -1,0 +1,5 @@
+---
+'style-dictionary': patch
+---
+
+Fix sizeRem to allow negative values

--- a/__tests__/common/transforms.test.js
+++ b/__tests__/common/transforms.test.js
@@ -790,6 +790,16 @@ describe('common', () => {
         );
         expect(value).to.equal('10px');
       });
+      it('should work for negative values', () => {
+        const value = transforms[sizePx].transform(
+          {
+            value: '-10',
+          },
+          {},
+          {},
+        );
+        expect(value).to.equal('-10px');
+      });
       it('should throw an error if prop value is Nan', () => {
         expect(() => transforms[sizeDp].transform({ value: 'a' }, {}, {})).to.throw();
       });
@@ -956,6 +966,46 @@ describe('common', () => {
           {},
         );
         expect(value).to.equal('1rem');
+      });
+      it('should work for negative values with unit', () => {
+        const value = transforms[sizeRem].transform(
+          {
+            value: '-1rem',
+          },
+          {},
+          {},
+        );
+        expect(value).to.equal('-1rem');
+      });
+      it('should work for negative values', () => {
+        const value = transforms[sizeRem].transform(
+          {
+            value: '-1',
+          },
+          {},
+          {},
+        );
+        expect(value).to.equal('-1rem');
+      });
+      it('should work for positive values', () => {
+        const value = transforms[sizeRem].transform(
+          {
+            value: '+1',
+          },
+          {},
+          {},
+        );
+        expect(value).to.equal('1rem');
+      });
+      it('should work for floating values', () => {
+        const value = transforms[sizeRem].transform(
+          {
+            value: '.5',
+          },
+          {},
+          {},
+        );
+        expect(value).to.equal('0.5rem');
       });
       ['0', 0].forEach((value) => {
         it('zero value is returned without a unit and remains same type', () => {

--- a/lib/common/transforms.js
+++ b/lib/common/transforms.js
@@ -829,7 +829,7 @@ export default {
     transform: function (token, _, options) {
       const nonParsed = options.usesDtcg ? token.$value : token.value;
       // if the dimension already has a unit (non-digit / . period character)
-      if (`${nonParsed}`.match(/[^0-9.]/g)) {
+      if (`${nonParsed}`.match(/^[^0-9.-]+$/)) {
         return nonParsed;
       }
       const parsedVal = parseFloat(nonParsed);


### PR DESCRIPTION
_Issue #, if available:_
Fixes #1408 

_Description of changes:_
Updated sizeRem regex to also allow negative and positive values so that negative values can also be transformed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
