### PR TITLE
chore: set up NPM trusted publisher and avoid access tokens

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+permissions:
+  id-token: write # Required for OIDC
+  contents: write # required for git tag push
+
 jobs:
   release:
     name: Release
@@ -32,4 +36,3 @@ jobs:
           version: 'npm run version'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Attempting to use NPM trusted publishers which is more secure and convenient than access tokens https://docs.npmjs.com/trusted-publishers

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
