### PR TITLE
fix(formats): fix misaligned comments in `typescript/es6-declarations`

### DIFF
--- a/.changeset/olive-lions-admire.md
+++ b/.changeset/olive-lions-admire.md
@@ -1,0 +1,5 @@
+---
+'style-dictionary': patch
+---
+
+fix misaligned comments in typescript/es6-declarations

--- a/__integration__/__snapshots__/w3c-forward-compat.test.snap.js
+++ b/__integration__/__snapshots__/w3c-forward-compat.test.snap.js
@@ -8,7 +8,7 @@ snapshots["integration DTCG draft spec forward compatibility should match snapsh
 
 :root {
   --colors-black-500: rgb(0, 0, 0);
-  --colors-black-dimension: 5px; /* Some description */
+  --colors-black-dimension: 5px; /** Some description */
   --colors-foo: rgb(0, 0, 0);
 }
 `;

--- a/__tests__/common/formatHelpers/__snapshots__/createPropertyFormatter.test.snap.js
+++ b/__tests__/common/formatHelpers/__snapshots__/createPropertyFormatter.test.snap.js
@@ -1,7 +1,7 @@
 /* @web/test-runner snapshot v1 */
 export const snapshots = {};
 snapshots["common formatHelpers createPropertyFormatter commentStyle should default to putting comment next to the output value 1"] = 
-`  --color-red: #FF0000; /* Foo bar qux */`;
+`  --color-red: #FF0000; /** Foo bar qux */`;
 /* end snapshot common formatHelpers createPropertyFormatter commentStyle should default to putting comment next to the output value 1 */
 
 snapshots["common formatHelpers createPropertyFormatter commentStyle should default to putting comment next to the output value 2"] = 
@@ -25,7 +25,7 @@ $color-blue: #0000FF;`;
 /* end snapshot common formatHelpers createPropertyFormatter commentStyle should default to putting comment next to the output value 4 */
 
 snapshots["common formatHelpers createPropertyFormatter commentStyle allows overriding formatting commentStyle 1"] = 
-`  /* Foo bar qux */
+`  /** Foo bar qux */
   --color-green: #00FF00;`;
 /* end snapshot common formatHelpers createPropertyFormatter commentStyle allows overriding formatting commentStyle 1 */
 
@@ -53,11 +53,11 @@ snapshots["common formatHelpers createPropertyFormatter commentStyle supports DT
 /* end snapshot common formatHelpers createPropertyFormatter commentStyle supports DTCG spec $description property for comments 3 */
 
 snapshots["common formatHelpers createPropertyFormatter DTCG supports DTCG spec $description property for comments 1"] = 
-`  --color-red: #FF0000; /* Foo bar qux red */`;
+`  --color-red: #FF0000; /** Foo bar qux red */`;
 /* end snapshot common formatHelpers createPropertyFormatter DTCG supports DTCG spec $description property for comments 1 */
 
 snapshots["common formatHelpers createPropertyFormatter DTCG supports DTCG spec $description property for comments 2"] = 
-`  --color-green: #00FF00; /* Foo bar qux green */`;
+`  --color-green: #00FF00; /** Foo bar qux green */`;
 /* end snapshot common formatHelpers createPropertyFormatter DTCG supports DTCG spec $description property for comments 2 */
 
 snapshots["common formatHelpers createPropertyFormatter DTCG supports DTCG spec $description property for comments 3"] = 

--- a/__tests__/formats/__snapshots__/all.test.snap.js
+++ b/__tests__/formats/__snapshots__/all.test.snap.js
@@ -7,7 +7,7 @@ snapshots["formats all should match css/variables snapshot"] =
  */
 
 :root {
-  --color_red: #FF0000; /* comment */
+  --color_red: #FF0000; /** comment */
 }
 `;
 /* end snapshot formats all should match css/variables snapshot */
@@ -19,7 +19,7 @@ snapshots["formats all should match css/variables snapshot with fileHeaderTimest
  */
 
 :root {
-  --color_red: #FF0000; /* comment */
+  --color_red: #FF0000; /** comment */
 }
 `;
 /* end snapshot formats all should match css/variables snapshot with fileHeaderTimestamp set */
@@ -1170,7 +1170,7 @@ snapshots["formats all should match ios-swift/class.swift snapshot"] =
 import UIKit
 
 public class {
-    public static let color_red = #FF0000 /* comment */
+    public static let color_red = #FF0000 /** comment */
 }`;
 /* end snapshot formats all should match ios-swift/class.swift snapshot */
 
@@ -1187,7 +1187,7 @@ snapshots["formats all should match ios-swift/class.swift snapshot with fileHead
 import UIKit
 
 public class {
-    public static let color_red = #FF0000 /* comment */
+    public static let color_red = #FF0000 /** comment */
 }`;
 /* end snapshot formats all should match ios-swift/class.swift snapshot with fileHeaderTimestamp set */
 
@@ -1203,7 +1203,7 @@ snapshots["formats all should match ios-swift/enum.swift snapshot"] =
 import UIKit
 
 public enum {
-    public static let color_red = #FF0000 /* comment */
+    public static let color_red = #FF0000 /** comment */
 }`;
 /* end snapshot formats all should match ios-swift/enum.swift snapshot */
 
@@ -1220,7 +1220,7 @@ snapshots["formats all should match ios-swift/enum.swift snapshot with fileHeade
 import UIKit
 
 public enum {
-    public static let color_red = #FF0000 /* comment */
+    public static let color_red = #FF0000 /** comment */
 }`;
 /* end snapshot formats all should match ios-swift/enum.swift snapshot with fileHeaderTimestamp set */
 
@@ -1236,7 +1236,7 @@ snapshots["formats all should match ios-swift/any.swift snapshot"] =
 import UIKit
 
 public class {
-    public static let color_red = #FF0000 /* comment */
+    public static let color_red = #FF0000 /** comment */
 }`;
 /* end snapshot formats all should match ios-swift/any.swift snapshot */
 
@@ -1253,7 +1253,7 @@ snapshots["formats all should match ios-swift/any.swift snapshot with fileHeader
 import UIKit
 
 public class {
-    public static let color_red = #FF0000 /* comment */
+    public static let color_red = #FF0000 /** comment */
 }`;
 /* end snapshot formats all should match ios-swift/any.swift snapshot with fileHeaderTimestamp set */
 
@@ -1424,7 +1424,7 @@ import 'dart:ui';
 class {
     ._();
 
-    static const color_red = #FF0000; /* comment */
+    static const color_red = #FF0000; /** comment */
 }`;
 /* end snapshot formats all should match flutter/class.dart snapshot */
 
@@ -1444,7 +1444,7 @@ import 'dart:ui';
 class {
     ._();
 
-    static const color_red = #FF0000; /* comment */
+    static const color_red = #FF0000; /** comment */
 }`;
 /* end snapshot formats all should match flutter/class.dart snapshot with fileHeaderTimestamp set */
 

--- a/__tests__/formats/__snapshots__/scssMaps.test.snap.js
+++ b/__tests__/formats/__snapshots__/scssMaps.test.snap.js
@@ -61,7 +61,7 @@ snapshots["should respect formatting options for scss/map-flat"] =
 $tokens: (
     'size-font-small': 12rem,
     'size-font-large': 18rem,
-    /* comment */
+    /** comment */
     'color-base-red': #ff0000,
     'color-white': #ffffff,
     'asset-icon-book': url("data:image/png;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9ImN1cnJlbnRDb2xvciIgc3Ryb2tlLXdpZHRoPSIyIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIGNsYXNzPSJmZWF0aGVyIGZlYXRoZXItYm9vayI+PHBhdGggZD0iTTQgMTkuNUEyLjUgMi41IDAgMCAxIDYuNSAxN0gyMCI+PC9wYXRoPjxwYXRoIGQ9Ik02LjUgMkgyMHYyMEg2LjVBMi41IDIuNSAwIDAgMSA0IDE5LjV2LTE1QTIuNSAyLjUgMCAwIDEgNi41IDJ6Ij48L3BhdGg+PC9zdmc+")
@@ -77,7 +77,7 @@ snapshots["should respect formatting options for scss/map-deep"] =
 
     $size-font-small: 12rem !default;
     $size-font-large: 18rem !default;
-    /* comment */
+    /** comment */
     $color-base-red: #ff0000 !default;
     $color-white: #ffffff !default;
     $asset-icon-book: url("data:image/png;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgdmlld0JveD0iMCAwIDI0IDI0IiBmaWxsPSJub25lIiBzdHJva2U9ImN1cnJlbnRDb2xvciIgc3Ryb2tlLXdpZHRoPSIyIiBzdHJva2UtbGluZWNhcD0icm91bmQiIHN0cm9rZS1saW5lam9pbj0icm91bmQiIGNsYXNzPSJmZWF0aGVyIGZlYXRoZXItYm9vayI+PHBhdGggZD0iTTQgMTkuNUEyLjUgMi41IDAgMCAxIDYuNSAxN0gyMCI+PC9wYXRoPjxwYXRoIGQ9Ik02LjUgMkgyMHYyMEg2LjVBMi41IDIuNSAwIDAgMSA0IDE5LjV2LTE1QTIuNSAyLjUgMCAwIDEgNi41IDJ6Ij48L3BhdGg+PC9zdmc+") !default;

--- a/__tests__/formats/__snapshots__/typeScriptEs6Declarations.test.snap.js
+++ b/__tests__/formats/__snapshots__/typeScriptEs6Declarations.test.snap.js
@@ -6,6 +6,7 @@ snapshots["formats typescript/es6-declarations with outputStringLiterals should 
  * Do not edit directly, this file was auto-generated.
  */
 
+export const colorBlue: "#0000FF";
 /** Used for errors */
 export const colorRed: "#FF0000";
 export const fontFamily: '"Source Sans Pro", Arial, sans-serif';
@@ -17,6 +18,7 @@ snapshots["formats typescript/es6-declarations without outputStringLiterals shou
  * Do not edit directly, this file was auto-generated.
  */
 
+export const colorBlue: string;
 /** Used for errors */
 export const colorRed: string;
 export const fontFamily: string;
@@ -28,6 +30,7 @@ snapshots["formats typescript/es6-declarations with DTCG tokens and outputString
  * Do not edit directly, this file was auto-generated.
  */
 
+export const colorBlue: "#0000FF";
 /** Used for errors */
 export const colorRed: "#FF0000";
 export const fontFamily: '"Source Sans Pro", Arial, sans-serif';
@@ -39,9 +42,21 @@ snapshots["formats typescript/es6-declarations with DTCG tokens and without outp
  * Do not edit directly, this file was auto-generated.
  */
 
+export const colorBlue: string;
 /** Used for errors */
 export const colorRed: string;
 export const fontFamily: string;
 `;
 /* end snapshot formats typescript/es6-declarations with DTCG tokens and without outputStringLiterals should match snapshot */
+
+snapshots["formats typescript/es6-declarations with formatted comment should match snapshot"] = 
+`/**
+ * Do not edit directly, this file was auto-generated.
+ */
+
+export const colorBlue: string; /** Used for errors */
+export const colorRed: string;
+export const fontFamily: string;
+`;
+/* end snapshot formats typescript/es6-declarations with formatted comment should match snapshot */
 

--- a/__tests__/formats/__snapshots__/typeScriptEs6Declarations.test.snap.js
+++ b/__tests__/formats/__snapshots__/typeScriptEs6Declarations.test.snap.js
@@ -49,14 +49,3 @@ export const fontFamily: string;
 `;
 /* end snapshot formats typescript/es6-declarations with DTCG tokens and without outputStringLiterals should match snapshot */
 
-snapshots["formats typescript/es6-declarations with formatted comment should match snapshot"] = 
-`/**
- * Do not edit directly, this file was auto-generated.
- */
-
-export const colorBlue: string; /** Used for errors */
-export const colorRed: string;
-export const fontFamily: string;
-`;
-/* end snapshot formats typescript/es6-declarations with formatted comment should match snapshot */
-

--- a/__tests__/formats/typeScriptEs6Declarations.test.js
+++ b/__tests__/formats/typeScriptEs6Declarations.test.js
@@ -13,7 +13,7 @@
 import { expect } from 'chai';
 import formats from '../../lib/common/formats.js';
 import createFormatArgs from '../../lib/utils/createFormatArgs.js';
-import { convertTokenData } from '../../lib/utils/convertTokenData.js';
+import { convertTokenData } from '../../lib/utils/index.js';
 import { formats as fileFormats } from '../../lib/enums/index.js';
 
 const { typescriptEs6Declarations } = fileFormats;
@@ -25,6 +25,10 @@ const file = {
 
 const tokens = {
   color: {
+    blue: {
+      name: 'colorBlue',
+      value: '#0000FF',
+    },
     red: {
       comment: 'Used for errors',
       name: 'colorRed',
@@ -41,6 +45,11 @@ const tokens = {
 
 const DTCGTokens = {
   color: {
+    blue: {
+      $type: 'color',
+      $value: '#0000FF',
+      name: 'colorBlue',
+    },
     red: {
       $description: 'Used for errors',
       $type: 'color',

--- a/__tests__/formats/typeScriptEs6Declarations.test.js
+++ b/__tests__/formats/typeScriptEs6Declarations.test.js
@@ -13,7 +13,7 @@
 import { expect } from 'chai';
 import formats from '../../lib/common/formats.js';
 import createFormatArgs from '../../lib/utils/createFormatArgs.js';
-import { convertTokenData } from '../../lib/utils/index.js';
+import { convertTokenData } from '../../lib/utils/convertTokenData.js';
 import { formats as fileFormats } from '../../lib/enums/index.js';
 
 const { typescriptEs6Declarations } = fileFormats;

--- a/lib/common/formatHelpers/createPropertyFormatter.js
+++ b/lib/common/formatHelpers/createPropertyFormatter.js
@@ -76,7 +76,7 @@ export function addComment(to_ret_token, comment, options) {
         );
         processedComment += `${indentation} */`;
       } else {
-        processedComment = `${commentPosition === above ? indentation : ''}/* ${comment} */`;
+        processedComment = `${commentPosition === above ? indentation : ''}/** ${comment} */`;
       }
       break;
   }

--- a/lib/common/formats.js
+++ b/lib/common/formats.js
@@ -750,12 +750,10 @@ const formats = {
         const comment = options.usesDtcg ? token.$description : token.comment;
         const to_ret = `export const ${token.name} : ${typescriptType};`;
         const format = {
-          indentation: '',
-          ...formatting,
-
-          // position and style are enforced to match TypeScript declaration file emitting
           commentPosition: above,
           commentStyle: long,
+          indentation: '',
+          ...formatting,
         };
 
         return comment ? addComment(to_ret, comment, format) : to_ret;

--- a/lib/common/formats.js
+++ b/lib/common/formats.js
@@ -53,6 +53,7 @@ import scssMapFlatTemplate from './templates/scss/map-flat.template.js';
 import macrosTemplate from './templates/ios/macros.template.js';
 import plistTemplate from './templates/ios/plist.template.js';
 import {
+  commentPositions,
   commentStyles,
   fileHeaderCommentStyles,
   formats as fileFormats,
@@ -72,6 +73,7 @@ import { addComment } from './formatHelpers/createPropertyFormatter.js';
  * @typedef {import('../utils/stripMeta.js').StripMetaOptions} StripMetaOptions
  */
 
+const { above } = commentPositions;
 const { none } = commentStyles;
 const { long, short, xml } = fileHeaderCommentStyles;
 const { css, sass, less, stylus } = propertyFormatNames;
@@ -746,15 +748,21 @@ const formats = {
           options,
         );
         const comment = options.usesDtcg ? token.$description : token.comment;
+        const to_ret = `export const ${token.name} : ${typescriptType};`;
+        const format = {
+          indentation: '',
+          ...formatting,
 
-        return [
-          `${comment ? `/** ${comment} */` : ''}`,
-          `export const ${token.name} : ${typescriptType};`,
-        ].join('\n');
+          // position and style are enforced to match TypeScript declaration file emitting
+          commentPosition: above,
+          commentStyle: long,
+        };
+
+        return comment ? addComment(to_ret, comment, format) : to_ret;
       }),
     ]
       .flat()
-      .join('');
+      .join('\n');
     return formatJS(content, true);
   },
 


### PR DESCRIPTION
**Related Issue:** #1466

## Summary

Ensures `addComment` places TS declaration file comments in JSDoc format above their respective targets for proper annotation, aligning with TS-emitted declaration files.

### Notes

* This updates all long comments to start with `/**`
* enforces `long` + `above` formatting options in `typescript/es6-declarations` format to ensure JSDoc syntax

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.