### PR TITLE
fix: prototype pollution in convertTokenData utility

### DIFF
--- a/.changeset/tame-bikes-joke.md
+++ b/.changeset/tame-bikes-joke.md
@@ -1,0 +1,7 @@
+---
+'style-dictionary': patch
+---
+
+Fix prototype pollution vulnerability in the `convertTokenData` utility function, this was introduced in version `4.3.0`.
+Any token key that includes `__proto__` will be ignored.
+See [Security Advisory GHSA-vj5c-m527-mpff](https://github.com/style-dictionary/style-dictionary/security/advisories/GHSA-vj5c-m527-mpff).

--- a/__tests__/utils/convertTokenData.test.js
+++ b/__tests__/utils/convertTokenData.test.js
@@ -94,5 +94,15 @@ describe('utils', () => {
         });
       });
     });
+
+    it('should not allow prototype pollution by converting to an object with a malicious token.key', () => {
+      // below key would cause prototype pollution via L40-L50 in convertTokenData.js
+      // this key would be dissected into essentially doing obj['__proto__']['a'] assignment
+      convertTokenData([{ key: '{__proto__.a}', value: 'b' }], {
+        output: 'object',
+        usesDtcg: false,
+      });
+      expect({}.a).to.be.undefined;
+    });
   });
 });

--- a/lib/utils/convertTokenData.js
+++ b/lib/utils/convertTokenData.js
@@ -33,6 +33,10 @@ function convertToTokenObject(tokenArray) {
   const obj = /** @type {Tokens} */ ({});
   tokenArray.forEach((token) => {
     const { key } = token;
+    // prototype pollution guard -> move to next token if key is malicious
+    if (key?.includes('__proto__')) {
+      return;
+    }
     const keyArr = /** @type {string} */ (key).replace('{', '').replace('}', '').split('.');
     let slice = obj;
     keyArr.forEach((k, i, arr) => {


### PR DESCRIPTION
fixes https://github.com/style-dictionary/style-dictionary/issues/1699

TODO:
- [x] add GH advisory number in changeset / commit for traceability
- [x] find version that added the vulnerability and document it in the changeset