### PR TITLE
fix: resolve token collisions in basic example

### DIFF
--- a/examples/basic/tokens/object-values.json
+++ b/examples/basic/tokens/object-values.json
@@ -1,5 +1,5 @@
 {
-  "text": {
+  "composite-examples": {
     "typography": {
       "$type": "typography",
       "heading": {


### PR DESCRIPTION
## Summary

Running `style-dictionary init` with the basic template triggers 13 token collision warnings. Both `object-values.json` and `text.json` define tokens under the `text.typography` path.

## Fix

Moved the typography examples in `object-values.json` from `text.typography` to `composite-examples.typography`. The `text.json` file retains the canonical typography definitions. These typography tokens in `object-values.json` exist to demonstrate composite token types and aren't referenced by any other tokens.

## Verification

After the change, initializing a basic project produces zero collision warnings.

Fixes #1480

This contribution was developed with AI assistance (Claude Code).