### PR TITLE
docs: fix layout issue

### DIFF
--- a/docs/src/styles.css
+++ b/docs/src/styles.css
@@ -39,10 +39,6 @@ table code {
   max-width: 900px;
 }
 
-a {
-  display: inline-block;
-}
-
 @media (min-width: 77rem) {
   [data-has-sidebar][data-has-toc] .main-pane {
     width: auto;


### PR DESCRIPTION
_Issue #, if available:_

_Description of changes:_ Setting `a` elements to `inline-block` was causing a layout issue in the header and link buttons. I've removed this style to restore proper display. I've reviewed each page and confirmed that no other issues have been introduced. (Apologies if there was a specific requirement for `inline-block`!)

| Before | After |
| --- | --- |
| <img width="1512" height="857" alt="Screenshot 2025-10-31 at 0 52 57" src="https://github.com/user-attachments/assets/64ec5119-6fe2-4ca3-8923-7bdbf1d4e2a7" /> | <img width="1512" height="857" alt="Screenshot 2025-10-31 at 0 54 15" src="https://github.com/user-attachments/assets/de65e2c2-ccb5-4c0e-9424-8baa95388f1f" /> |

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
