### PR TITLE
fix(types): add missing type definition for transform and format

### DIFF
--- a/types/Config.ts
+++ b/types/Config.ts
@@ -124,4 +124,6 @@ export interface Config {
   parsers?: string[];
   preprocessors?: string[];
   usesDtcg?: boolean;
+  transform?: Record<string, Transform>;
+  format?: Record<string, Format>;
 }


### PR DESCRIPTION
_Description of changes:_

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Add missing properties to the Config type: `transform` and `format` as shown in https://styledictionary.com/reference/config/