### PR TITLE
Update filters.md

### DIFF
--- a/docs/src/content/docs/reference/Hooks/filters.md
+++ b/docs/src/content/docs/reference/Hooks/filters.md
@@ -51,7 +51,7 @@ StyleDictionary.registerFilter(myFilter);
 export default {
   hooks: {
     filters: {
-      'my-filter': myFilter,
+      'my-filter': myFilter.filter,
     },
   },
   // ... the rest of the configuration


### PR DESCRIPTION
Fix typo when inlining filter hooks, the type signature is not the same as the filter register config parameter.

_Issue #, if available:_

_Description of changes:_

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
