### PR TITLE
feat: add emitEmptyFiles option to write files even when no tokens match

### DIFF
--- a/.changeset/emit-empty-files.md
+++ b/.changeset/emit-empty-files.md
@@ -1,0 +1,5 @@
+---
+"style-dictionary": minor
+---
+
+Add `emitEmptyFiles` option to write output files even when no tokens match the file's filter, instead of skipping them.

--- a/__integration__/android.test.js
+++ b/__integration__/android.test.js
@@ -11,6 +11,7 @@ const { android } = transformGroups;
 
 describe('integration', async () => {
   before(async () => {
+    clearOutput(buildPath);
     const sd = new StyleDictionary({
       source: [`__integration__/tokens/**/[!_]*.json?(c)`],
       platforms: {
@@ -43,7 +44,7 @@ describe('integration', async () => {
     await sd.buildAllPlatforms();
   });
 
-  afterEach(() => {
+  after(() => {
     clearOutput(buildPath);
   });
 

--- a/__integration__/async.test.js
+++ b/__integration__/async.test.js
@@ -15,12 +15,9 @@ const textFile = resolve(`${buildPath}text.txt`);
 
 // Tests all hooks async, into a single config
 describe('integration', async function () {
-  this.timeout(10000);
   before(async () => {
-    // so we don't accidentally create side-effects on the StyleDictionary class
-    // that will affect outputs of other tests.
+    clearOutput(buildPath);
     const SDExtension = class extends StyleDictionary {};
-
     SDExtension.registerParser({
       name: 'json-parser',
       pattern: /^.+\.json$/g,
@@ -118,11 +115,10 @@ describe('integration', async function () {
         },
       },
     });
-
     await sd.buildAllPlatforms();
   });
 
-  afterEach(() => {
+  after(() => {
     clearOutput(buildPath);
   });
 

--- a/__integration__/compose.test.js
+++ b/__integration__/compose.test.js
@@ -10,6 +10,7 @@ const { composeObject } = formats;
 
 describe('integration', async () => {
   before(async () => {
+    clearOutput(buildPath);
     const sd = new StyleDictionary({
       source: [`__integration__/tokens/**/[!_]*.json?(c)`],
       platforms: {
@@ -41,7 +42,7 @@ describe('integration', async () => {
     await sd.buildAllPlatforms();
   });
 
-  afterEach(() => {
+  after(() => {
     clearOutput(buildPath);
   });
 

--- a/__integration__/css.test.js
+++ b/__integration__/css.test.js
@@ -10,6 +10,7 @@ const { cssVariables } = formats;
 
 describe('integration', async () => {
   before(async () => {
+    clearOutput(buildPath);
     const sd = new StyleDictionary({
       source: [`__integration__/tokens/**/[!_]*.json?(c)`],
       // Testing proper string interpolation with multiple references here.
@@ -64,7 +65,7 @@ describe('integration', async () => {
     await sd.buildAllPlatforms();
   });
 
-  afterEach(() => {
+  after(() => {
     clearOutput(buildPath);
   });
 

--- a/__integration__/customFileHeader.test.js
+++ b/__integration__/customFileHeader.test.js
@@ -11,6 +11,7 @@ const { css, js } = transformGroups;
 
 describe(`integration`, async () => {
   before(async () => {
+    clearOutput(buildPath);
     // Adding a custom file header with the `.registerFileHeader`
     StyleDictionary.registerFileHeader({
       name: `valid custom file headers test fileHeader`,
@@ -95,11 +96,10 @@ describe(`integration`, async () => {
         },
       },
     });
-
     await sd.buildAllPlatforms();
   });
 
-  afterEach(() => {
+  after(() => {
     clearOutput(buildPath);
   });
 

--- a/__integration__/customFormats.test.js
+++ b/__integration__/customFormats.test.js
@@ -10,6 +10,7 @@ const { js } = transformGroups;
 
 describe('integration', async () => {
   before(async () => {
+    clearOutput(buildPath);
     const sd = new StyleDictionary({
       source: [`__integration__/tokens/size/padding.json`],
       // Adding formats directly to SD
@@ -75,11 +76,10 @@ describe('integration', async () => {
         return JSON.stringify(opts, null, 2);
       },
     });
-
     await sd.buildAllPlatforms();
   });
 
-  afterEach(() => {
+  after(() => {
     clearOutput(buildPath);
   });
 

--- a/__integration__/flutter.test.js
+++ b/__integration__/flutter.test.js
@@ -11,6 +11,7 @@ const { flutter, flutterSeparate } = transformGroups;
 
 describe('integration', async () => {
   before(async () => {
+    clearOutput(buildPath);
     const sd = new StyleDictionary({
       source: [`__integration__/tokens/**/[!_]*.json?(c)`],
       platforms: {
@@ -68,7 +69,7 @@ describe('integration', async () => {
     await sd.buildAllPlatforms();
   });
 
-  afterEach(() => {
+  after(() => {
     clearOutput(buildPath);
   });
 

--- a/__integration__/iOSObjectiveC.test.js
+++ b/__integration__/iOSObjectiveC.test.js
@@ -11,6 +11,7 @@ const { iosColorsH, iosColorsM, iosMacros, iosSingletonH, iosSingletonM, iosStat
 
 describe('integration', async () => {
   before(async () => {
+    clearOutput(buildPath);
     const sd = new StyleDictionary({
       source: [`__integration__/tokens/**/[!_]*.json?(c)`],
       platforms: {
@@ -79,7 +80,7 @@ describe('integration', async () => {
     await sd.buildAllPlatforms();
   });
 
-  afterEach(() => {
+  after(() => {
     clearOutput(buildPath);
   });
 

--- a/__integration__/objectValues.test.js
+++ b/__integration__/objectValues.test.js
@@ -12,6 +12,7 @@ const { value: transformTypeValue } = transformTypes;
 
 describe('integration', async () => {
   before(async () => {
+    clearOutput(buildPath);
     const options = {
       outputReferences: true,
     };
@@ -193,7 +194,7 @@ describe('integration', async () => {
     await sd.buildAllPlatforms();
   });
 
-  afterEach(() => {
+  after(() => {
     clearOutput(buildPath);
   });
 

--- a/__integration__/scss.test.js
+++ b/__integration__/scss.test.js
@@ -11,6 +11,7 @@ const { scssVariables, scssMapFlat, scssMapDeep } = formats;
 
 describe(`integration`, async () => {
   before(async () => {
+    clearOutput(buildPath);
     const sd = new StyleDictionary({
       source: [`__integration__/tokens/**/[!_]*.json?(c)`],
       platforms: {
@@ -81,7 +82,7 @@ describe(`integration`, async () => {
     await sd.buildAllPlatforms();
   });
 
-  afterEach(() => {
+  after(() => {
     clearOutput(buildPath);
   });
 

--- a/__integration__/showFileHeader.test.js
+++ b/__integration__/showFileHeader.test.js
@@ -11,6 +11,7 @@ const { css } = transformGroups;
 
 describe('integration', async () => {
   before(async () => {
+    clearOutput(buildPath);
     const sd = new StyleDictionary({
       // we are only testing showFileHeader options so we don't need
       // the full source.
@@ -58,7 +59,7 @@ describe('integration', async () => {
     await sd.buildAllPlatforms();
   });
 
-  afterEach(() => {
+  after(() => {
     clearOutput(buildPath);
   });
 

--- a/__integration__/swift.test.js
+++ b/__integration__/swift.test.js
@@ -10,6 +10,7 @@ const { iosSwiftClassSwift } = formats;
 
 describe('integration', async () => {
   before(async () => {
+    clearOutput(buildPath);
     const sd = new StyleDictionary({
       source: [`__integration__/tokens/**/[!_]*.json?(c)`],
       platforms: {
@@ -39,7 +40,7 @@ describe('integration', async () => {
     await sd.buildAllPlatforms();
   });
 
-  afterEach(() => {
+  after(() => {
     clearOutput(buildPath);
   });
 

--- a/__tests__/StyleDictionary.test.js
+++ b/__tests__/StyleDictionary.test.js
@@ -903,6 +903,73 @@ Refer to: https://styledictionary.com/reference/logging/
         expect(property.value).to.equal('bango');
       });
     });
+
+    it('should not write an empty-token file by default', async () => {
+      const sd = new StyleDictionary({
+        ...dictionary,
+        hooks,
+        platforms: {
+          foo: {
+            buildPath: '__tests__/__output/',
+            files: [
+              {
+                destination: 'test.json',
+                filter: () => false,
+                format: 'foo',
+              },
+            ],
+          },
+        },
+      });
+      await sd.buildPlatform('foo');
+      expect(fileExists('__tests__/__output/test.json')).to.be.false;
+    });
+
+    it('should write an empty-token file when emitEmptyFiles is enabled on the file', async () => {
+      const sd = new StyleDictionary({
+        ...dictionary,
+        hooks,
+        platforms: {
+          foo: {
+            buildPath: '__tests__/__output/',
+            files: [
+              {
+                destination: 'test.json',
+                filter: () => false,
+                format: 'foo',
+                emitEmptyFiles: true,
+              },
+            ],
+          },
+        },
+      });
+      await sd.buildPlatform('foo');
+      expect(fileExists('__tests__/__output/test.json')).to.be.true;
+      expect(fs.readFileSync(resolve('__tests__/__output/test.json'), 'utf-8')).to.equal('{}');
+    });
+
+    it('should write an empty-token file when emitEmptyFiles is enabled on the platform', async () => {
+      const sd = new StyleDictionary({
+        ...dictionary,
+        hooks,
+        platforms: {
+          foo: {
+            buildPath: '__tests__/__output/',
+            emitEmptyFiles: true,
+            files: [
+              {
+                destination: 'test.json',
+                filter: () => false,
+                format: 'foo',
+              },
+            ],
+          },
+        },
+      });
+      await sd.buildPlatform('foo');
+      expect(fileExists('__tests__/__output/test.json')).to.be.true;
+      expect(fs.readFileSync(resolve('__tests__/__output/test.json'), 'utf-8')).to.equal('{}');
+    });
   });
 
   describe('formatFile', () => {
@@ -987,31 +1054,30 @@ Refer to: https://styledictionary.com/reference/logging/
     });
 
     const destEmptyTokens = '__tests__/__output/test.emptyTokens';
+    const emptyTokensDictionary = {
+      allTokens: [
+        {
+          name: 'someName',
+          type: 'color',
+          path: ['some', 'name', 'path1'],
+          value: 'value1',
+        },
+      ],
+    };
+    const emptyTokensFilter = function (token) {
+      return token.type === 'color2';
+    };
+
     it('should warn when a file is not created because of empty tokens', async () => {
-      const dictionary = {
-        allTokens: [
-          {
-            name: 'someName',
-            type: 'color',
-            path: ['some', 'name', 'path1'],
-            value: 'value1',
-          },
-        ],
-      };
-
-      const filter = function (token) {
-        return token.type === 'color2';
-      };
-
       const sd = new StyleDictionary();
       const { logs, output } = await sd.formatFile(
         {
           destination: destEmptyTokens,
           format,
-          filter,
+          filter: emptyTokensFilter,
         },
         {},
-        dictionary,
+        emptyTokensDictionary,
       );
 
       expect(output).to.be.undefined;
@@ -1021,17 +1087,6 @@ Refer to: https://styledictionary.com/reference/logging/
     });
 
     it('should warn when a file is not created because of empty tokens using async filters', async () => {
-      const dictionary = {
-        allTokens: [
-          {
-            name: 'someName',
-            type: 'color',
-            path: ['some', 'name', 'path1'],
-            value: 'value1',
-          },
-        ],
-      };
-
       const filter = async (token) => {
         await new Promise((resolve) => setTimeout(resolve, 100));
         return token.type === 'color2';
@@ -1045,12 +1100,95 @@ Refer to: https://styledictionary.com/reference/logging/
           filter,
         },
         {},
-        dictionary,
+        emptyTokensDictionary,
       );
       expect(output).to.be.undefined;
 
       const warn = chalk.rgb(255, 140, 0)(`No tokens for ${destEmptyTokens}. File not created.`);
       expect(logs.warning[0]).to.equal(warn);
+    });
+
+    it('should throw when a file is not created because of empty tokens and warnings are errors', async () => {
+      const sd = new StyleDictionary();
+      await expect(
+        sd.formatFile(
+          {
+            destination: destEmptyTokens,
+            format,
+            filter: emptyTokensFilter,
+          },
+          { log: { warnings: errorLog } },
+          emptyTokensDictionary,
+        ),
+      ).to.eventually.rejectedWith(`No tokens for ${destEmptyTokens}. File not created.`);
+    });
+
+    it('should create file output when emitEmptyFiles is enabled on the file', async () => {
+      const sd = new StyleDictionary();
+      const { logs, output } = await sd.formatFile(
+        {
+          destination: destEmptyTokens,
+          format,
+          filter: emptyTokensFilter,
+          emitEmptyFiles: true,
+        },
+        {},
+        emptyTokensDictionary,
+      );
+
+      expect(output).to.equal('hi');
+      expect(logs.warning.length).to.equal(0);
+    });
+
+    it('should create file output when emitEmptyFiles is enabled on the platform', async () => {
+      const sd = new StyleDictionary();
+      const { logs, output } = await sd.formatFile(
+        {
+          destination: destEmptyTokens,
+          format,
+          filter: emptyTokensFilter,
+        },
+        { emitEmptyFiles: true },
+        emptyTokensDictionary,
+      );
+
+      expect(output).to.equal('hi');
+      expect(logs.warning.length).to.equal(0);
+    });
+
+    it('should prefer file-level emitEmptyFiles false over platform-level true', async () => {
+      const sd = new StyleDictionary();
+      const { logs, output } = await sd.formatFile(
+        {
+          destination: destEmptyTokens,
+          format,
+          filter: emptyTokensFilter,
+          emitEmptyFiles: false,
+        },
+        { emitEmptyFiles: true },
+        emptyTokensDictionary,
+      );
+
+      expect(output).to.be.undefined;
+      const warn = chalk.rgb(255, 140, 0)(`No tokens for ${destEmptyTokens}. File not created.`);
+      expect(logs.warning[0]).to.equal(warn);
+    });
+
+    it('should prefer file-level emitEmptyFiles true over platform-level false', async () => {
+      const sd = new StyleDictionary();
+      const { logs, output } = await sd.formatFile(
+        {
+          destination: destEmptyTokens,
+          format,
+          filter: emptyTokensFilter,
+          emitEmptyFiles: true,
+        },
+        { emitEmptyFiles: false },
+        emptyTokensDictionary,
+      );
+
+      expect(output).to.equal('hi');
+      expect(logs.warning.length).to.equal(0);
     });
 
     it('should create file output properly', async () => {

--- a/__tests__/StyleDictionary.test.js
+++ b/__tests__/StyleDictionary.test.js
@@ -21,6 +21,10 @@ const { console: logToConsole } = logBrokenReferenceLevels;
 const { silent, verbose } = logVerbosityLevels;
 const { error: errorLog, warn } = logWarningLevels;
 
+const testOutputFolder = '__tests__/__output';
+const testConfigsFolder = '__tests__/__configs';
+const testTokensFolder = '__tests__/__tokens';
+
 function traverseObj(obj, fn) {
   for (let key in obj) {
     fn.apply(this, [obj, key, obj[key]]);
@@ -42,21 +46,21 @@ const test_props = {
 describe('StyleDictionary class', () => {
   beforeEach(() => {
     restore();
-    clearOutput();
+    clearOutput(testOutputFolder);
   });
 
   afterEach(() => {
-    clearOutput();
+    clearOutput(testOutputFolder);
   });
 
   it('should accept a string as a path to a JSON5 file', async () => {
-    const StyleDictionaryExtended = new StyleDictionary('__tests__/__configs/test.json5');
+    const StyleDictionaryExtended = new StyleDictionary(`${testConfigsFolder}/test.json5`);
     await StyleDictionaryExtended.hasInitialized;
     expect(StyleDictionaryExtended).to.have.nested.property('platforms.web');
   });
 
   it('should accept a string as a path to a JSONC file', async () => {
-    const StyleDictionaryExtended = new StyleDictionary('__tests__/__configs/test.jsonc');
+    const StyleDictionaryExtended = new StyleDictionary(`${testConfigsFolder}/test.jsonc`);
     await StyleDictionaryExtended.hasInitialized;
     expect(StyleDictionaryExtended).to.have.nested.property('platforms.web');
   });
@@ -115,13 +119,13 @@ describe('StyleDictionary class', () => {
 
   describe('method signature', () => {
     it('should accept a string as a path to a JSON file', async () => {
-      const StyleDictionaryExtended = new StyleDictionary('__tests__/__configs/test.json');
+      const StyleDictionaryExtended = new StyleDictionary(`${testConfigsFolder}/test.json`);
       await StyleDictionaryExtended.hasInitialized;
       expect(StyleDictionaryExtended).to.have.nested.property('platforms.web');
     });
 
     it('should accept an object as options', () => {
-      const config = fileToJSON('__tests__/__configs/test.json');
+      const config = fileToJSON(`${testConfigsFolder}/test.json`);
       const StyleDictionaryExtended = new StyleDictionary(config);
       expect(StyleDictionaryExtended).to.have.nested.property('platforms.web');
     });
@@ -151,7 +155,7 @@ describe('StyleDictionary class', () => {
 
     it('should properly glob paths', async () => {
       const StyleDictionaryExtended = new StyleDictionary({
-        include: ['__tests__/__tokens/*.json'],
+        include: [`${testTokensFolder}/*.json`],
       });
       await StyleDictionaryExtended.hasInitialized;
       expect(typeof StyleDictionaryExtended.tokens.size.padding.tiny).to.equal('object');
@@ -159,12 +163,12 @@ describe('StyleDictionary class', () => {
 
     it('should build the tokens object if an include is given', async () => {
       const StyleDictionaryExtended = new StyleDictionary({
-        include: ['__tests__/__tokens/paddings.json'],
+        include: [`${testTokensFolder}/paddings.json`],
       });
-      const output = fileToJSON('__tests__/__tokens/paddings.json');
+      const output = fileToJSON(`${testTokensFolder}/paddings.json`);
       traverseObj(output, (obj) => {
         if (Object.hasOwn(obj, 'value') && !obj.filePath) {
-          obj.filePath = '__tests__/__tokens/paddings.json';
+          obj.filePath = `${testTokensFolder}/paddings.json`;
           obj.isSource = false;
         }
       });
@@ -175,12 +179,12 @@ describe('StyleDictionary class', () => {
     it('should override existing tokens if include is given', async () => {
       const StyleDictionaryExtended = new StyleDictionary({
         tokens: test_props,
-        include: ['__tests__/__tokens/paddings.json'],
+        include: [`${testTokensFolder}/paddings.json`],
       });
-      const output = fileToJSON('__tests__/__tokens/paddings.json');
+      const output = fileToJSON(`${testTokensFolder}/paddings.json`);
       traverseObj(output, (obj) => {
         if (Object.hasOwn(obj, 'value') && !obj.filePath) {
-          obj.filePath = '__tests__/__tokens/paddings.json';
+          obj.filePath = `${testTokensFolder}/paddings.json`;
           obj.isSource = false;
         }
       });
@@ -190,7 +194,7 @@ describe('StyleDictionary class', () => {
 
     it('should update tokens if there are includes', async () => {
       const StyleDictionaryExtended = new StyleDictionary({
-        include: ['__tests__/__configs/include.json'],
+        include: [`${testConfigsFolder}/include.json`],
       });
       await StyleDictionaryExtended.hasInitialized;
       expect(typeof StyleDictionaryExtended.tokens.size.padding.tiny).to.equal('object');
@@ -199,7 +203,7 @@ describe('StyleDictionary class', () => {
     it('should override existing tokens if there are includes', async () => {
       const StyleDictionaryExtended = new StyleDictionary({
         tokens: test_props,
-        include: ['__tests__/__configs/include.json'],
+        include: [`${testConfigsFolder}/include.json`],
       });
       await StyleDictionaryExtended.hasInitialized;
       expect(StyleDictionaryExtended).to.have.nested.property(
@@ -225,12 +229,12 @@ describe('StyleDictionary class', () => {
 
     it('should build the tokens object if a source is given', async () => {
       const StyleDictionaryExtended = new StyleDictionary({
-        source: ['__tests__/__tokens/paddings.json'],
+        source: [`${testTokensFolder}/paddings.json`],
       });
-      const output = fileToJSON('__tests__/__tokens/paddings.json');
+      const output = fileToJSON(`${testTokensFolder}/paddings.json`);
       traverseObj(output, (obj) => {
         if (Object.hasOwn(obj, 'value') && !obj.filePath) {
-          obj.filePath = '__tests__/__tokens/paddings.json';
+          obj.filePath = `${testTokensFolder}/paddings.json`;
           obj.isSource = true;
         }
       });
@@ -239,11 +243,11 @@ describe('StyleDictionary class', () => {
     });
 
     it('should use relative filePaths for the filePath property', async () => {
-      const filePath = '__tests__/__tokens/paddings.json';
+      const filePath = `${testTokensFolder}/paddings.json`;
       const StyleDictionaryExtended = new StyleDictionary({
         source: [filePath],
       });
-      const output = fileToJSON('__tests__/__tokens/paddings.json');
+      const output = fileToJSON(`${testTokensFolder}/paddings.json`);
       traverseObj(output, (obj) => {
         if (Object.hasOwn(obj, 'value') && !obj.filePath) {
           obj.filePath = filePath;
@@ -257,12 +261,12 @@ describe('StyleDictionary class', () => {
     it('should override existing tokens source is given', async () => {
       const StyleDictionaryExtended = new StyleDictionary({
         tokens: test_props,
-        source: ['__tests__/__tokens/paddings.json'],
+        source: [`${testTokensFolder}/paddings.json`],
       });
-      const output = fileToJSON('__tests__/__tokens/paddings.json');
+      const output = fileToJSON(`${testTokensFolder}/paddings.json`);
       traverseObj(output, (obj) => {
         if (Object.hasOwn(obj, 'value') && !obj.filePath) {
-          obj.filePath = '__tests__/__tokens/paddings.json';
+          obj.filePath = `${testTokensFolder}/paddings.json`;
           obj.isSource = true;
         }
       });
@@ -274,14 +278,14 @@ describe('StyleDictionary class', () => {
   describe('collisions', () => {
     it('should not throw a collision error if a source file collides with an include', async () => {
       const StyleDictionaryExtended = new StyleDictionary({
-        include: ['__tests__/__tokens/paddings.json'],
-        source: ['__tests__/__tokens/paddings.json'],
+        include: [`${testTokensFolder}/paddings.json`],
+        source: [`${testTokensFolder}/paddings.json`],
         log: errorLog,
       });
-      const output = fileToJSON('__tests__/__tokens/paddings.json');
+      const output = fileToJSON(`${testTokensFolder}/paddings.json`);
       traverseObj(output, (obj) => {
         if (Object.hasOwn(obj, 'value') && !obj.filePath) {
-          obj.filePath = '__tests__/__tokens/paddings.json';
+          obj.filePath = `${testTokensFolder}/paddings.json`;
           obj.isSource = true;
         }
       });
@@ -292,7 +296,7 @@ describe('StyleDictionary class', () => {
     it('should throw an error if the collision is in source files and log is set to error', async () => {
       const sd = new StyleDictionary(
         {
-          source: ['__tests__/__tokens/paddings.json', '__tests__/__tokens/_paddings.json'],
+          source: [`${testTokensFolder}/paddings.json`, `${testTokensFolder}/_paddings.json`],
           log: { warnings: errorLog, verbosity: verbose },
         },
         { init: false },
@@ -309,7 +313,7 @@ describe('StyleDictionary class', () => {
     it('should throw a brief error if the collision is in source files and log is set to error and verbosity default', async () => {
       const sd = new StyleDictionary(
         {
-          source: ['__tests__/__tokens/paddings.json', '__tests__/__tokens/_paddings.json'],
+          source: [`${testTokensFolder}/paddings.json`, `${testTokensFolder}/_paddings.json`],
           log: { warnings: errorLog },
         },
         { init: false },
@@ -326,7 +330,7 @@ describe('StyleDictionary class', () => {
     it('should throw a warning if the collision is in source files and log is set to warn', async () => {
       const sd = new StyleDictionary(
         {
-          source: ['__tests__/__tokens/paddings.json', '__tests__/__tokens/paddings.json'],
+          source: [`${testTokensFolder}/paddings.json`, `${testTokensFolder}/paddings.json`],
           log: warn,
         },
         { init: false },
@@ -796,14 +800,14 @@ Refer to: https://styledictionary.com/reference/logging/
     const platform = {
       files: [
         {
-          destination: '__tests__/__output/test.json',
+          destination: `${testOutputFolder}/test.json`,
           format: 'foo',
         },
       ],
     };
 
     const platformWithBuildPath = {
-      buildPath: '__tests__/__output/',
+      buildPath: testOutputFolder,
       files: [
         {
           destination: 'test.json',
@@ -813,7 +817,7 @@ Refer to: https://styledictionary.com/reference/logging/
     };
 
     const platformWithFilter = {
-      buildPath: '__tests__/__output/',
+      buildPath: testOutputFolder,
       files: [
         {
           destination: 'test.json',
@@ -826,7 +830,7 @@ Refer to: https://styledictionary.com/reference/logging/
     };
 
     const platformWithoutFormat = {
-      buildPath: '__tests__/__output/',
+      buildPath: testOutputFolder,
       files: [
         {
           destination: 'test.json',
@@ -835,7 +839,7 @@ Refer to: https://styledictionary.com/reference/logging/
     };
 
     const platformWithoutFiles = {
-      buildPath: '__tests__/__output/',
+      buildPath: testOutputFolder,
     };
 
     it('should throw if there is no files property', async () => {
@@ -871,7 +875,7 @@ Refer to: https://styledictionary.com/reference/logging/
         },
       });
       await sd.buildPlatform('foo');
-      expect(fileExists('__tests__/__output/test.json')).to.be.true;
+      expect(fileExists(`${testOutputFolder}/test.json`)).to.be.true;
     });
 
     it('should work with buildPath', async () => {
@@ -883,7 +887,7 @@ Refer to: https://styledictionary.com/reference/logging/
         },
       });
       await sd.buildPlatform('foo');
-      expect(fileExists('__tests__/__output/test.json')).to.be.true;
+      expect(fileExists(`${testOutputFolder}/test.json`)).to.be.true;
     });
 
     it('should work with a filter', async () => {
@@ -895,8 +899,8 @@ Refer to: https://styledictionary.com/reference/logging/
         },
       });
       await sd.buildPlatform('foo');
-      expect(fileExists('__tests__/__output/test.json')).to.be.true;
-      const output = JSON.parse(fs.readFileSync(resolve('__tests__/__output/test.json')));
+      expect(fileExists(`${testOutputFolder}/test.json`)).to.be.true;
+      const output = JSON.parse(fs.readFileSync(resolve(`${testOutputFolder}/test.json`)));
       expect(output).to.have.property('bingo');
       expect(output).to.not.have.property('foo');
       Object.values(output).forEach((property) => {
@@ -910,7 +914,7 @@ Refer to: https://styledictionary.com/reference/logging/
         hooks,
         platforms: {
           foo: {
-            buildPath: '__tests__/__output/',
+            buildPath: testOutputFolder,
             files: [
               {
                 destination: 'test.json',
@@ -922,7 +926,7 @@ Refer to: https://styledictionary.com/reference/logging/
         },
       });
       await sd.buildPlatform('foo');
-      expect(fileExists('__tests__/__output/test.json')).to.be.false;
+      expect(fileExists(`${testOutputFolder}/test.json`)).to.be.false;
     });
 
     it('should write an empty-token file when emitEmptyFiles is enabled on the file', async () => {
@@ -931,7 +935,7 @@ Refer to: https://styledictionary.com/reference/logging/
         hooks,
         platforms: {
           foo: {
-            buildPath: '__tests__/__output/',
+            buildPath: testOutputFolder,
             files: [
               {
                 destination: 'test.json',
@@ -944,8 +948,8 @@ Refer to: https://styledictionary.com/reference/logging/
         },
       });
       await sd.buildPlatform('foo');
-      expect(fileExists('__tests__/__output/test.json')).to.be.true;
-      expect(fs.readFileSync(resolve('__tests__/__output/test.json'), 'utf-8')).to.equal('{}');
+      expect(fileExists(`${testOutputFolder}/test.json`)).to.be.true;
+      expect(fs.readFileSync(resolve(`${testOutputFolder}/test.json`), 'utf-8')).to.equal('{}');
     });
 
     it('should write an empty-token file when emitEmptyFiles is enabled on the platform', async () => {
@@ -954,7 +958,7 @@ Refer to: https://styledictionary.com/reference/logging/
         hooks,
         platforms: {
           foo: {
-            buildPath: '__tests__/__output/',
+            buildPath: testOutputFolder,
             emitEmptyFiles: true,
             files: [
               {
@@ -967,8 +971,8 @@ Refer to: https://styledictionary.com/reference/logging/
         },
       });
       await sd.buildPlatform('foo');
-      expect(fileExists('__tests__/__output/test.json')).to.be.true;
-      expect(fs.readFileSync(resolve('__tests__/__output/test.json'), 'utf-8')).to.equal('{}');
+      expect(fileExists(`${testOutputFolder}/test.json`)).to.be.true;
+      expect(fs.readFileSync(resolve(`${testOutputFolder}/test.json`), 'utf-8')).to.equal('{}');
     });
   });
 
@@ -996,7 +1000,7 @@ Refer to: https://styledictionary.com/reference/logging/
         sd.formatFile({ destination: '__tests__output/test.txt', format: {} }, {}, {}),
       ).to.eventually.rejectedWith('Please enter a valid file format');
       await expect(
-        sd.formatFile({ destination: '__tests__/__output/test.txt', format: [] }, {}, {}),
+        sd.formatFile({ destination: `${testOutputFolder}/test.txt`, format: [] }, {}, {}),
       ).to.eventually.rejectedWith('Please enter a valid file format');
     });
 
@@ -1015,7 +1019,7 @@ Refer to: https://styledictionary.com/reference/logging/
     });
 
     describe('name collisions', () => {
-      const destination = '__tests__/__output/test.collisions';
+      const destination = `${testOutputFolder}/test.collisions`;
       const PROPERTY_NAME_COLLISION_WARNINGS = `${GroupMessages.GROUP.PropertyNameCollisionWarnings}:${destination}`;
       const name = 'someName';
       const dictionary = {
@@ -1053,7 +1057,7 @@ Refer to: https://styledictionary.com/reference/logging/
       });
     });
 
-    const destEmptyTokens = '__tests__/__output/test.emptyTokens';
+    const destEmptyTokens = `${testOutputFolder}/test.emptyTokens`;
     const emptyTokensDictionary = {
       allTokens: [
         {
@@ -1199,7 +1203,7 @@ Refer to: https://styledictionary.com/reference/logging/
           format,
         },
         {
-          buildPath: '__tests__/__output/',
+          buildPath: testOutputFolder,
         },
         {},
       );
@@ -1265,7 +1269,7 @@ ${dictionary.allTokens.map((tok) => `  ${tok.name}: "${tok.value}";`).join('\n')
           format: customCSSFormat,
         },
         {
-          buildPath: '__tests__/__output/',
+          buildPath: testOutputFolder,
         },
         {
           tokens: tokens,
@@ -1301,7 +1305,7 @@ ${dictionary.allTokens.map((tok) => `  ${tok.name}: "${tok.value}";`).join('\n')
           },
         },
         {
-          buildPath: '__tests__/__output/',
+          buildPath: testOutputFolder,
         },
         dictionary,
       );

--- a/__tests__/__helpers.js
+++ b/__tests__/__helpers.js
@@ -37,8 +37,8 @@ export const fileToJSON = (_path, _fs = fs) => {
 
 export const clearOutput = (outputFolder = '__tests__/__output', _fs = fs) => {
   try {
-    _fs.rmdirSync(outputFolder);
-  } catch {
+    _fs.rmSync(outputFolder, { force: true, recursive: true });
+  } catch (_e) {
     //
   }
 };

--- a/__tests__/performAction.test.js
+++ b/__tests__/performAction.test.js
@@ -53,11 +53,11 @@ describe('performAction', () => {
       sd.registerAction({
         name: 'test-async',
         do: async function () {
-          fs.promises.mkdir('__tests__/__output', { recursive: true });
-          fs.promises.writeFile('__tests__/__output/action.txt', 'hi', 'utf-8');
+          await fs.promises.mkdir('__tests__/__output', { recursive: true });
+          await fs.promises.writeFile('__tests__/__output/action.txt', 'hi', 'utf-8');
         },
         undo: async function () {
-          fs.promises.unlink('__tests__/__output/action.txt');
+          await fs.promises.unlink('__tests__/__output/action.txt');
         },
       });
       await sd.buildPlatform('android');

--- a/lib/StyleDictionary.js
+++ b/lib/StyleDictionary.js
@@ -646,6 +646,7 @@ export default class StyleDictionary extends Register {
     const { destination } = file || {};
     const filter = /** @type {Filter['filter']|undefined} */ (file.filter);
     let { format } = file || {};
+    const emitEmptyFiles = file.emitEmptyFiles ?? platform.emitEmptyFiles ?? false;
 
     if (typeof format !== 'function') throw new Error('Please enter a valid file format');
     if (destination !== undefined && typeof destination !== 'string')
@@ -677,6 +678,7 @@ export default class StyleDictionary extends Register {
 
     // if tokens object is empty, return without creating a file
     if (
+      !emitEmptyFiles &&
       Object.hasOwn(filteredTokens, 'tokens') &&
       Object.keys(filteredTokens.tokens).length === 0 &&
       filteredTokens.tokens.constructor === Object

--- a/types/Config.ts
+++ b/types/Config.ts
@@ -96,6 +96,7 @@ export interface PlatformConfig {
   preprocessors?: string[];
   prefix?: string;
   buildPath?: string;
+  emitEmptyFiles?: boolean;
   files?: File[];
   actions?: string[] | Omit<Action, 'name'>[];
   options?: LocalOptions;

--- a/types/File.ts
+++ b/types/File.ts
@@ -37,5 +37,6 @@ export interface File {
   destination?: string;
   format?: string | FormatFn;
   filter?: string | Partial<TransformedToken> | Filter['filter'];
+  emitEmptyFiles?: boolean;
   options?: LocalOptions;
 }


### PR DESCRIPTION
## Summary
A new `emitEmptyFiles` file option writes the output file even when no tokens match the filter, instead of skipping it.

## Why this matters
When a file's `filter` matches no tokens, Style Dictionary skips writing the file entirely. For build pipelines that expect a file to always exist (and commit it, or consume it downstream), a missing file is harder to handle than an empty one. `emitEmptyFiles: true` opts into writing the file with empty output; the default behavior is unchanged.

## Changes
- Add the `emitEmptyFiles` option to the `File` and `Config` types.
- Honor it in `StyleDictionary` when deciding whether to skip an empty file.

## Testing
Added tests for both the default skip behavior and the `emitEmptyFiles: true` path.

Fixes #1689

AI was used for assistance.
