### PR TITLE
fix: gracefully handle unparseable dimension token values

### DIFF
--- a/.changeset/olive-streets-hug.md
+++ b/.changeset/olive-streets-hug.md
@@ -1,0 +1,5 @@
+---
+'style-dictionary': patch
+---
+
+Fix regression to gracefully handle unparseable dimension tokens which is required to support custom dimension tokens from third party vendors like Tokens Studio.

--- a/__tests__/common/transforms.test.js
+++ b/__tests__/common/transforms.test.js
@@ -2527,6 +2527,18 @@ describe('common', () => {
           expect(getTokenDimensionValue(it.value)).to.deep.equal(expected[idx]);
         });
       });
+
+      it('should gracefully handle dimension values that cannot be parsed', () => {
+        expect(getTokenDimensionValue('something weird')).to.deep.equal({
+          value: 'something weird',
+          unit: undefined,
+        });
+
+        expect(getTokenDimensionValue('calc(100% - 20px)')).to.deep.equal({
+          value: 'calc(100% - 20px)',
+          unit: undefined,
+        });
+      });
     });
   });
 });

--- a/lib/common/transforms.js
+++ b/lib/common/transforms.js
@@ -381,13 +381,14 @@ function transformCubicBezierCSS(token, options) {
  * Note: the result could contain a unitless dimension
  * Historically in Style Dictionary, number tokens were defined as unitless dimension tokens
  * We can `deprecated` this and remove that in a breaking change, forcing users to change them to number tokens
- * @param {Token['value']} val
+ * @param {Token['value']} _val
  *
  * unit can be undefined for this utility method as well to support old dimension token values
  * which can be defined as unitless dimension tokens or numbers
  * @returns {{ value: string | number; unit: TokenTypeDimensionUnit | undefined }}
  */
-export function getTokenDimensionValue(val) {
+export function getTokenDimensionValue(_val) {
+  let val = _val;
   /** @type {TokenTypeDimensionUnit | undefined} */
   let unit;
   const valueObj = typeof val === 'object' && !Array.isArray(val) && val !== null;
@@ -396,9 +397,14 @@ export function getTokenDimensionValue(val) {
   if (!valueObj) {
     // if it contains a unit -> split it into unit and val
     const unitMatch = `${val}`.match(/[^0-9.-]+$/);
-    if (unitMatch) {
+
+    // try to get the value already without unit
+    const valWithoutUnit = `${val}`.replace(unitMatch?.[0] ?? '', '');
+
+    // guard that we can actually parse the value as a number
+    if (unitMatch && !Number.isNaN(parseFloat(valWithoutUnit))) {
       unit = /** @type {TokenTypeDimensionUnit} */ (unitMatch[0]);
-      val = val.replace(unit, '');
+      val = valWithoutUnit;
     }
   }
 


### PR DESCRIPTION
More agnostic fix compared to https://github.com/style-dictionary/style-dictionary/pull/1701

_Issue #, if available:_
fixes https://github.com/style-dictionary/style-dictionary/issues/1665

_Description of changes:_

@mvanhorn I co-authored you in the commit and took your test from your PR, but just skipping the tests/code implementation that's very specific to Tokens Studio's math computations in dimension tokens, as SD tries to stay agnostic to custom implementations of the DTCG spec.

Let me know if this looks good for you :) thanks for starting the process of fixing this issue

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
