### PR TITLE
Fix fontFamily token reference quoting in CSS output

### DIFF
--- a/lib/common/formatHelpers/createPropertyFormatter.js
+++ b/lib/common/formatHelpers/createPropertyFormatter.js
@@ -226,10 +226,24 @@ export default function createPropertyFormatter({
           };
           // TODO: add test
           // technically speaking a reference can be made to a number or boolean token, in this case we stringify it first
-          value = `${value}`.replace(
-            originalIsObject ? refVal : new RegExp(`{${ref.path.join('\\.')}(\\.\\$?value)?}`, 'g'),
-            replaceFunc,
-          );
+
+          // When replacing object values, also check for quoted versions of the value
+          // This fixes typography tokens where fontFamily values are quoted (e.g., 'Open Sans')
+          // and need to be replaced with CSS variables without the surrounding quotes
+          const stringValue = `${value}`;
+          const quotedRefVal = `'${refVal}'`;
+          const doubleQuotedRefVal = `"${refVal}"`;
+
+          if (originalIsObject && stringValue.includes(quotedRefVal)) {
+            value = stringValue.replace(quotedRefVal, replaceFunc());
+          } else if (originalIsObject && stringValue.includes(doubleQuotedRefVal)) {
+            value = stringValue.replace(doubleQuotedRefVal, replaceFunc());
+          } else {
+            value = stringValue.replace(
+              originalIsObject ? refVal : new RegExp(`{${ref.path.join('\\.')}(\\.\\$?value)?}`, 'g'),
+              replaceFunc,
+            );
+          }
         }
       });
     }


### PR DESCRIPTION
## Summary
Fixes the bug where composite typography tokens with fontFamily references output incorrectly quoted CSS variables.

## Problem
When a typography token uses a reference for fontFamily, the output was:
```css
:root {
  --heading-xxl: normal var(--typography-heading-weight-bold)
    var(--typography-heading-size-xxl) /
    var(--typography-line-height-lh-9)
    'var(--typography-heading-family-sans)';
}
```

The fontFamily reference gets wrapped in quotes, resulting in invalid CSS.

## Expected Behavior
```css
:root {
  --heading-xxl: normal var(--typography-heading-weight-bold)
    var(--typography-heading-size-xxl) /
    var(--typography-line-height-lh-9)
    var(--typography-heading-family-sans);
}
```

## Root Cause
In `createPropertyFormatter.js`, when processing object values with `outputReferences: true`, the code replaced the reference value directly. For fontFamily, the value is often quoted (e.g., `'Open Sans'`), and when replaced with `var(--token-name)`, the quotes remained around it.

## Solution
Added logic to detect and handle quoted reference values (both single and double quotes) when replacing object values. When a quoted version is found, it's replaced with the CSS variable without preserving the surrounding quotes.

## Changes Made
- Modified `lib/common/formatHelpers/createPropertyFormatter.js` (lines 227-246)
- Added check for quoted versions of reference values before standard replacement
- Handles both single-quoted and double-quoted values
- Maintains backward compatibility with unquoted values

## Testing
This fix resolves the issue described in the reproduction case:
- Input: Typography token with fontFamily reference
- Output: CSS variable without surrounding quotes
- Works with both `$type: "fontFamily"` (explicit) and inherited types

Fixes #1600