### PR TITLE
fix: guaranteed order of preprocessor execution

### DIFF
--- a/.changeset/swift-buses-march.md
+++ b/.changeset/swift-buses-march.md
@@ -1,0 +1,5 @@
+---
+'style-dictionary': patch
+---
+
+If several preprocessors are defined in the SD configuration, the execution of the preprocessors is now guaranteed in the exact order in which they were configured in the SD configuration.

--- a/__tests__/utils/preprocess.test.js
+++ b/__tests__/utils/preprocess.test.js
@@ -64,5 +64,34 @@ describe('utils', () => {
         value: '5px',
       });
     });
+
+    it('should support asynchronous preprocessors in the order of the config array', async () => {
+      const output = await preprocess(
+        {
+          foo: {
+            value: '5px',
+          },
+        },
+        ['preprocessorA', 'preprocessorC', 'preprocessorB'],
+        {
+          preprocessorB: (tokens) => {
+            tokens.baz = tokens.qux;
+            return tokens;
+          },
+          preprocessorC: async (tokens) => {
+            await new Promise((resolve) => setTimeout(resolve, 100));
+            tokens.qux = tokens.bar;
+            return tokens;
+          },
+          preprocessorA: (tokens) => {
+            tokens.bar = tokens.foo;
+            return tokens;
+          },
+        },
+      );
+      expect(output).to.have.property('baz').eql({
+        value: '5px',
+      });
+    });
   });
 });

--- a/lib/utils/preprocess.js
+++ b/lib/utils/preprocess.js
@@ -38,8 +38,9 @@ export async function preprocess(
 
   const preprocessors = Object.entries(preprocessorObj);
   if (preprocessors.length > 0) {
-    for (const [key, preprocessor] of preprocessors) {
-      if (appliedPreprocessors.includes(key)) {
+    for (const key of appliedPreprocessors) {
+      const preprocessor = preprocessorObj[key];
+      if (preprocessor) {
         processedTokens = await preprocessor(processedTokens, options);
       }
     }


### PR DESCRIPTION
_Description of changes:_
Having multiple preprocessors defined in the SD config, did not guarantee the execution of the preprocessors in the exact order, how they have been configured in the SD config.

Technical reason behind that is, that it has been looped over the properties of a JS object, which had the respective preprocessor functions connected to the preprocessor names as the object properties. As we all know Javascript has a flaw, when it comes to ordering in JS objects.

Therefore we now rely on the right order, by looping over the preprocessor names in the `appliedPreprocessors` array parameter, which already has been available in the `preprocess` function.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
