### PR TITLE
fix: size error to throw Error instead of string

### DIFF
--- a/.changeset/fast-turkeys-allow.md
+++ b/.changeset/fast-turkeys-allow.md
@@ -1,0 +1,5 @@
+---
+'style-dictionary': patch
+---
+
+Fix of a regression bug caused by sizeRem transform throwing an error for NaN values. Because a string was thrown instead of an Error, this wasn't handled correctly by the transforms wrapper utility. Now we handle this scenario, and we also changed it to throw an actual Error.

--- a/__integration__/nameInOutput.test.js
+++ b/__integration__/nameInOutput.test.js
@@ -1,0 +1,36 @@
+import { expect } from 'chai';
+import StyleDictionary from 'style-dictionary';
+import { transformGroups } from '../lib/enums/index.js';
+
+describe(`integration`, async () => {
+  it('should support name transforms to still work even if another transform errors (sizeRem for "auto" value)', async () => {
+    const sd = new StyleDictionary({
+      hooks: {
+        formats: {
+          'in-memory': ({ dictionary }) => dictionary.allTokens,
+        },
+      },
+      tokens: {
+        spacing: {
+          breadcrumbs: {
+            separator: {
+              margin: { $value: 'auto', $type: 'dimension' },
+            },
+          },
+        },
+      },
+      platforms: {
+        css: {
+          transformGroup: transformGroups.css,
+          files: [
+            {
+              format: 'in-memory',
+            },
+          ],
+        },
+      },
+    });
+    const { css } = await sd.formatAllPlatforms();
+    expect(css[0].output[0].name).to.equal('spacing-breadcrumbs-separator-margin');
+  });
+});

--- a/__tests__/transform/transformToken.test.js
+++ b/__tests__/transform/transformToken.test.js
@@ -40,6 +40,30 @@ describe('transform', () => {
       expect(test).to.have.property('name', 'hello');
     });
 
+    it('can throw anything and handle gracefully', async () => {
+      const test = await transformToken(
+        { name: 'foo-bar', value: 'abc', path: ['foo', 'bar'], original: { value: 'abc' } },
+        {
+          transforms: [
+            {
+              type: transformTypeValue,
+              transform: function () {
+                return 'def';
+              },
+            },
+            {
+              type: transformTypeValue,
+              transform: function () {
+                throw 123;
+              },
+            },
+          ],
+        },
+        {},
+      );
+      expect(test).to.have.property('value', 'def');
+    });
+
     // This allows transformObject utility to then consider this token's transformation undefined and thus "deferred"
     it('returns a token as undefined if transitive transform dictates that the transformation has to be deferred', async () => {
       const result = await transformToken(

--- a/lib/common/transforms.js
+++ b/lib/common/transforms.js
@@ -105,7 +105,9 @@ function wrapValueWithDoubleQuote(token, options) {
  * @returns {string}
  */
 function throwSizeError(name, value, unitType) {
-  throw `Invalid Number: '${name}: ${value}' is not a valid number, cannot transform to '${unitType}' \n`;
+  throw new Error(
+    `Invalid Number: '${name}: ${value}' is not a valid number, cannot transform to '${unitType}' \n`,
+  );
 }
 
 /**

--- a/lib/transform/token.js
+++ b/lib/transform/token.js
@@ -46,20 +46,24 @@ async function _transformTokenWrapper(transform, token, config, options, vol) {
   try {
     to_ret = await transform.transform(token, config, options, vol);
   } catch (e) {
-    if (e instanceof Error) {
-      const transformError = createErrorMessage(token, e, transform.name, !!options?.usesDtcg);
-      // collect the errors so we can warn the user at the end of the run
-      GroupMessages.add(TRANSFORM_ERRORS, transformError);
+    const message = e instanceof Error ? e.message : String(e);
+    const transformError = createErrorMessage(
+      token,
+      e instanceof Error ? e : new Error(message),
+      transform.name,
+      !!options?.usesDtcg,
+    );
+    // collect the errors so we can warn the user at the end of the run
+    GroupMessages.add(TRANSFORM_ERRORS, transformError);
 
-      // Return a sensible fallback value
-      switch (transform.type) {
-        case 'attribute':
-          return token.attributes;
-        case 'name':
-          return token.name;
-        case 'value':
-          return options.usesDtcg ? token.$value : token.value;
-      }
+    // Return a sensible fallback value
+    switch (transform.type) {
+      case 'attribute':
+        return token.attributes;
+      case 'name':
+        return token.name;
+      case 'value':
+        return options.usesDtcg ? token.$value : token.value;
     }
   }
   return to_ret;


### PR DESCRIPTION
_Issue #, if available:_
https://github.com/style-dictionary/style-dictionary/issues/1618

This bug was caused by:
- ancient code throwing a string instead of an error, which is the root cause and a bug that's been there for many years
- transforms now handling errors thrown
- sizeRem throwing for NaN added recently in https://github.com/style-dictionary/style-dictionary/pull/1587

_Description of changes:_
- Properly handle if something other than an Error is thrown in transforms
- Throw an Error instead of string in the size transforms error thrower.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
