### PR TITLE
fix: preserve calc() expressions in dimension and fontSize transforms

### DIFF
--- a/__tests__/common/transforms.test.js
+++ b/__tests__/common/transforms.test.js
@@ -1039,6 +1039,10 @@ describe('common', () => {
           expect(remValue).to.equal('12.00sp');
         });
 
+        it('should preserve CSS function values', () => {
+          expect(runTransform(sizeSp, { value: 'calc(1rem + 2px)' })).to.equal('calc(1rem + 2px)');
+        });
+
         it('should throw an error if prop value is NaN', () => {
           expect(() => runTransform(sizeSp, { value: 'a' })).to.throw();
         });
@@ -1061,6 +1065,12 @@ describe('common', () => {
 
           expect(pxValue).to.equal('12.00dp');
           expect(remValue).to.equal('12.00dp');
+        });
+
+        it('should preserve CSS function values', () => {
+          expect(runTransform(sizeDp, { value: 'calc(100% - 20px)' })).to.equal(
+            'calc(100% - 20px)',
+          );
         });
 
         it('should throw an error if prop value is NaN', () => {
@@ -1136,6 +1146,12 @@ describe('common', () => {
           expect(remValue).to.equal('14.00sp');
         });
 
+        it('should preserve CSS function values', () => {
+          expect(runTransform(sizeRemToSp, { value: 'calc(1rem + 2px)' })).to.equal(
+            'calc(1rem + 2px)',
+          );
+        });
+
         it('should throw an error if prop value is NaN', () => {
           expect(() => runTransform(sizeRemToSp, { value: 'a' })).to.throw();
         });
@@ -1180,6 +1196,12 @@ describe('common', () => {
           expect(value).to.equal('224.00dp');
         });
 
+        it('should preserve CSS function values', () => {
+          expect(runTransform(sizeRemToDp, { value: 'calc(100% - 20px)' })).to.equal(
+            'calc(100% - 20px)',
+          );
+        });
+
         it('should throw an error if prop value is NaN', () => {
           expect(() => runTransform(sizeRemToDp, { value: 'a' }, {}, {})).to.throw();
         });
@@ -1220,6 +1242,12 @@ describe('common', () => {
 
           expect(pxValue).to.equal('-10px');
           expect(remValue).to.equal('-10px'); // value transformation doesn't make sense here
+        });
+
+        it('should preserve CSS function values', () => {
+          expect(runTransform(sizePx, { value: 'calc(1rem + 2px)', type: 'fontSize' })).to.equal(
+            'calc(1rem + 2px)',
+          );
         });
 
         it('should throw an error if prop value is NaN', () => {
@@ -1282,6 +1310,12 @@ describe('common', () => {
 
           expect(value).to.equal('1em');
           expect(nonUnitValue).to.equal('5lightyears');
+        });
+
+        it('should preserve CSS function values', () => {
+          expect(runTransform(sizeRem, { value: 'calc(1rem + 2px)', type: 'fontSize' })).to.equal(
+            'calc(1rem + 2px)',
+          );
         });
 
         it('should throw an error if prop value is NaN', () => {
@@ -1574,6 +1608,12 @@ describe('common', () => {
           expect(pxValue).to.equal('224px');
         });
 
+        it('should preserve CSS function values', () => {
+          expect(runTransform(sizeRemToPx, { value: 'calc(1rem + 2px)' })).to.equal(
+            'calc(1rem + 2px)',
+          );
+        });
+
         it('should throw an error if prop value is NaN', () => {
           expect(() => runTransform(sizeRemToPx, { value: 'a' })).to.throw();
         });
@@ -1608,6 +1648,12 @@ describe('common', () => {
             });
           },
         );
+
+        it('should preserve CSS function values', () => {
+          expect(runTransform(sizePxToRem, { value: 'calc(100% - 20px)' })).to.equal(
+            'calc(100% - 20px)',
+          );
+        });
 
         it('should throw an error if prop value is NaN', () => {
           expect(() => runTransform(sizePxToRem, { value: 'a' })).to.throw();
@@ -1960,6 +2006,15 @@ describe('common', () => {
               lineHeight: { value: 1, unit: 'rem' },
             }),
           ).to.equal('20px/1rem sans-serif');
+        });
+
+        it('should preserve CSS function dimension values', () => {
+          expect(
+            typographyTransform({
+              fontSize: 'calc(1rem + 2px)',
+              lineHeight: 'clamp(1.2rem, 2vw, 1.5rem)',
+            }),
+          ).to.equal('calc(1rem + 2px)/clamp(1.2rem, 2vw, 1.5rem) sans-serif');
         });
       });
 
@@ -2449,7 +2504,9 @@ describe('common', () => {
       it('should return token value', () => {
         const allTokensNonDtcg = [
           { value: '42px' },
+          { value: '16px' },
           { value: '42rem' },
+          { value: '1.5rem' },
           { value: '42em' },
           { value: '42unit' },
 
@@ -2461,7 +2518,9 @@ describe('common', () => {
         ];
         const allTokensDtcg = [
           { $value: '42px' },
+          { $value: '16px' },
           { $value: '42rem' },
+          { $value: '1.5rem' },
           { $value: '42em' },
           { $value: '42unit' },
 
@@ -2478,7 +2537,9 @@ describe('common', () => {
 
         const expected = [
           { value: 42, unit: 'px' },
+          { value: 16, unit: 'px' },
           { value: 42, unit: 'rem' },
+          { value: 1.5, unit: 'rem' },
           { value: 42, unit: 'em' },
           { value: 42, unit: 'unit' },
 
@@ -2498,6 +2559,19 @@ describe('common', () => {
         allTokensNonDtcg.forEach((it, idx) => {
           expect(getTokenDimensionValue(it.value)).to.deep.equal(expected[idx]);
         });
+      });
+
+      it('should preserve CSS function values', () => {
+        expect(getTokenDimensionValue('calc(100% - 20px)')).to.deep.equal({
+          value: 'calc(100% - 20px)',
+          unit: undefined,
+        });
+
+        ['min(1rem, 2vw)', 'max(1rem, 2vw)', 'clamp(1rem, 2vw, 2rem)', 'var(--size)'].forEach(
+          (value) => {
+            expect(getTokenDimensionValue(value)).to.deep.equal({ value, unit: undefined });
+          },
+        );
       });
     });
   });

--- a/lib/common/transforms.js
+++ b/lib/common/transforms.js
@@ -275,7 +275,7 @@ function wrapValueWithDoubleQuote(token, options) {
 
 /**
  * @param {string} name
- * @param {string|number} value
+ * @param {unknown} value
  * @param {string} unitType
  * @returns {string}
  */
@@ -283,6 +283,16 @@ function throwSizeError(name, value, unitType) {
   throw new Error(
     `Invalid Number: '${name}: ${value}' is not a valid number, cannot transform to '${unitType}' \n`,
   );
+}
+
+const CSS_FUNCTION_DIMENSION_VALUE = /(^|[^a-zA-Z])(calc|min|max|clamp|var)\(/i;
+
+/**
+ * @param {unknown} val
+ * @returns {val is string}
+ */
+function isCssFunctionDimensionValue(val) {
+  return typeof val === 'string' && CSS_FUNCTION_DIMENSION_VALUE.test(val);
 }
 
 /**
@@ -385,7 +395,7 @@ function transformCubicBezierCSS(token, options) {
  *
  * unit can be undefined for this utility method as well to support old dimension token values
  * which can be defined as unitless dimension tokens or numbers
- * @returns {{ value: number; unit: TokenTypeDimensionUnit | undefined }}
+ * @returns {{ value: number | string; unit: TokenTypeDimensionUnit | undefined }}
  */
 export function getTokenDimensionValue(val) {
   /** @type {TokenTypeDimensionUnit | undefined} */
@@ -394,6 +404,10 @@ export function getTokenDimensionValue(val) {
 
   // old string dimension value
   if (!valueObj) {
+    if (isCssFunctionDimensionValue(val)) {
+      return { value: val, unit: undefined };
+    }
+
     // if it contains a unit -> split it into unit and val
     const unitMatch = `${val}`.match(/[^0-9.-]+$/);
     if (unitMatch) {
@@ -406,6 +420,27 @@ export function getTokenDimensionValue(val) {
   return valueObj
     ? { value: val.value, unit: val.unit }
     : { value: val, unit: unit ? unit : undefined };
+}
+
+/**
+ * @param {Token} token
+ * @param {Config} options
+ * @param {string} unitType
+ * @returns {{ value: number | string; parsedValue: number | string; unit: TokenTypeDimensionUnit | undefined }}
+ */
+function getParsedDimensionValue(token, options, unitType) {
+  const tokenVal = options.usesDtcg ? token.$value : token.value;
+  const nonParsed = getTokenDimensionValue(tokenVal);
+  const parsedValue = parseFloat(`${nonParsed.value}`);
+
+  if (isNaN(parsedValue)) {
+    if (isCssFunctionDimensionValue(nonParsed.value)) {
+      return { ...nonParsed, parsedValue: nonParsed.value };
+    }
+    throwSizeError(token.name, tokenVal, unitType);
+  }
+
+  return { ...nonParsed, parsedValue };
 }
 
 /**
@@ -1033,11 +1068,8 @@ export default {
     type: value,
     filter: isFontSize,
     transform: function (token, _, options) {
-      const tokenVal = options.usesDtcg ? token.$value : token.value;
-      const nonParsed = getTokenDimensionValue(tokenVal);
-      const val = parseFloat(`${nonParsed.value}`);
-      if (isNaN(val))
-        throwSizeError(token.name, options.usesDtcg ? token.$value : token.value, 'sp');
+      const { parsedValue: val } = getParsedDimensionValue(token, options, 'sp');
+      if (typeof val === 'string') return val;
 
       return `${val.toFixed(2)}sp`;
     },
@@ -1058,11 +1090,8 @@ export default {
     type: value,
     filter: isDimension,
     transform: function (token, _, options) {
-      const tokenVal = options.usesDtcg ? token.$value : token.value;
-      const nonParsed = getTokenDimensionValue(tokenVal);
-      const val = parseFloat(`${nonParsed.value}`);
-      if (isNaN(val))
-        throwSizeError(token.name, options.usesDtcg ? token.$value : token.value, 'dp');
+      const { parsedValue: val } = getParsedDimensionValue(token, options, 'dp');
+      if (typeof val === 'string') return val;
 
       return `${val.toFixed(2)}dp`;
     },
@@ -1089,13 +1118,11 @@ export default {
     filter: (token, options) => isDimension(token, options) || isFontSize(token, options),
     transform: function (token, config, options) {
       const tokenVal = options.usesDtcg ? token.$value : token.value;
-      const nonParsed = getTokenDimensionValue(tokenVal);
-      const parsedVal = parseFloat(`${nonParsed.value}`);
-      if (isNaN(parsedVal))
-        throwSizeError(token.name, options.usesDtcg ? token.$value : token.value, 'object');
+      const { parsedValue: parsedVal } = getParsedDimensionValue(token, options, 'object');
+      if (typeof parsedVal === 'string') return parsedVal;
 
       return {
-        original: options.usesDtcg ? token.$value : token.value,
+        original: tokenVal,
         number: parsedVal,
         decimal: parsedVal / 100,
         scale: parsedVal * getBasePxFontSize(config),
@@ -1118,12 +1145,9 @@ export default {
     type: value,
     filter: isFontSize,
     transform: function (token, config, options) {
-      const tokenVal = options.usesDtcg ? token.$value : token.value;
-      const nonParsed = getTokenDimensionValue(tokenVal);
-      const parsedVal = parseFloat(`${nonParsed.value}`);
+      const { parsedValue: parsedVal } = getParsedDimensionValue(token, options, 'sp');
       const baseFont = getBasePxFontSize(config);
-      if (isNaN(parsedVal))
-        throwSizeError(token.name, options.usesDtcg ? token.$value : token.value, 'sp');
+      if (typeof parsedVal === 'string') return parsedVal;
 
       return `${(parsedVal * baseFont).toFixed(2)}sp`;
     },
@@ -1145,12 +1169,9 @@ export default {
     type: value,
     filter: isDimension,
     transform: function (token, config, options) {
-      const tokenVal = options.usesDtcg ? token.$value : token.value;
-      const nonParsed = getTokenDimensionValue(tokenVal);
-      const parsedVal = parseFloat(`${nonParsed.value}`);
+      const { parsedValue: parsedVal } = getParsedDimensionValue(token, options, 'dp');
       const baseFont = getBasePxFontSize(config);
-      if (isNaN(parsedVal))
-        throwSizeError(token.name, options.usesDtcg ? token.$value : token.value, 'dp');
+      if (typeof parsedVal === 'string') return parsedVal;
 
       return `${(parsedVal * baseFont).toFixed(2)}dp`;
     },
@@ -1171,11 +1192,8 @@ export default {
     type: value,
     filter: (token, options) => isDimension(token, options) || isFontSize(token, options),
     transform: function (token, _, options) {
-      const tokenVal = options.usesDtcg ? token.$value : token.value;
-      const nonParsed = getTokenDimensionValue(tokenVal);
-      const parsedVal = parseFloat(`${nonParsed.value}`);
-      if (isNaN(parsedVal))
-        throwSizeError(token.name, options.usesDtcg ? token.$value : token.value, 'px');
+      const { parsedValue: parsedVal } = getParsedDimensionValue(token, options, 'px');
+      if (typeof parsedVal === 'string') return parsedVal;
 
       return `${parsedVal}px`;
     },
@@ -1196,14 +1214,15 @@ export default {
     type: value,
     filter: (token, options) => isDimension(token, options) || isFontSize(token, options),
     transform: function (token, _, options) {
-      const tokenVal = options.usesDtcg ? token.$value : token.value;
-      const nonParsed = getTokenDimensionValue(tokenVal);
-      const parsedVal = parseFloat(`${nonParsed.value}`);
-      if (isNaN(parsedVal))
-        throwSizeError(token.name, options.usesDtcg ? token.$value : token.value, 'rem');
+      const {
+        value: dimensionValue,
+        unit,
+        parsedValue: parsedVal,
+      } = getParsedDimensionValue(token, options, 'rem');
+      if (typeof parsedVal === 'string') return parsedVal;
       if (parsedVal === 0) return 0;
-      if (nonParsed.unit !== undefined) {
-        return `${nonParsed.value}${nonParsed.unit}`;
+      if (unit !== undefined) {
+        return `${dimensionValue}${unit}`;
       }
 
       return `${parsedVal}rem`;
@@ -1225,13 +1244,10 @@ export default {
     type: value,
     filter: (token, options) => isDimension(token, options) || isFontSize(token, options),
     transform: function (token, config, options) {
-      const tokenVal = options.usesDtcg ? token.$value : token.value;
-      const nonParsed = getTokenDimensionValue(tokenVal);
-      const parsedVal = parseFloat(`${nonParsed.value}`);
+      const { parsedValue: parsedVal } = getParsedDimensionValue(token, options, 'f');
       const baseFont = getBasePxFontSize(config);
+      if (typeof parsedVal === 'string') return parsedVal;
 
-      if (isNaN(parsedVal))
-        throwSizeError(token.name, options.usesDtcg ? token.$value : token.value, 'f');
       return `${(parsedVal * baseFont).toFixed(2)}f`;
     },
   },
@@ -1251,13 +1267,10 @@ export default {
     type: value,
     filter: (token, options) => isDimension(token, options) || isFontSize(token, options),
     transform: function (token, config, options) {
-      const tokenVal = options.usesDtcg ? token.$value : token.value;
-      const nonParsed = getTokenDimensionValue(tokenVal);
-      const parsedVal = parseFloat(`${nonParsed.value}`);
+      const { parsedValue: parsedVal } = getParsedDimensionValue(token, options, 'pt');
       const baseFont = getBasePxFontSize(config);
+      if (typeof parsedVal === 'string') return parsedVal;
 
-      if (isNaN(parsedVal))
-        throwSizeError(token.name, options.usesDtcg ? token.$value : token.value, 'pt');
       return `${(parsedVal * baseFont).toFixed(2)}pt`;
     },
   },
@@ -1278,12 +1291,9 @@ export default {
     type: value,
     filter: isFontSize,
     transform: function (token, config, options) {
-      const tokenVal = options.usesDtcg ? token.$value : token.value;
-      const nonParsed = getTokenDimensionValue(tokenVal);
-      const parsedVal = parseFloat(`${nonParsed.value}`);
+      const { parsedValue: parsedVal } = getParsedDimensionValue(token, options, 'sp');
       const baseFont = getBasePxFontSize(config);
-      if (isNaN(parsedVal))
-        throwSizeError(token.name, options.usesDtcg ? token.$value : token.value, 'sp');
+      if (typeof parsedVal === 'string') return parsedVal;
 
       return `${(parsedVal * baseFont).toFixed(2)}.sp`;
     },
@@ -1304,12 +1314,9 @@ export default {
     type: value,
     filter: isDimension,
     transform: function (token, config, options) {
-      const tokenVal = options.usesDtcg ? token.$value : token.value;
-      const nonParsed = getTokenDimensionValue(tokenVal);
-      const parsedVal = parseFloat(`${nonParsed.value}`);
+      const { parsedValue: parsedVal } = getParsedDimensionValue(token, options, 'dp');
       const baseFont = getBasePxFontSize(config);
-      if (isNaN(parsedVal))
-        throwSizeError(token.name, options.usesDtcg ? token.$value : token.value, 'dp');
+      if (typeof parsedVal === 'string') return parsedVal;
 
       return `${(parsedVal * baseFont).toFixed(2)}.dp`;
     },
@@ -1330,11 +1337,8 @@ export default {
     type: value,
     filter: isFontSize,
     transform: function (token, _, options) {
-      const tokenVal = options.usesDtcg ? token.$value : token.value;
-      const nonParsed = getTokenDimensionValue(tokenVal);
-      const parsedVal = parseFloat(`${nonParsed.value}`);
-      if (isNaN(parsedVal))
-        throwSizeError(token.name, options.usesDtcg ? token.$value : token.value, 'em');
+      const { parsedValue: parsedVal } = getParsedDimensionValue(token, options, 'em');
+      if (typeof parsedVal === 'string') return parsedVal;
 
       return `${parsedVal}.em`;
     },
@@ -1355,11 +1359,8 @@ export default {
     type: value,
     filter: isFontSize,
     transform: function (token, _, options) {
-      const tokenVal = options.usesDtcg ? token.$value : token.value;
-      const nonParsed = getTokenDimensionValue(tokenVal);
-      const val = parseFloat(`${nonParsed.value}`);
-      if (isNaN(val))
-        throwSizeError(token.name, options.usesDtcg ? token.$value : token.value, 'sp');
+      const { parsedValue: val } = getParsedDimensionValue(token, options, 'sp');
+      if (typeof val === 'string') return val;
 
       return `${val.toFixed(2)}.sp`;
     },
@@ -1380,11 +1381,8 @@ export default {
     type: value,
     filter: isDimension,
     transform: function (token, _, options) {
-      const tokenVal = options.usesDtcg ? token.$value : token.value;
-      const nonParsed = getTokenDimensionValue(tokenVal);
-      const val = parseFloat(`${nonParsed.value}`);
-      if (isNaN(val))
-        throwSizeError(token.name, options.usesDtcg ? token.$value : token.value, 'dp');
+      const { parsedValue: val } = getParsedDimensionValue(token, options, 'dp');
+      if (typeof val === 'string') return val;
 
       return `${val.toFixed(2)}.dp`;
     },
@@ -1404,12 +1402,9 @@ export default {
     type: value,
     filter: (token, options) => isDimension(token, options) || isFontSize(token, options),
     transform: function (token, config, options) {
-      const tokenVal = options.usesDtcg ? token.$value : token.value;
-      const nonParsed = getTokenDimensionValue(tokenVal);
-      const parsedVal = parseFloat(`${nonParsed.value}`);
+      const { parsedValue: parsedVal } = getParsedDimensionValue(token, options, 'CGFloat');
       const baseFont = getBasePxFontSize(config);
-      if (isNaN(parsedVal))
-        throwSizeError(token.name, options.usesDtcg ? token.$value : token.value, 'CGFloat');
+      if (typeof parsedVal === 'string') return parsedVal;
 
       return `CGFloat(${(parsedVal * baseFont).toFixed(2)})`;
     },
@@ -1430,12 +1425,9 @@ export default {
     type: value,
     filter: (token, options) => isDimension(token, options) || isFontSize(token, options),
     transform: function (token, config, options) {
-      const tokenVal = options.usesDtcg ? token.$value : token.value;
-      const nonParsed = getTokenDimensionValue(tokenVal);
-      const parsedVal = parseFloat(`${nonParsed.value}`);
+      const { parsedValue: parsedVal } = getParsedDimensionValue(token, options, 'px');
       const baseFont = getBasePxFontSize(config);
-      if (isNaN(parsedVal))
-        throwSizeError(token.name, options.usesDtcg ? token.$value : token.value, 'px');
+      if (typeof parsedVal === 'string') return parsedVal;
 
       return `${(parsedVal * baseFont).toFixed(0)}px`;
     },
@@ -1459,12 +1451,9 @@ export default {
     type: value,
     filter: (token, options) => isDimension(token, options) || isFontSize(token, options),
     transform: (token, config, options) => {
-      const tokenVal = options.usesDtcg ? token.$value : token.value;
-      const nonParsed = getTokenDimensionValue(tokenVal);
-      const parsedVal = parseFloat(`${nonParsed.value}`);
+      const { parsedValue: parsedVal } = getParsedDimensionValue(token, options, 'rem');
       const baseFont = getBasePxFontSize(config);
-      if (isNaN(parsedVal))
-        throwSizeError(token.name, options.usesDtcg ? token.$value : token.value, 'rem');
+      if (typeof parsedVal === 'string') return parsedVal;
       if (parsedVal === 0) return 0;
 
       return `${parsedVal / baseFont}rem`;
@@ -1485,12 +1474,9 @@ export default {
     type: value,
     filter: (token, options) => isDimension(token, options) || isFontSize(token, options),
     transform: function (token, config, options) {
-      const tokenVal = options.usesDtcg ? token.$value : token.value;
-      const nonParsed = getTokenDimensionValue(tokenVal);
+      const { parsedValue: parsedVal } = getParsedDimensionValue(token, options, 'Number');
       const baseFont = getBasePxFontSize(config);
-      const parsedVal = parseFloat(`${nonParsed.value}`);
-      if (isNaN(parsedVal))
-        throwSizeError(token.name, options.usesDtcg ? token.$value : token.value, 'Number');
+      if (typeof parsedVal === 'string') return parsedVal;
 
       return (parsedVal * baseFont).toFixed(2);
     },


### PR DESCRIPTION
## Summary
The dimension and fontSize transforms preserve CSS function values like `calc(...)`, `clamp(...)`, `min/max(...)`, and `var(...)` instead of mangling them.

## Why this matters
A token whose value is `calc(1rem + 2px)` was run through the numeric dimension parser, which does not understand CSS functions and produced broken output. The transforms now detect when a value is a CSS function and pass it through untouched, only applying numeric unit handling to plain dimension values.

## Changes
- Add a shared guard that recognizes `calc`/`min`/`max`/`clamp`/`var` function values.
- Skip numeric parsing for those values in the dimension and fontSize transforms; leave plain dimensions unchanged.

## Testing
Added transform tests covering `calc()` and other CSS-function values alongside the existing plain-dimension cases.

Fixes #1665

AI was used for assistance.
