### PR TITLE
Tranform.sizePX DTCG unit value object

### DIFF
--- a/__tests__/common/transforms.test.js
+++ b/__tests__/common/transforms.test.js
@@ -899,6 +899,32 @@ describe('common', () => {
         );
         expect(value).to.equal('-10px');
       });
+      it('should work with object values with unit', () => {
+        const value = transforms[sizePx].transform(
+          {
+            value: {
+              value: '24',
+              unit: 'px',
+            },
+          },
+          {},
+          {},
+        );
+        expect(value).to.equal('24px');
+      });
+      it('should work with object values with unit and negative value', () => {
+        const value = transforms[sizePx].transform(
+          {
+            value: {
+              value: '-24',
+              unit: 'px',
+            },
+          },
+          {},
+          {},
+        );
+        expect(value).to.equal('-24px');
+      });
       it('should throw an error if prop value is Nan', () => {
         expect(() => transforms[sizeDp].transform({ value: 'a' }, {}, {})).to.throw();
       });

--- a/lib/common/transforms.js
+++ b/lib/common/transforms.js
@@ -814,12 +814,36 @@ export default {
    */
   [transforms.sizePx]: {
     type: value,
-    filter: (token, options) => isDimension(token, options) || isFontSize(token, options),
+    filter: (token, options) => {
+      const rawValue = options.usesDtcg ? token.$value : token.value;
+      if (
+        typeof rawValue === 'object' &&
+        rawValue !== null &&
+        'value' in rawValue &&
+        'unit' in rawValue
+      ) {
+        return (
+          rawValue.unit === 'px' && (isDimension(token, options) || isFontSize(token, options))
+        );
+      }
+      return isDimension(token, options) || isFontSize(token, options);
+    },
     transform: function (token, _, options) {
-      const value = options.usesDtcg ? token.$value : token.value;
-      const parsedVal = parseFloat(value);
-      if (isNaN(parsedVal)) throwSizeError(token.name, value, 'px');
-      return parsedVal + 'px';
+      const rawValue = options.usesDtcg ? token.$value : token.value;
+      if (
+        typeof rawValue === 'object' &&
+        rawValue !== null &&
+        'value' in rawValue &&
+        'unit' in rawValue
+      ) {
+        const parsedVal = parseFloat(rawValue.value);
+        if (isNaN(parsedVal)) throwSizeError(token.name, rawValue.value, rawValue.unit || 'px');
+        return parsedVal + (rawValue.unit || 'px');
+      } else {
+        const parsedVal = parseFloat(rawValue);
+        if (isNaN(parsedVal)) throwSizeError(token.name, rawValue, 'px');
+        return parsedVal + 'px';
+      }
     },
   },
 


### PR DESCRIPTION
_Issue #1501_

_Description of changes:_

Add support for nested value unit object of the DTCG format in tranform.sizePX. 

```

value: {
       value: '24',
       unit: 'px',
},

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
